### PR TITLE
Initial support for setup and interactive commands, using powershell in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.egg-info
 __pycache__
 /rust/origen/target
+pip-wheel-metadata/
+_origen.pyd
 
 # Editor cruft
 *.swp

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 ## Development Environment Setup
 
+0) Windows-Specific Setup
+
+If using Windows, ensure that the `HOME` environment variable is set. For example, using Powershell:
+
+~~~
+# In this instance, $HOME is NOT an environment variable, but a shortcut. Set it to the similarly-named environment variable.
+$env:HOME = $HOME
+~~~
+
 1) [Install Rust](https://www.rust-lang.org/tools/install)
 
 2) Enable Rust nightly version (this must be done for every o2 workspace):
@@ -22,11 +31,28 @@ cd o2/rust/origen
 cd pyapi && cargo build && cd ../ && cargo build --workspace --bins
 ~~~
 
+Or, using powershell:
+
+~~~
+cd o2\rust\origen
+cd pyapi ; cargo build ; cd .. ; cargo build --workspace --bins
+~~~
+
+4a) Missing Ubuntu Packages
+
 On Ubuntu, the following packages may need to be installed if you get errors:
 
 ~~~
 sudo apt install libssl-dev
 sudo apt install pkg-config
+~~~
+
+4b) Windows Compiled Libary
+
+On Windows, in addition to `4)`, the resulting `_origen.dll` must be moved and renamed to a `.pyd`:
+
+~~~
+cp .\target\debug\_origen.dll ..\..\python\_origen.pyd
 ~~~
 
 5) Add this dir to your $PATH, ahead of any other dir that provides an `origen` command:
@@ -41,7 +67,6 @@ Origen: 2.0.0-pre0
 ~~~
 
 7) Make sure your system has at least Python 3.5 available
-
 
 8) Now that you have the Origen CLI available and Python, you can try booting the example app:
 

--- a/example/poetry.lock
+++ b/example/poetry.lock
@@ -50,8 +50,8 @@ category = "dev"
 description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
-python-versions = ">=3.4"
-version = "7.2.0"
+python-versions = ">=3.5"
+version = "8.0.0"
 
 [[package]]
 category = "main"
@@ -60,6 +60,10 @@ name = "origen"
 optional = false
 python-versions = "^3.6"
 version = "0.1.0"
+
+[package.dependencies]
+pyreadline = "^2.1"
+termcolor = ">= 1.1.0"
 
 [package.source]
 reference = ""
@@ -91,6 +95,15 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.8.0"
 
 [[package]]
+category = "main"
+description = "A python implmementation of GNU readline."
+marker = "sys_platform == \"win32\""
+name = "pyreadline"
+optional = false
+python-versions = "*"
+version = "2.1"
+
+[[package]]
 category = "dev"
 description = "pytest: simple powerful testing with Python"
 name = "pytest"
@@ -115,6 +128,14 @@ name = "six"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 version = "1.13.0"
+
+[[package]]
+category = "main"
+description = "ANSII Color formatting for output in terminal."
+name = "termcolor"
+optional = false
+python-versions = "*"
+version = "1.1.0"
 
 [[package]]
 category = "dev"
@@ -154,8 +175,8 @@ importlib-metadata = [
     {file = "importlib_metadata-0.23.tar.gz", hash = "sha256:aa18d7378b00b40847790e7c27e11673d7fed219354109d0e7b9e5b25dc3ad26"},
 ]
 more-itertools = [
-    {file = "more-itertools-7.2.0.tar.gz", hash = "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832"},
-    {file = "more_itertools-7.2.0-py3-none-any.whl", hash = "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"},
+    {file = "more-itertools-8.0.0.tar.gz", hash = "sha256:53ff73f186307d9c8ef17a9600309154a6ae27f25579e80af4db8f047ba14bc2"},
+    {file = "more_itertools-8.0.0-py3-none-any.whl", hash = "sha256:a0ea684c39bc4315ba7aae406596ef191fd84f873d2d2751f84d64e81a7a2d45"},
 ]
 origen = []
 pluggy = [
@@ -166,6 +187,11 @@ py = [
     {file = "py-1.8.0-py2.py3-none-any.whl", hash = "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa"},
     {file = "py-1.8.0.tar.gz", hash = "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"},
 ]
+pyreadline = [
+    {file = "pyreadline-2.1.win-amd64.exe", hash = "sha256:9ce5fa65b8992dfa373bddc5b6e0864ead8f291c94fbfec05fbd5c836162e67b"},
+    {file = "pyreadline-2.1.win32.exe", hash = "sha256:65540c21bfe14405a3a77e4c085ecfce88724743a4ead47c66b84defcf82c32e"},
+    {file = "pyreadline-2.1.zip", hash = "sha256:4530592fc2e85b25b1a9f79664433da09237c1a270e4d78ea5aa3a2c7229e2d1"},
+]
 pytest = [
     {file = "pytest-3.10.1-py2.py3-none-any.whl", hash = "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec"},
     {file = "pytest-3.10.1.tar.gz", hash = "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"},
@@ -173,6 +199,9 @@ pytest = [
 six = [
     {file = "six-1.13.0-py2.py3-none-any.whl", hash = "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd"},
     {file = "six-1.13.0.tar.gz", hash = "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 zipp = [
     {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},

--- a/python/origen/boot.py
+++ b/python/origen/boot.py
@@ -17,22 +17,37 @@ def __origen__(command, target=None, environment=None, mode=None):
         print("Generate command called!")
 
     elif command == "interactive":
-        import atexit
-        import os
-        import readline
-        import rlcompleter
+        import atexit, os, rlcompleter, sys, colorama, termcolor
+        if sys.platform == "win32":
+            import pyreadline as readline
+        else:
+            import readline
 
+        # Colorama init only required on windows, but place it here to keep consistent with all platforms, or in case options
+        # need to be added
+        # Also, its a known issue that powershell doesn't display yellow text correctly. The standard command prompt will
+        # though.
+        colorama.init()
         historyPath = origen.root.joinpath(".origen").joinpath("console_history")
 
         def save_history(historyPath=historyPath):
-            import readline
-            readline.write_history_file(historyPath)
+            import sys, colorama, termcolor
+            colorama.init()
+            if sys.platform == "win32":
+                import pyreadline as readline # This isn't necssary but left it in, in case we want to experiment with it.
+                print(termcolor.colored("Origen: Warning: origen currently does not support history files on Windows. :(", 'yellow'))
+            else:
+                import readline
+                readline.write_history_file(historyPath)
 
         if os.path.exists(historyPath):
-            readline.read_history_file(historyPath)
+            if sys.platform == "win32":
+                print(termcolor.colored("Origen: Warning: origen currently does not support history files on Windows. :(", 'yellow'))
+            else:
+                readline.read_history_file(historyPath)
 
         atexit.register(save_history)
-        del os, atexit, readline, rlcompleter, save_history, historyPath
+        del os, atexit, readline, rlcompleter, sys, colorama, termcolor, save_history, historyPath
 
         import code
         from origen import dut, tester

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,8 @@ authors = ["Stephen McGinty <stephen.f.mcginty@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.6"
+termcolor = ">= 1.1.0"
+pyreadline = { "version" = "^2.1",  "platform" = "win32" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/rust/origen/cli/src/commands/mod.rs
+++ b/rust/origen/cli/src/commands/mod.rs
@@ -10,10 +10,7 @@ use origen::clean_mode;
 
 /// Launch the given command in Python
 pub fn launch(command: &str, target: &Option<&str>, environment: &Option<&str>, mode: &Option<&str>) {
-    let mut cmd = format!("
-from origen.boot import __origen__;
-
-__origen__('{}'", command);
+    let mut cmd = format!("from origen.boot import __origen__; __origen__('{}'", command);
     
     if target.is_some() {
         cmd += &format!(", target='{}'", target.unwrap()).to_string(); 

--- a/rust/origen/cli/src/commands/setup.rs
+++ b/rust/origen/cli/src/commands/setup.rs
@@ -3,10 +3,10 @@ extern crate time;
 use crate::python::{poetry_version, MIN_PYTHON_VERSION, PYTHON_CONFIG};
 use online::online;
 use origen::core::term::*;
+use origen::core::os;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
-use std::process::Command;
 
 const POETRY_INSTALLER: &str =
     "https://raw.githubusercontent.com/sdispater/poetry/1.0.0b7/get-poetry.py";
@@ -49,7 +49,7 @@ pub fn run() {
 
             let tmp_dir =
                 PathBuf::from("/tmp").join(format!("origen-{}", time::now().to_timespec().nsec));
-            fs::create_dir(format!("{}", tmp_dir.display())).expect("Couldn't create tmp dir");
+            fs::create_dir_all(format!("{}", tmp_dir.display())).expect("Couldn't create tmp dir");
 
             // Get the Poetry installer script
             let get_poetry_file = tmp_dir.join("get-poetry.py");
@@ -69,16 +69,16 @@ pub fn run() {
             fs::write(&get_poetry_file, new_data).expect("Unable to write Poetry install file");
 
             // Install Poetry
-            Command::new(&PYTHON_CONFIG.command)
+            os::cmd(&PYTHON_CONFIG.command)
                 .arg(format!("{}", get_poetry_file.display()))
                 .arg("--yes")
                 .status()
-                .expect("Something wend wrong install Poetry");
+                .expect("Something went wrong install Poetry");
 
             if poetry_version().unwrap().major != 1 {
                 // Have to use --preview here to get a 1.0.0 pre version, can only use versions for
                 // official releases
-                Command::new(&PYTHON_CONFIG.poetry_command)
+                os::cmd(&PYTHON_CONFIG.poetry_command)
                     .arg("self:update")
                     .arg("--preview")
                     .status()
@@ -90,7 +90,7 @@ pub fn run() {
 
     print!("Are the app's deps. installed?  ... ");
 
-    let status = Command::new(&PYTHON_CONFIG.poetry_command)
+    let status = os::cmd(&PYTHON_CONFIG.poetry_command)
         .arg("install")
         .status();
 

--- a/rust/origen/cli/src/python.rs
+++ b/rust/origen/cli/src/python.rs
@@ -1,7 +1,7 @@
 // Responsible for managing Python execution
 
 use semver::Version;
-use std::process::Command;
+use origen::core::os;
 
 const PYTHONS: &[&str] = &[
     "python",
@@ -65,7 +65,7 @@ impl Default for Config {
 
 /// Get the Python version from the given command
 fn get_version(command: &str) -> Option<Version> {
-    match Command::new(command).arg("--version").output() {
+    match os::cmd(command).arg("--version").output() {
         Ok(output) => return extract_version(std::str::from_utf8(&output.stdout).unwrap()),
         Err(_e) => return None,
     }
@@ -73,7 +73,7 @@ fn get_version(command: &str) -> Option<Version> {
 
 /// Returns the version of poetry (obtained from running "poetry --version")
 pub fn poetry_version() -> Option<Version> {
-    match Command::new(&PYTHON_CONFIG.poetry_command)
+    match os::cmd(&PYTHON_CONFIG.poetry_command)
         .arg("--version")
         .output()
     {
@@ -99,11 +99,11 @@ fn extract_version(text: &str) -> Option<Version> {
 
 /// Execute the given Python code
 pub fn run(code: &str) {
-    let _status = Command::new(&PYTHON_CONFIG.poetry_command)
+    let _status = os::cmd(&PYTHON_CONFIG.poetry_command)
         .arg("run")
         .arg(&PYTHON_CONFIG.command)
         .arg("-c")
-        .arg(code)
+        .arg(&code)
         .status();
 }
 

--- a/rust/origen/src/core/mod.rs
+++ b/rust/origen/src/core/mod.rs
@@ -3,3 +3,4 @@ pub mod config;
 pub mod model;
 pub mod status;
 pub mod term;
+pub mod os;

--- a/rust/origen/src/core/os.rs
+++ b/rust/origen/src/core/os.rs
@@ -1,0 +1,31 @@
+use std::process::Command;
+
+pub fn on_windows() -> bool {
+  if cfg!(windows) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+pub fn on_linux() -> bool {
+  if cfg!(linux) {
+    return true;
+  } else {
+    return false;
+  };
+}
+
+// Due to OS differences, the basic std::process::Command doesn't cooperate very well in a Windows environment.
+// Instead, wrap the cmd function here, which will ensures some semblance between Windows and Linux commands.
+#[allow(unused_mut)]
+pub fn cmd(cmd: &str) -> std::process::Command {
+    if on_windows() {
+      let mut c = Command::new("cmd");
+      c.arg("/C").arg(&cmd);
+      return c;
+    } else {
+      let mut c = Command::new(&cmd);
+      return c;
+    }
+}


### PR DESCRIPTION
Hi,

I got O2 working in Windows. There were some problems, but I think I've at least the basics worked out. With the updates here, and the few additional steps added to the README, I can get the `setup` and `interactive` commands to work.

I think there's still some improvements to make here but this should at get some Windows-side developments going and, given the volatile nature of this project being very early in development, I don't really want to sit on these changes while I continue to learn Rust and risk having merging nightmares later on.

I don't have WSL installed yet, but I'll be doing that pretty soon here and I can start running O2 on both systems. I don't think anything I changed should have affected Linux.

I can give some more details if needed, but most changes boil down to syntax differences between Linux and Windows, and then how Rust handles system commands, which IMO, is really user-unfriendly since no other languages I'm aware of calls commands in that way. Not even C++ or Java.

Thanks!