### PR TITLE
Regs WIP

### DIFF
--- a/example/example/blocks/adc/registers.py
+++ b/example/example/blocks/adc/registers.py
@@ -1,1 +1,1 @@
-reg("reg1", 0)
+SimpleReg("reg1", 0)

--- a/example/example/blocks/dut/derivatives/falcon/registers.py
+++ b/example/example/blocks/dut/derivatives/falcon/registers.py
@@ -1,1 +1,1 @@
-reg("reg3", 0x20)
+SimpleReg("freg1", 0x20)

--- a/example/example/blocks/dut/registers.py
+++ b/example/example/blocks/dut/registers.py
@@ -21,9 +21,12 @@ with Reg("reg3", 0x0024, size=16) as reg:
 # Regs can be added within a defined memory map, and in this case no address
 # block is given so that will mean they are placed in a default address block
 # named 'default'.
-with MemoryMap("user") as mem:
-    pass
+with MemoryMap("user"):
+    # Test that reg names can be reused when scoped within a different map
+    SimpleReg("reg1", 0)
 
+    with Reg("reg2", 0x0024, size=16) as reg:
+        reg.bit([4,0], "adch", reset=0x1F)
 
 
 

--- a/example/example/blocks/dut/registers.py
+++ b/example/example/blocks/dut/registers.py
@@ -1,9 +1,30 @@
-reg("reg1", 0)
+# Registers added in the global scope of these files will be added to
+# a memory map called 'default' and within that an address block called
+# 'default'. Such regs can be accessed via my_block.regs and users who
+# don't care about maps don't have to even think about them.
+# Note that such regs can also be accessed via my_block.default.default.regs
+
+# A simple reg definition with all bits writable, here at address 0 and a
+# default size of 32-bits
+SimpleReg("reg1", 0)
+# Another simple reg with custom size
+SimpleReg("reg2", 4, size=16)
 
 # This is the reg definition
-with Reg("reg2", 0x0024, size=16) as reg:
+with Reg("reg3", 0x0024, size=16) as reg:
     # This is the COCO definition
     reg.bit(7, "coco", access="ro")
     reg.bit(6, "aien")
     reg.bit(5, "diff")
     reg.bit([4,0], "adch", reset=0x1F)
+
+# Regs can be added within a defined memory map, and in this case no address
+# block is given so that will mean they are placed in a default address block
+# named 'default'.
+with MemoryMap("user") as mem:
+    pass
+
+
+
+
+# Finally regs can be added to a full declared scope like this:

--- a/example/example/blocks/dut/registers.py
+++ b/example/example/blocks/dut/registers.py
@@ -29,5 +29,11 @@ with MemoryMap("user"):
         reg.bit([4,0], "adch", reset=0x1F)
 
 
-
 # Finally regs can be added to a full declared scope like this:
+with MemoryMap("test"):
+    with AddressBlock("bank0"):
+        # Test that reg names can be reused when scoped within a different map
+        SimpleReg("reg1", 0)
+
+        with Reg("reg2", 0x0024, size=16) as reg:
+            reg.bit([4,0], "adch", reset=0x1F)

--- a/example/tests/block_loader_test.py
+++ b/example/tests/block_loader_test.py
@@ -2,10 +2,10 @@ import origen
 
 def test_registers_are_loaded():
     origen.app.instantiate_dut("dut.falcon")
-    assert origen.dut.regs.len() == 3
+    assert origen.dut.regs.len() == 4
 
     origen.app.instantiate_dut("dut.eagle")
-    assert origen.dut.regs.len() == 2
+    assert origen.dut.regs.len() == 3
 
 def test_sub_blocks_are_loaded():
     origen.app.instantiate_dut("dut.falcon")

--- a/example/tests/registers_test.py
+++ b/example/tests/registers_test.py
@@ -1,10 +1,28 @@
 import origen
 
-def test_memory_maps_can_be_fetched():
+def test_memory_maps():
     origen.app.instantiate_dut("dut.falcon")
     assert origen.dut.memory_maps
-    assert len(origen.dut.memory_maps) == 1
     assert origen.dut.memory_map("default") == origen.dut.memory_maps["default"]
+    assert len(origen.dut.memory_maps) == 1
+
+    # Check some of the dict-like API
+    assert "default" in origen.dut.memory_maps
+    keys = origen.dut.memory_maps.keys()
+    assert set(keys) == set(['default'])
+    values = origen.dut.memory_maps.values()
+    assert len(values) == 1
+    assert type(values[0]).__name__ == "MemoryMap"
+    for k in origen.dut.memory_maps:
+        assert k in keys
+    d = dict(origen.dut.memory_maps)
+    assert isinstance(d, dict)
+    assert type(d["default"]).__name__ == "MemoryMap"
+    for k, v in origen.dut.memory_maps.items():
+        assert k in keys
+        assert isinstance(k, str)
+        assert type(v).__name__ == "MemoryMap"
+
 
 def test_address_blocks_can_be_fetched():
     pass
@@ -15,4 +33,5 @@ def test_regs_can_be_fetched():
 def test_register_value_can_be_read():
     origen.app.instantiate_dut("dut.falcon")
     #assert origen.dut.regs["reg1"].data == 0
+
 

--- a/example/tests/registers_test.py
+++ b/example/tests/registers_test.py
@@ -4,14 +4,14 @@ def test_memory_maps():
     origen.app.instantiate_dut("dut.falcon")
     assert origen.dut.memory_maps
     assert origen.dut.memory_map("default") == origen.dut.memory_maps["default"]
-    assert len(origen.dut.memory_maps) == 1
+    assert len(origen.dut.memory_maps) == 2
 
     # Check some of the dict-like API
     assert "default" in origen.dut.memory_maps
     keys = origen.dut.memory_maps.keys()
-    assert set(keys) == set(['default'])
+    assert set(keys) == set(['default', 'user'])
     values = origen.dut.memory_maps.values()
-    assert len(values) == 1
+    assert len(values) == 2
     assert type(values[0]).__name__ == "MemoryMap"
     for k in origen.dut.memory_maps:
         assert k in keys
@@ -22,6 +22,8 @@ def test_memory_maps():
         assert k in keys
         assert isinstance(k, str)
         assert type(v).__name__ == "MemoryMap"
+
+    assert origen.dut.memory_maps.user.regs.len() == 2
 
 def test_regs_can_be_added():
     origen.app.instantiate_dut("dut.falcon")

--- a/example/tests/registers_test.py
+++ b/example/tests/registers_test.py
@@ -23,6 +23,14 @@ def test_memory_maps():
         assert isinstance(k, str)
         assert type(v).__name__ == "MemoryMap"
 
+def test_regs_can_be_added():
+    origen.app.instantiate_dut("dut.falcon")
+    assert origen.dut.regs.len() == 4
+    origen.dut.add_simple_reg("treg1", 0x1000)
+    assert origen.dut.regs.len() == 5
+    with origen.dut.add_reg("treg2", 0x1004) as reg:
+        reg.bit([7,0], 'trim')
+    assert origen.dut.regs.len() == 6
 
 def test_address_blocks_can_be_fetched():
     pass

--- a/example/tests/registers_test.py
+++ b/example/tests/registers_test.py
@@ -4,14 +4,14 @@ def test_memory_maps():
     origen.app.instantiate_dut("dut.falcon")
     assert origen.dut.memory_maps
     assert origen.dut.memory_map("default") == origen.dut.memory_maps["default"]
-    assert len(origen.dut.memory_maps) == 2
+    assert len(origen.dut.memory_maps) == 3
 
     # Check some of the dict-like API
     assert "default" in origen.dut.memory_maps
     keys = origen.dut.memory_maps.keys()
-    assert set(keys) == set(['default', 'user'])
+    assert set(keys) == set(['default', 'user', 'test'])
     values = origen.dut.memory_maps.values()
-    assert len(values) == 2
+    assert len(values) == 3
     assert type(values[0]).__name__ == "MemoryMap"
     for k in origen.dut.memory_maps:
         assert k in keys
@@ -24,6 +24,8 @@ def test_memory_maps():
         assert type(v).__name__ == "MemoryMap"
 
     assert origen.dut.memory_maps.user.regs.len() == 2
+
+    #assert origen.dut.memory_maps.test.bank0.regs.len() == 2
 
 def test_regs_can_be_added():
     origen.app.instantiate_dut("dut.falcon")

--- a/example/tests/registers_test.py
+++ b/example/tests/registers_test.py
@@ -4,7 +4,7 @@ def test_memory_maps_can_be_fetched():
     origen.app.instantiate_dut("dut.falcon")
     assert origen.dut.memory_maps
     assert len(origen.dut.memory_maps) == 1
-    #assert origen.dut.memory_map("default") == origen.dut.memory_maps["default"]
+    assert origen.dut.memory_map("default") == origen.dut.memory_maps["default"]
 
 def test_address_blocks_can_be_fetched():
     pass

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -42,19 +42,40 @@ class Base:
             self.regs  # Ensure the memory maps for this block have been loaded
             return origen.dut.db.memory_maps(self.path)
 
+        elif name in self.sub_blocks:
+            return self.sub_blocks[name]
+
         else:
             raise AttributeError(f"The block '{self.block_path}' has no attribute '{name}'")
 
     def tree(self):
         print(self.tree_as_str())
 
-    def tree_as_str(self):
-        if self.is_top:
-            t = "dut"
-        elif self.parent == '':
-            t = f"dut.{self.id}"
+    def tree_as_str(self, leader='', include_header=True):
+        if include_header:
+            if self.is_top:
+                t = "'dut'"
+            elif self.parent_path == '':
+                t = f"'dut.{self.id}'"
+            else:
+                t = f"'dut.{self.parent_path}.{self.id}'"
+            names = t.split('.')
+            names.pop()
+            leader = ' ' * (2 + len('.'.join(names)))
         else:
-            t = f"dut.{self.parent}.{self.id}"
+            t = ''
+        last = len(self.sub_blocks) - 1
+        for i, key in enumerate(sorted(self.sub_blocks.keys())):
+            if i != last:
+                t += "\n" + leader + f"├── {key}"
+            else:
+                t += "\n" + leader + f"└── {key}"
+            if self.sub_blocks[key].sub_blocks.len() > 0:
+                if i != last:
+                    l = leader + '│     '
+                else:
+                    l = leader + '      '
+                t += self.sub_blocks[key].tree_as_str(l, False)
         return t
 
     def memory_map(self, id):

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -48,7 +48,7 @@ class Base:
         else:
             self.regs  # Ensure the memory maps for this block have been loaded
             if name in self.memory_maps:
-                return self.sub_blocks[name]
+                return self.memory_maps[name]
 
             else:
                 raise AttributeError(f"The block '{self.block_path}' has no attribute '{name}'")

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -46,7 +46,12 @@ class Base:
             return self.sub_blocks[name]
 
         else:
-            raise AttributeError(f"The block '{self.block_path}' has no attribute '{name}'")
+            self.regs  # Ensure the memory maps for this block have been loaded
+            if name in self.memory_maps:
+                return self.sub_blocks[name]
+
+            else:
+                raise AttributeError(f"The block '{self.block_path}' has no attribute '{name}'")
 
     def tree(self):
         print(self.tree_as_str())
@@ -54,14 +59,17 @@ class Base:
     def tree_as_str(self, leader='', include_header=True):
         if include_header:
             if self.is_top:
-                t = "'dut'"
+                t = "dut"
             elif self.parent_path == '':
-                t = f"'dut.{self.id}'"
+                t = f"dut.{self.id}"
             else:
-                t = f"'dut.{self.parent_path}.{self.id}'"
+                t = f"dut.{self.parent_path}.{self.id}"
             names = t.split('.')
             names.pop()
-            leader = ' ' * (2 + len('.'.join(names)))
+            if not names:
+                leader = ' '
+            else:
+                leader = ' ' * (2 + len('.'.join(names)))
         else:
             t = ''
         last = len(self.sub_blocks) - 1
@@ -72,9 +80,9 @@ class Base:
                 t += "\n" + leader + f"└── {key}"
             if self.sub_blocks[key].sub_blocks.len() > 0:
                 if i != last:
-                    l = leader + '│     '
+                    l = leader + '│    '
                 else:
-                    l = leader + '      '
+                    l = leader + '     '
                 t += self.sub_blocks[key].tree_as_str(l, False)
         return t
 

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -1,5 +1,7 @@
 import origen
 import _origen
+from origen.registers import Loader as RegLoader
+from contextlib import contextmanager
 
 # The base class of all Origen controller objects
 class Base:
@@ -90,6 +92,13 @@ class Base:
         self.regs  # Ensure the memory maps for this block have been loaded
         return origen.dut.db.memory_map(self.path, id)
 
+    def add_simple_reg(self, *args, **kwargs):
+        RegLoader(self).SimpleReg(*args, **kwargs)
+
+    @contextmanager
+    def add_reg(self, *args, **kwargs):
+        with RegLoader(self).Reg(*args, **kwargs) as reg:
+            yield reg
 
 # The base class of all Origen controller objects which are also
 # the top-level (DUT)

--- a/python/origen/registers.py
+++ b/python/origen/registers.py
@@ -40,10 +40,17 @@ class Loader:
         yield self
         self.memory_map = None
 
+    @contextmanager
+    def AddressBlock(self, id):
+        self.address_block = id
+        yield self
+        self.address_block = None
+
     # Defines the methods that are accessible within blocks/<block>/registers.py
     def api(self):
         return {
             "Reg": self.Reg, 
             "SimpleReg": self.SimpleReg, 
             "MemoryMap": self.MemoryMap, 
+            "AddressBlock": self.AddressBlock, 
         }

--- a/python/origen/registers.py
+++ b/python/origen/registers.py
@@ -26,21 +26,22 @@ class Loader:
     @contextmanager
     def Reg(self, id, address_offset, size=32):
         origen.dut.db.create_reg(self.controller.path, self.memory_map, self.address_block, id, address_offset, size);
-        try:
-            yield self
-        finally:
-            pass
+        yield self
 
-    def reg(self, id, address_offset, size=32):
+    def SimpleReg(self, id, address_offset, size=32):
         origen.dut.db.create_reg(self.controller.path, self.memory_map, self.address_block, id, address_offset, size);
 
     def bit(self, number, id, access="rw", reset=0):
         pass
 
+    @contextmanager
+    def MemoryMap(self, id):
+        yield self
+
     # Defines the methods that are accessible within blocks/<block>/registers.py
     def api(self):
         return {
             "Reg": self.Reg, 
-            "reg": self.reg, 
-            "bit": self.bit
+            "SimpleReg": self.SimpleReg, 
+            "MemoryMap": self.MemoryMap, 
         }

--- a/python/origen/registers.py
+++ b/python/origen/registers.py
@@ -15,7 +15,7 @@ class Proxy:
     #def __repr__(self):
     #    return f"Registers in {self.controller.block_path}:\n0  : Reg 1\n4  : Reg 2"
 
-# This defines the methods for defining registers in Python and then handles serializing
+# This defines the API for defining registers in Python and then handles serializing
 # the definitions and handing them over to the Rust model for instantiation.
 class Loader:
     def __init__(self, controller):
@@ -36,7 +36,9 @@ class Loader:
 
     @contextmanager
     def MemoryMap(self, id):
+        self.memory_map = id
         yield self
+        self.memory_map = None
 
     # Defines the methods that are accessible within blocks/<block>/registers.py
     def api(self):

--- a/python/origen/sub_blocks.py
+++ b/python/origen/sub_blocks.py
@@ -6,13 +6,34 @@ import origen
 class Proxy:
     def __init__(self, controller):
         self.controller = controller
-        self.__store = {}
+        self.__dict__ = {}
 
     def __getitem__(self, key):
-        return self.__store[key]
+        return self.__dict__[key]
 
     def __add_block__(self, id, obj):
-        self.__store[id] = obj
+        self.__dict__[id] = obj
+
+    def __len__(self):
+        return len(self.__dict__)
+
+    def len(self):
+        return len(self.__dict__)
+
+    def keys(self):
+        return self.__dict__.keys()
+
+    def values(self):
+        return self.__dict__.values()
+
+    def items(self):
+        return self.__dict__.items()
+
+    def __cmp__(self, dict_):
+        return self.__cmp__(self.__dict__, dict_)
+
+    def __contains__(self, item):
+        return item in self.__dict__
 
 # This defines the methods for defining sub-blocks in Python and then handles serializing
 # the definitions and handing them over to the Rust model for instantiation.

--- a/rust/origen/pyapi/src/dut.rs
+++ b/rust/origen/pyapi/src/dut.rs
@@ -1,6 +1,5 @@
 use pyo3::prelude::*;
 //use pyo3::wrap_pyfunction;
-use crate::register::BitCollection;
 use origen::DUT;
 
 /// Implements the module _origen.dut in Python which exposes all
@@ -43,30 +42,5 @@ impl PyDUT {
         Ok(dut
             .get_mut_model(path)?
             .create_reg(memory_map, address_block, id, offset, size)?)
-    }
-
-    fn number_of_regs(&self, path: &str) -> PyResult<usize> {
-        let dut = DUT.lock().unwrap();
-        let model = dut.get_model(path)?;
-        Ok(model.number_of_regs())
-    }
-
-    fn get_reg(
-        &self,
-        path: &str,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
-        id: &str,
-    ) -> PyResult<BitCollection> {
-        let dut = DUT.lock().unwrap();
-        let model = dut.get_model(path)?;
-        let reg = model.get_reg(memory_map, address_block, id)?;
-
-        Ok(BitCollection::from_reg(
-            path,
-            memory_map,
-            address_block,
-            reg,
-        ))
     }
 }

--- a/rust/origen/pyapi/src/memory_map.rs
+++ b/rust/origen/pyapi/src/memory_map.rs
@@ -4,7 +4,7 @@ use origen::DUT;
 use pyo3::class::basic::PyObjectProtocol;
 use pyo3::class::PyMappingProtocol;
 use pyo3::prelude::*;
-use pyo3::exceptions::KeyError;
+use pyo3::exceptions::{KeyError, AttributeError};
 
 /// Implements the user APIs dut[.sub_block].memory_map() and
 /// dut[.sub_block].memory_maps
@@ -48,7 +48,8 @@ impl MemoryMaps {
 }
 
 /// Internal, Rust-only methods
-impl MemoryMaps {}
+impl MemoryMaps {
+}
 
 #[pyproto]
 impl PyMappingProtocol for MemoryMaps {
@@ -61,22 +62,79 @@ impl PyMappingProtocol for MemoryMaps {
         let dut = DUT.lock().unwrap();
         let model = dut.get_model(&self.model_path)?;
         if model.memory_maps.contains_key(query) {
-            return Ok(MemoryMap {
+            Ok(MemoryMap {
                 model_path: self.model_path.clone(),
                 id: query.to_string(),
-            });
+            })
         } else {
-            return Err(KeyError::py_err(format!("'{}' does not have a memory map called '{}'", model.display_path, query)));
+            Err(KeyError::py_err(format!("'{}' does not have a memory map called '{}'", model.display_path, query)))
         }
     }
 }
 
 #[pyproto]
 impl PyObjectProtocol for MemoryMaps {
+    /// Implements memory_map.my_map
+    fn __getattr__(&self, query: &str) -> PyResult<MemoryMap> {
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        if model.memory_maps.contains_key(query) {
+            Ok(MemoryMap {
+                model_path: self.model_path.clone(),
+                id: query.to_string(),
+            })
+        } else {
+            Err(AttributeError::py_err(format!("'MemoryMaps' object has no attribute '{}'", query)))
+        }
+    }
+
     fn __repr__(&self) -> PyResult<String> {
-        Ok("Here should be a nice graphic of the memory maps".to_string())
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        //let mut output: String = "".to_string();
+        let (mut output, offset) = model.console_header();
+        output += &(" ".repeat(offset));
+        output += "└── memory_maps\n";
+        let leader = " ".repeat(offset + 5);
+        let num_maps = model.memory_maps.keys().len();
+        if num_maps > 0 {
+            for (i, key) in model.memory_maps.keys().enumerate() {
+                if i != num_maps - 1 {
+                    output += &format!("{}├── {}\n", leader, key);
+                } else {
+                    output += &format!("{}└── {}\n", leader, key);
+                }
+            }
+        } else {
+            output += &format!("{}└── NONE\n", leader);
+        }
+        Ok(output)
     }
 }
+
+//#[pyproto]
+//impl PyIterProtocol for MemoryMaps {
+//    fn __iter__(slf: PyRefMut<Self>) -> PyResult<MemoryMap> {
+//        let py = unsafe { Python::assume_gil_acquired() };
+//        Ok(slf.to_object(py))
+//    }
+//    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PyObject>> {
+//        let py = unsafe { Python::assume_gil_acquired() };
+//        match slf.keys.as_ref(py).as_bytes().get(slf.idx) {
+//            Some(&b) => {
+//                let res = slf
+//                    .reader
+//                    .as_ref(py)
+//                    .inner
+//                    .get(&b)
+//                    .map(|s| PyString::new(py, s).into());
+//                slf.idx += 1;
+//                Ok(res)
+//            }
+//            None => Ok(None),
+//        }
+//    }
+//}
 
 /// Implements the user API to work with a single memory map, an instance
 /// of this is returned by dut[.sub_block].memory_maps["my_map"]

--- a/rust/origen/pyapi/src/memory_map.rs
+++ b/rust/origen/pyapi/src/memory_map.rs
@@ -213,14 +213,12 @@ impl MemoryMap {}
 #[pyproto]
 impl PyObjectProtocol for MemoryMap {
     fn __getattr__(&self, query: &str) -> PyResult<PyObject> {
-        //let dut = DUT.lock().unwrap();
-        //let model = dut.get_model(&self.model_path)?;
+        let gil = Python::acquire_gil();
+        let py = gil.python();
 
         // Calling .regs on an individual memory map returns the regs in its default
         // address block (the one named 'default')
         if query == "regs" {
-            let gil = Python::acquire_gil();
-            let py = gil.python();
             let pyref = PyRef::new(
                 py,
                 Registers {
@@ -232,10 +230,27 @@ impl PyObjectProtocol for MemoryMap {
             )?;
             Ok(pyref.to_object(py))
         } else {
-            Err(AttributeError::py_err(format!(
-                "'MemoryMap' object has no attribute '{}'",
-                query
-            )))
+            //let dut = DUT.lock().unwrap();
+            //let model = dut.get_model(&self.model_path)?;
+            //let map = model.memory_maps.get(&self.id).unwrap();
+
+            //if map.address_blocks.contains_key(query) {
+            //    let pyref = PyRef::new(
+            //        py,
+            //        AddressBlock {
+            //            model_path: self.model_path.to_string(),
+            //            memory_map: self.id.to_string(),
+            //            id: query.to_string(),
+            //            i: 0,
+            //        },
+            //    )?;
+            //    Ok(pyref.to_object(py))
+            //} else {
+                Err(AttributeError::py_err(format!(
+                    "'MemoryMap' object has no attribute '{}'",
+                    query
+                )))
+            //}
         }
     }
 

--- a/rust/origen/pyapi/src/memory_map.rs
+++ b/rust/origen/pyapi/src/memory_map.rs
@@ -4,17 +4,26 @@ use origen::DUT;
 use pyo3::class::basic::PyObjectProtocol;
 use pyo3::class::PyMappingProtocol;
 use pyo3::prelude::*;
+use pyo3::exceptions::KeyError;
 
 /// Implements the user APIs dut[.sub_block].memory_map() and
 /// dut[.sub_block].memory_maps
 #[pymethods]
 impl PyDUT {
     fn memory_maps(&self, path: &str) -> PyResult<MemoryMaps> {
-        let dut = DUT.lock().unwrap();
         // Verify the model exists, though we don't need it for now
-        dut.get_model(path)?;
+        DUT.lock().unwrap().get_model(path)?;
         Ok(MemoryMaps {
             model_path: path.to_string(),
+        })
+    }
+
+    fn memory_map(&self, path: &str, id: &str) -> PyResult<MemoryMap> {
+        // Verify the model exists, though we don't need it for now
+        DUT.lock().unwrap().get_model(path)?;
+        Ok(MemoryMap {
+            model_path: path.to_string(),
+            id: id.to_string(),
         })
     }
 }
@@ -46,11 +55,50 @@ impl PyMappingProtocol for MemoryMaps {
     fn __len__(&self) -> PyResult<usize> {
         self.len()
     }
+
+    /// Implements memory_map["my_map"]
+    fn __getitem__(&self, query: &str) -> PyResult<MemoryMap> {
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        if model.memory_maps.contains_key(query) {
+            return Ok(MemoryMap {
+                model_path: self.model_path.clone(),
+                id: query.to_string(),
+            });
+        } else {
+            return Err(KeyError::py_err(format!("'{}' does not have a memory map called '{}'", model.display_path, query)));
+        }
+    }
 }
 
 #[pyproto]
 impl PyObjectProtocol for MemoryMaps {
     fn __repr__(&self) -> PyResult<String> {
         Ok("Here should be a nice graphic of the memory maps".to_string())
+    }
+}
+
+/// Implements the user API to work with a single memory map, an instance
+/// of this is returned by dut[.sub_block].memory_maps["my_map"]
+#[pyclass]
+#[derive(Debug)]
+pub struct MemoryMap {
+    /// The path to the model which owns the contained memory maps
+    model_path: String,
+    id: String,
+}
+
+/// User API methods, available to both Rust and Python
+#[pymethods]
+impl MemoryMap {
+}
+
+/// Internal, Rust-only methods
+impl MemoryMap {}
+
+#[pyproto]
+impl PyObjectProtocol for MemoryMap {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok("Here should be a nice graphic of the memory map".to_string())
     }
 }

--- a/rust/origen/pyapi/src/register.rs
+++ b/rust/origen/pyapi/src/register.rs
@@ -1,5 +1,129 @@
+use crate::dut::PyDUT;
 use origen::core::model::registers::Register;
+use origen::DUT;
 use pyo3::prelude::*;
+
+/// Implements the user APIs my_block.[.my_memory_map][.my_address_block].reg() and
+/// my_block.[.my_memory_map][.my_address_block].regs
+#[pymethods]
+impl PyDUT {
+    fn regs(
+        &self,
+        path: &str,
+        memory_map: Option<&str>,
+        address_block: Option<&str>,
+    ) -> PyResult<Registers> {
+        // Verify the model exists, though we don't need it for now
+        DUT.lock().unwrap().get_model(path)?;
+        // TODO: Verify the memory_map and address_block
+        Ok(Registers {
+            model_path: path.to_string(),
+            memory_map: memory_map.unwrap_or("default").to_string(),
+            address_block: address_block.unwrap_or("default").to_string(),
+            i: 0,
+        })
+    }
+
+    fn reg(
+        &self,
+        path: &str,
+        memory_map: Option<&str>,
+        address_block: Option<&str>,
+        id: &str,
+    ) -> PyResult<BitCollection> {
+        // Verify the model exists, though we don't need it for now
+        DUT.lock().unwrap().get_model(path)?;
+        // TODO: Verify the memory_map and address_block
+        Ok(BitCollection {
+            model_path: path.to_string(),
+            memory_map: memory_map.unwrap_or("default").to_string(),
+            address_block: address_block.unwrap_or("default").to_string(),
+            reg_id: id.to_string(),
+            whole: true,
+            bit_numbers: Vec::new(),
+            i: 0,
+        })
+    }
+}
+
+/// Implements the user API to work with a model's collection of registers, an instance
+/// of this is returned by my_block.[.my_memory_map][.my_address_block].regs
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct Registers {
+    /// The path to the model which owns the contained registers
+    pub model_path: String,
+    /// The name of the model's memory map which contains these registers
+    pub memory_map: String,
+    /// The name of the memory map's address block which contains these register
+    pub address_block: String,
+    /// Iterator index
+    pub i: usize,
+}
+
+/// User API methods, available to both Rust and Python
+#[pymethods]
+impl Registers {
+    fn len(&self) -> PyResult<usize> {
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        let map = model.memory_maps.get(&self.memory_map).unwrap();
+        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        Ok(ab.registers.len())
+    }
+
+    fn keys(&self) -> PyResult<Vec<String>> {
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        let map = model.memory_maps.get(&self.memory_map).unwrap();
+        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        let keys: Vec<String> = ab.registers.keys().map(|x| x.clone()).collect();
+        Ok(keys)
+    }
+
+    fn values(&self) -> PyResult<Vec<BitCollection>> {
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        let map = model.memory_maps.get(&self.memory_map).unwrap();
+        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        let values: Vec<BitCollection> = ab
+            .registers
+            .keys()
+            .map(|x| {
+                BitCollection::from_reg(
+                    &self.model_path,
+                    &self.memory_map,
+                    &self.address_block,
+                    &ab.registers.get(x).unwrap(),
+                )
+            })
+            .collect();
+        Ok(values)
+    }
+
+    fn items(&self) -> PyResult<Vec<(String, BitCollection)>> {
+        let dut = DUT.lock().unwrap();
+        let model = dut.get_model(&self.model_path)?;
+        let map = model.memory_maps.get(&self.memory_map).unwrap();
+        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        let items: Vec<(String, BitCollection)> = ab
+            .registers
+            .keys()
+            .map(|x| {
+                (
+                    x.to_string(),
+                    BitCollection::from_reg(
+                        &self.model_path,
+                        &self.memory_map,
+                        &self.address_block,
+                        &ab.registers.get(x).unwrap(),
+                    ),
+                )
+            })
+            .collect();
+        Ok(items)
+    }
+}
 
 /// A BitCollection represents either a whole register of a subset of a
 /// registers bits (not necessarily contiguous bits) and provides the user
@@ -21,23 +145,26 @@ pub struct BitCollection {
     /// collection. Typically this will be mapped to the actual register bits by
     /// BitCollection's methods.
     bit_numbers: Vec<u16>,
+    /// Iterator index
+    i: usize,
 }
 
 /// Rust-private methods, i.e. not accessible from Python
 impl BitCollection {
     pub fn from_reg(
         path: &str,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
+        memory_map: &str,
+        address_block: &str,
         reg: &Register,
     ) -> BitCollection {
         BitCollection {
             model_path: path.to_string(),
-            memory_map: memory_map.unwrap_or("default").to_string(),
-            address_block: address_block.unwrap_or("default").to_string(),
+            memory_map: memory_map.to_string(),
+            address_block: address_block.to_string(),
             reg_id: reg.id.clone(),
             whole: true,
             bit_numbers: Vec::new(),
+            i: 0,
         }
     }
 }

--- a/rust/origen/src/core/model/mod.rs
+++ b/rust/origen/src/core/model/mod.rs
@@ -48,6 +48,19 @@ impl Model {
         }
     }
 
+    /// Returns the hierarchical name of the model and the offset for console displays
+    pub fn console_header(&self) -> (String, usize) {
+        let l = format!("{}", self.display_path);
+        let mut names: Vec<&str> = l.split(".").collect();
+        names.pop();
+        if names.is_empty() {
+            (l + "\n", 1)
+        } else {
+            let s = names.join(".").chars().count() + 2;
+            (l + "\n", s)
+        }
+    }
+
     pub fn add_memory_map(&mut self, id: &str, address_unit_bits: Option<u32>) {
         let mut defaults = MemoryMap::default();
         match address_unit_bits {


### PR DESCRIPTION
This is partial work on implementing the regs APIs, which mainly adds the ability to instantiate regs within memory map and address block structures.

It also adds friendly DUT traversal (`dut.core0.adc0.memory_maps.user.bank0.regs`) and a `tree()` method for looking at the dut structure in the console (`dut.tree()`, `dut.core0.tree()`).

I would like to merge it at this point as I am about to experiment with changing how the DUT object storage works from a hierarchical representation to some kind of ID-based system and I would like to de-couple that change from this stuff that I have in progress.

Here's the API example for defining regs in a block's registers.py file:

~~~python
# Registers added in the global scope of these files will be added to
# a memory map called 'default' and within that an address block called
# 'default'. Such regs can be accessed via my_block.regs and users who
# don't care about maps don't have to even think about them.
# Note that such regs can also be accessed via my_block.default.default.regs

# A simple reg definition with all bits writable, here at address 0 and a
# default size of 32-bits
SimpleReg("reg1", 0)
# Another simple reg with custom size
SimpleReg("reg2", 4, size=16)

# This is the reg definition
with Reg("reg3", 0x0024, size=16) as reg:
    # This is the COCO definition
    reg.bit(7, "coco", access="ro")
    reg.bit(6, "aien")
    reg.bit(5, "diff")
    reg.bit([4,0], "adch", reset=0x1F)

# Regs can be added within a defined memory map, and in this case no address
# block is given so that will mean they are placed in a default address block
# named 'default'.
with MemoryMap("user"):
    # Test that reg names can be reused when scoped within a different map
    SimpleReg("reg1", 0)

    with Reg("reg2", 0x0024, size=16) as reg:
        reg.bit([4,0], "adch", reset=0x1F)


# Finally regs can be added to a full declared scope like this:
with MemoryMap("test"):
    with AddressBlock("bank0"):
        # Test that reg names can be reused when scoped within a different map
        SimpleReg("reg1", 0)

        with Reg("reg2", 0x0024, size=16) as reg:
            reg.bit([4,0], "adch", reset=0x1F)
~~~

