### PR TITLE
Overhaul DUT Database Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__
 pip-wheel-metadata/
 _origen.pyd
 log/
+.vscode
 
 # Editor cruft
 *.swp

--- a/example/config/application.toml
+++ b/example/config/application.toml
@@ -1,6 +1,6 @@
 name = "example"
 # Define a default target that will be used by a new workspace
-#target = "eagle"
+target = "falcon"
 # Define a default environment that will be used by a new workspace
 #environment = "v93k"
 # To make your application workspace run in production mode by default

--- a/example/config/application.toml
+++ b/example/config/application.toml
@@ -1,4 +1,4 @@
-id = "example"
+name = "example"
 # Define a default target that will be used by a new workspace
 #target = "eagle"
 # Define a default environment that will be used by a new workspace

--- a/example/example/blocks/dut/registers.py
+++ b/example/example/blocks/dut/registers.py
@@ -10,9 +10,9 @@ SimpleReg("reg1", 0)
 # Another simple reg with custom size
 SimpleReg("reg2", 4, size=16)
 
-# This is the reg definition
+# This is the reg description
 with Reg("reg3", 0x0024, size=16) as reg:
-    # This is the COCO definition
+    # This is the COCO description
     reg.bit(7, "coco", access="ro")
     reg.bit(6, "aien")
     reg.bit(5, "diff")

--- a/example/poetry.lock
+++ b/example/poetry.lock
@@ -25,8 +25,8 @@ category = "main"
 description = "Cross-platform colored terminal text."
 name = "colorama"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.4.1"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.4.3"
 
 [[package]]
 category = "dev"
@@ -34,8 +34,8 @@ description = "Read metadata from Python packages"
 marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
-python-versions = ">=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4"
-version = "1.1.0"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+version = "1.3.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -50,11 +50,12 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.0.0"
+version = "8.0.2"
 
 [[package]]
 category = "main"
 description = ""
+develop = true
 name = "origen"
 optional = false
 python-versions = "^3.6"
@@ -167,16 +168,16 @@ attrs = [
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
 colorama = [
-    {file = "colorama-0.4.1-py2.py3-none-any.whl", hash = "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"},
-    {file = "colorama-0.4.1.tar.gz", hash = "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"},
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.1.0-py2.py3-none-any.whl", hash = "sha256:e6ac600a142cf2db707b1998382cc7fc3b02befb7273876e01b8ad10b9652742"},
-    {file = "importlib_metadata-1.1.0.tar.gz", hash = "sha256:b044f07694ef14a6683b097ba56bd081dbc7cdc7c7fe46011e499dfecc082f21"},
+    {file = "importlib_metadata-1.3.0-py2.py3-none-any.whl", hash = "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"},
+    {file = "importlib_metadata-1.3.0.tar.gz", hash = "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.0.0.tar.gz", hash = "sha256:53ff73f186307d9c8ef17a9600309154a6ae27f25579e80af4db8f047ba14bc2"},
-    {file = "more_itertools-8.0.0-py3-none-any.whl", hash = "sha256:a0ea684c39bc4315ba7aae406596ef191fd84f873d2d2751f84d64e81a7a2d45"},
+    {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
+    {file = "more_itertools-8.0.2-py3-none-any.whl", hash = "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"},
 ]
 origen = []
 pluggy = [

--- a/example/tests/block_loader_test.py
+++ b/example/tests/block_loader_test.py
@@ -10,3 +10,10 @@ def test_registers_are_loaded():
 def test_sub_blocks_are_loaded():
     origen.app.instantiate_dut("dut.falcon")
     assert origen.dut.sub_blocks["core0"].sub_blocks["adc0"].regs.len() == 1
+
+def test_tree_method():
+    # Just a simple test to make sure it doesn't crash and returns
+    origen.app.instantiate_dut("dut.falcon")
+    assert origen.dut.tree() is None
+    assert origen.dut.core0.tree() is None
+    assert origen.dut.core0.adc0.tree() is None

--- a/example/tests/registers_test.py
+++ b/example/tests/registers_test.py
@@ -5,6 +5,12 @@ def test_memory_maps():
     assert origen.dut.memory_maps
     assert origen.dut.memory_map("default") == origen.dut.memory_maps["default"]
     assert len(origen.dut.memory_maps) == 3
+    assert len(origen.dut.core0.memory_maps) == 0
+    assert len(origen.dut.core0.adc0.memory_maps) == 1
+    # Simple test to make sure the display method doesn't hang/crash
+    assert origen.dut.memory_maps.__repr__()
+    assert origen.dut.core0.memory_maps.__repr__()
+    assert origen.dut.core0.adc0.memory_maps.__repr__()
 
     # Check some of the dict-like API
     assert "default" in origen.dut.memory_maps

--- a/python/origen/__init__.py
+++ b/python/origen/__init__.py
@@ -16,7 +16,7 @@ mode = "development"
 
 if status["is_app_present"]:
     sys.path.insert(0, status["root"])
-    a = importlib.import_module(f'{_origen.app_config()["id"]}.application')
+    a = importlib.import_module(f'{_origen.app_config()["name"]}.application')
     app = a.Application()
 
 def set_mode(val):

--- a/python/origen/application.py
+++ b/python/origen/application.py
@@ -9,14 +9,14 @@ from origen.controller import TopLevel
 # The base class of all application classes
 class Base:
     # Returns the unique ID (name) of the app/plugin
-    id =  _origen.app_config()["id"]
+    name =  _origen.app_config()["name"]
 
     __instantiate_dut_called = False
 
     # Translates something like "dut.falcon" to <root>/<app>/blocks/dut/derivatives/falcon
     def block_path_to_filepath(self, path):
         fields = path.split(".")
-        filepath = origen.root.joinpath(self.id).joinpath('blocks')
+        filepath = origen.root.joinpath(self.name).joinpath('blocks')
         for i, field in enumerate(fields):
             if i > 0:
                 filepath = filepath.joinpath('derivatives')
@@ -60,7 +60,7 @@ class Base:
                 block = Base()
         else:
             controller = '.derivatives.'.join(path.split("."))
-            controller = self.id + ".blocks." + controller + ".controller"
+            controller = self.name + ".blocks." + controller + ".controller"
             m = importlib.import_module(controller)
             block = m.Controller()
 
@@ -75,7 +75,7 @@ class Base:
         fields = controller.block_path.split(".")
         for i, field in enumerate(fields):
             if i == 0:
-                filepath = origen.root.joinpath(self.id).joinpath("blocks").joinpath(fields[i])
+                filepath = origen.root.joinpath(self.name).joinpath("blocks").joinpath(fields[i])
             else:
                 filepath = filepath.joinpath("derivatives").joinpath(fields[i])
             p = filepath.joinpath(filename)

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -34,7 +34,10 @@ class Base:
         # memory map and address block
         if name == "regs":
             self._load_regs()
-            return origen.dut.db.regs(self.path, None, None)
+            if self._default_default_address_block:
+                return origen.dut.db.regs(self._default_default_address_block.id)
+            else:
+                return origen.dut.db.regs(None)
 
         elif name == "sub_blocks":
             self._load_sub_blocks()
@@ -42,7 +45,7 @@ class Base:
 
         elif name == "memory_maps":
             self._load_regs()
-            return origen.dut.db.memory_maps(self.path)
+            return origen.dut.db.memory_maps(self.model_id)
 
         else:
             self._load_sub_blocks()
@@ -62,12 +65,7 @@ class Base:
 
     def tree_as_str(self, leader='', include_header=True):
         if include_header:
-            if self.is_top:
-                t = "dut"
-            elif self.parent_path == '':
-                t = f"dut.{self.id}"
-            else:
-                t = f"dut.{self.parent_path}.{self.id}"
+            t = self.path
             names = t.split('.')
             names.pop()
             if not names:
@@ -90,9 +88,9 @@ class Base:
                 t += self.sub_blocks[key].tree_as_str(l, False)
         return t
 
-    def memory_map(self, id):
+    def memory_map(self, name):
         self.regs  # Ensure the memory maps for this block have been loaded
-        return origen.dut.db.memory_map(self.path, id)
+        return origen.dut.db.memory_map(self.model_id, name)
 
     def add_simple_reg(self, *args, **kwargs):
         RegLoader(self).SimpleReg(*args, **kwargs)

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -17,7 +17,9 @@ class Base:
     # Returns the application instance that defines this block
     app = None
 
-    _id = None
+    model_id = None
+
+    _default_default_address_block = None
 
     is_top = False
 
@@ -27,6 +29,7 @@ class Base:
 
     # This lazy-loads the block's files the first time a given resource is referenced
     def __getattr__(self, name):
+        #print(f"Looking for attribute {name}")
         # regs called directly on the controller means only the regs in the default
         # memory map and address block
         if name == "regs":
@@ -121,7 +124,7 @@ class TopLevel(Base):
     def __init__(self):
         self.name = "dut"
         self.path = "dut"
-        self._id = 0
+        self.model_id = 0
         origen.dut = self
         # TODO: Probably pass the name of the target in here to act as the DUT name/ID
         self.db = _origen.dut.PyDUT("tbd")

--- a/python/origen/registers.py
+++ b/python/origen/registers.py
@@ -25,6 +25,8 @@ class Loader:
                 ab = origen.dut.db.get_or_create_address_block(mm.id, "default")
                 self.controller._default_default_address_block = ab
                 return ab
+            else:
+                return self.controller._default_default_address_block
         else:
             return origen.dut.db.get_or_create_address_block(self.memory_map.id, "default")
 

--- a/python/origen/registers.py
+++ b/python/origen/registers.py
@@ -1,20 +1,6 @@
 import origen
 from contextlib import contextmanager
 
-# A middleman between the Python controller and the associated Rust model and
-# which implements the application/user API for working with registers.
-# An instance of this class is returned by <my_controller>.regs
-class Proxy:
-    def __init__(self, controller):
-        self.controller = controller
-
-    # Returns the number of contained registers
-    def len(self):
-        return origen.dut.db.number_of_regs(self.controller.path);
-
-    #def __repr__(self):
-    #    return f"Registers in {self.controller.block_path}:\n0  : Reg 1\n4  : Reg 2"
-
 # This defines the API for defining registers in Python and then handles serializing
 # the definitions and handing them over to the Rust model for instantiation.
 class Loader:
@@ -23,26 +9,49 @@ class Loader:
         self.memory_map = None
         self.address_block = None
 
+    def current_memory_map(self):
+        if self.memory_map is not None:
+            return self.memory_map
+        else:
+            return origen.dut.db.get_or_create_memory_map(self.controller.model_id, "default")
+
+    def current_address_block(self):
+        if self.address_block is not None:
+            return self.address_block
+
+        elif self.memory_map is None and self.address_block is None:
+            if self.controller._default_default_address_block is None:
+                mm = origen.dut.db.get_or_create_memory_map(self.controller.model_id, "default")
+                ab = origen.dut.db.get_or_create_address_block(mm.id, "default")
+                self.controller._default_default_address_block = ab
+                return ab
+        else:
+            return origen.dut.db.get_or_create_address_block(self.memory_map.id, "default")
+
     @contextmanager
-    def Reg(self, id, address_offset, size=32):
-        origen.dut.db.create_reg(self.controller.path, self.memory_map, self.address_block, id, address_offset, size);
+    def Reg(self, name, address_offset, size=32):
+        origen.dut.db.create_reg(self.current_address_block().id, name, address_offset, size);
         yield self
 
-    def SimpleReg(self, id, address_offset, size=32):
-        origen.dut.db.create_reg(self.controller.path, self.memory_map, self.address_block, id, address_offset, size);
+    def SimpleReg(self, name, address_offset, size=32):
+        origen.dut.db.create_reg(self.current_address_block().id, name, address_offset, size);
 
-    def bit(self, number, id, access="rw", reset=0):
+    def bit(self, number, name, access="rw", reset=0):
         pass
 
     @contextmanager
-    def MemoryMap(self, id):
-        self.memory_map = id
+    def MemoryMap(self, name):
+        if self.memory_map is not None:
+            raise RuntimeError(f"Attempted to open memory map '{name}' when memory map '{self.memory_map.name}' is already open")
+        self.memory_map = origen.dut.db.get_or_create_memory_map(self.controller.model_id, name)
         yield self
         self.memory_map = None
 
     @contextmanager
-    def AddressBlock(self, id):
-        self.address_block = id
+    def AddressBlock(self, name):
+        if self.address_block is not None:
+            raise RuntimeError(f"Attempted to open address block '{name}' when address block '{self.address_block.name}' is already open")
+        self.address_block = origen.dut.db.get_or_create_address_block(self.current_memory_map().id, name)
         yield self
         self.address_block = None
 

--- a/python/origen/sub_blocks.py
+++ b/python/origen/sub_blocks.py
@@ -11,8 +11,8 @@ class Proxy:
     def __getitem__(self, key):
         return self.__dict__[key]
 
-    def __add_block__(self, id, obj):
-        self.__dict__[id] = obj
+    def __add_block__(self, name, obj):
+        self.__dict__[name] = obj
 
     def __len__(self):
         return len(self.__dict__)
@@ -41,24 +41,15 @@ class Loader:
     def __init__(self, controller):
         self.controller = controller
 
-    def sub_block(self, id, block_path=None):
+    def sub_block(self, name, block_path=None):
         b = self.controller.app.instantiate_block(block_path)
-        b.id = id
-        if self.controller.parent_path == "":
-            if self.controller.id == "":
-                b.parent_path = ""
-                b.path = id
-            else:
-                b.parent_path = self.controller.id
-                b.path = f"{b.parent_path}.{b.id}"
-        else:
-            b.parent_path = f"{self.controller.parent_path}.{self.controller.id}"
-            b.path = f"{b.parent_path}.{b.id}"
+        b.name = name
+        b.path = f"{self.controller.path}.{name}"
         # Add the python representation of this block to its parent
-        self.controller.sub_blocks.__add_block__(id, b)
+        self.controller.sub_blocks.__add_block__(name, b)
         # Create a new representation of it in the internal database
-        origen.dut.db.create_sub_block(b.parent_path, b.id)
-        pass
+        b._id = origen.dut.db.create_model(self.controller._id, name)
+        return b
 
     # Defines the methods that are accessible within blocks/<block>/sub_blocks.py
     def api(self):

--- a/python/origen/sub_blocks.py
+++ b/python/origen/sub_blocks.py
@@ -56,4 +56,3 @@ class Loader:
         return {
             "sub_block": self.sub_block, 
         }
-                

--- a/python/origen/sub_blocks.py
+++ b/python/origen/sub_blocks.py
@@ -48,7 +48,7 @@ class Loader:
         # Add the python representation of this block to its parent
         self.controller.sub_blocks.__add_block__(name, b)
         # Create a new representation of it in the internal database
-        b._id = origen.dut.db.create_model(self.controller._id, name)
+        b.model_id = origen.dut.db.create_model(self.controller.model_id, name)
         return b
 
     # Defines the methods that are accessible within blocks/<block>/sub_blocks.py

--- a/rust/origen/cli/src/commands/setup.rs
+++ b/rust/origen/cli/src/commands/setup.rs
@@ -92,6 +92,7 @@ pub fn run() {
 
     let status = os::cmd(&PYTHON_CONFIG.poetry_command)
         .arg("install")
+        .arg("--no-root")
         .status();
 
     if status.is_ok() {

--- a/rust/origen/pyapi/src/address_block.rs
+++ b/rust/origen/pyapi/src/address_block.rs
@@ -1,37 +1,66 @@
 use crate::dut::PyDUT;
-use crate::register::Registers;
+//use crate::register::Registers;
 use origen::DUT;
-use pyo3::class::basic::{CompareOp, PyObjectProtocol};
-use pyo3::class::PyMappingProtocol;
-use pyo3::exceptions::{AttributeError, KeyError, TypeError};
+//use pyo3::class::basic::{CompareOp, PyObjectProtocol};
+//use pyo3::class::PyMappingProtocol;
+//use pyo3::exceptions::{AttributeError, KeyError, TypeError};
 use pyo3::prelude::*;
 
 /// Implements the user APIs dut[.sub_block].memory_map() and
 /// dut[.sub_block].memory_maps
 #[pymethods]
 impl PyDUT {
-    fn create_memory_map(
-        &self,
-        model_id: usize,
-        name: &str,
-        address_unit_bits: Option<u32>,
-    ) -> PyResult<usize> {
-        Ok(DUT
-            .lock()
-            .unwrap()
-            .create_memory_map(model_id, name, address_unit_bits)?)
-    }
+    //fn create_address_block(
+    //    &self,
+    //    memory_map_id: usize,
+    //    name: &str,
+    //    base_address: Option<u64>,
+    //    range: Option<u64>,
+    //    width: Option<u64>,
+    //    access: Option<&str>,
+    //) -> PyResult<usize> {
+    //    let acc: AccessType = match access {
+    //        Some(x) => match x.parse() {
+    //            Ok(y) => y,
+    //            Err(msg) => return Err(exceptions::OSError::py_err(msg)),
+    //        },
+    //        None => AccessType::ReadWrite,
+    //    };
 
-    fn get_or_create_address_block(&self, memory_map_id: usize, name: &str) -> PyResult<AddressBlock> {
+    //    Ok(DUT.lock().unwrap().create_address_block(
+    //        memory_map_id,
+    //        name,
+    //        base_address,
+    //        range,
+    //        width,
+    //        Some(acc),
+    //    )?)
+    //}
+
+    fn get_or_create_address_block(
+        &self,
+        memory_map_id: usize,
+        name: &str,
+    ) -> PyResult<AddressBlock> {
         let mut dut = DUT.lock().unwrap();
         let mm = dut.get_memory_map(memory_map_id)?;
-        let id = match model.get_memory_map_id(name) {
+        let id = match mm.get_address_block_id(name) {
             Ok(v) => v,
-            Err(_) => dut.create_memory_map(model_id, name, None)?,
+            Err(_) => dut.create_address_block(memory_map_id, name, None, None, None, None)?,
         };
-        Ok(MemoryMap {
+        Ok(AddressBlock {
             id: id,
             name: name.to_string(),
         })
     }
+}
+
+/// Implements the user API to work with a single address block
+#[pyclass]
+#[derive(Debug)]
+pub struct AddressBlock {
+    #[pyo3(get)]
+    id: usize,
+    #[pyo3(get)]
+    name: String,
 }

--- a/rust/origen/pyapi/src/address_block.rs
+++ b/rust/origen/pyapi/src/address_block.rs
@@ -1,1 +1,37 @@
+use crate::dut::PyDUT;
+use crate::register::Registers;
+use origen::DUT;
+use pyo3::class::basic::{CompareOp, PyObjectProtocol};
+use pyo3::class::PyMappingProtocol;
+use pyo3::exceptions::{AttributeError, KeyError, TypeError};
+use pyo3::prelude::*;
 
+/// Implements the user APIs dut[.sub_block].memory_map() and
+/// dut[.sub_block].memory_maps
+#[pymethods]
+impl PyDUT {
+    fn create_memory_map(
+        &self,
+        model_id: usize,
+        name: &str,
+        address_unit_bits: Option<u32>,
+    ) -> PyResult<usize> {
+        Ok(DUT
+            .lock()
+            .unwrap()
+            .create_memory_map(model_id, name, address_unit_bits)?)
+    }
+
+    fn get_or_create_address_block(&self, memory_map_id: usize, name: &str) -> PyResult<AddressBlock> {
+        let mut dut = DUT.lock().unwrap();
+        let mm = dut.get_memory_map(memory_map_id)?;
+        let id = match model.get_memory_map_id(name) {
+            Ok(v) => v,
+            Err(_) => dut.create_memory_map(model_id, name, None)?,
+        };
+        Ok(MemoryMap {
+            id: id,
+            name: name.to_string(),
+        })
+    }
+}

--- a/rust/origen/pyapi/src/dut.rs
+++ b/rust/origen/pyapi/src/dut.rs
@@ -31,18 +31,6 @@ impl PyDUT {
         Ok(DUT.lock().unwrap().create_model(parent_id, name)?)
     }
 
-    fn create_memory_map(
-        &self,
-        model_id: usize,
-        name: &str,
-        address_unit_bits: Option<u32>,
-    ) -> PyResult<usize> {
-        Ok(DUT
-            .lock()
-            .unwrap()
-            .create_memory_map(model_id, name, address_unit_bits)?)
-    }
-
     fn create_address_block(
         &self,
         memory_map_id: usize,

--- a/rust/origen/pyapi/src/dut.rs
+++ b/rust/origen/pyapi/src/dut.rs
@@ -25,22 +25,21 @@ impl PyDUT {
     }
 
     /// Creates a new model at the given path
-    fn create_sub_block(&self, path: &str, id: &str) -> PyResult<()> {
-        Ok(DUT.lock().unwrap().create_sub_block(path, id)?)
+    fn create_sub_block(&self, parent_id: usize, name: &str) -> PyResult<usize> {
+        Ok(DUT.lock().unwrap().create_sub_block(parent_id, name)?)
     }
 
     fn create_reg(
         &self,
-        path: &str,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
-        id: &str,
+        address_block_id: usize,
+        name: &str,
         offset: u32,
         size: Option<u32>,
-    ) -> PyResult<()> {
+    ) -> PyResult<usize> {
         let mut dut = DUT.lock().unwrap();
-        Ok(dut
-            .get_mut_model(path)?
-            .create_reg(memory_map, address_block, id, offset, size)?)
+        Ok(DUT
+            .lock()
+            .unwrap()
+            .create_reg(address_block_id, name, offset, size)?)
     }
 }

--- a/rust/origen/pyapi/src/dut.rs
+++ b/rust/origen/pyapi/src/dut.rs
@@ -1,7 +1,5 @@
-use pyo3::exceptions;
 use pyo3::prelude::*;
 //use pyo3::wrap_pyfunction;
-use origen::core::model::registers::AccessType;
 use origen::DUT;
 
 /// Implements the module _origen.dut in Python which exposes all
@@ -29,33 +27,6 @@ impl PyDUT {
     /// Creates a new model at the given path
     fn create_model(&self, parent_id: Option<usize>, name: &str) -> PyResult<usize> {
         Ok(DUT.lock().unwrap().create_model(parent_id, name)?)
-    }
-
-    fn create_address_block(
-        &self,
-        memory_map_id: usize,
-        name: &str,
-        base_address: Option<u64>,
-        range: Option<u64>,
-        width: Option<u64>,
-        access: Option<&str>,
-    ) -> PyResult<usize> {
-        let acc: AccessType = match access {
-            Some(x) => match x.parse() {
-                Ok(y) => y,
-                Err(msg) => return Err(exceptions::OSError::py_err(msg)),
-            },
-            None => AccessType::ReadWrite,
-        };
-
-        Ok(DUT.lock().unwrap().create_address_block(
-            memory_map_id,
-            name,
-            base_address,
-            range,
-            width,
-            Some(acc),
-        )?)
     }
 
     fn create_reg(

--- a/rust/origen/pyapi/src/dut.rs
+++ b/rust/origen/pyapi/src/dut.rs
@@ -1,5 +1,5 @@
+use pyo3::exceptions;
 use pyo3::prelude::*;
-use pyo3::{exceptions};
 //use pyo3::wrap_pyfunction;
 use origen::core::model::registers::AccessType;
 use origen::DUT;
@@ -21,13 +21,13 @@ pub struct PyDUT {}
 impl PyDUT {
     #[new]
     /// Instantiating a new instance of PyDUT means re-loading the target
-    fn new(obj: &PyRawObject, id: &str) {
-        DUT.lock().unwrap().change(id);
+    fn new(obj: &PyRawObject, name: &str) {
+        DUT.lock().unwrap().change(name);
         obj.init({ PyDUT {} });
     }
 
     /// Creates a new model at the given path
-    fn create_model(&self, parent_id: usize, name: &str) -> PyResult<usize> {
+    fn create_model(&self, parent_id: Option<usize>, name: &str) -> PyResult<usize> {
         Ok(DUT.lock().unwrap().create_model(parent_id, name)?)
     }
 
@@ -52,12 +52,10 @@ impl PyDUT {
         width: Option<u64>,
         access: Option<&str>,
     ) -> PyResult<usize> {
-
         let acc: AccessType = match access {
             Some(x) => match x.parse() {
                 Ok(y) => y,
                 Err(msg) => return Err(exceptions::OSError::py_err(msg)),
-        
             },
             None => AccessType::ReadWrite,
         };

--- a/rust/origen/pyapi/src/lib.rs
+++ b/rust/origen/pyapi/src/lib.rs
@@ -57,7 +57,7 @@ fn config(py: Python) -> PyResult<PyObject> {
 fn app_config(py: Python) -> PyResult<PyObject> {
     let ret = PyDict::new(py);
     // Don't think an error can really happen here, so not handled
-    let _ = ret.set_item("id", &APPLICATION_CONFIG.id);
+    let _ = ret.set_item("name", &APPLICATION_CONFIG.name);
     let _ = ret.set_item("target", &APPLICATION_CONFIG.target);
     let _ = ret.set_item("environment", &APPLICATION_CONFIG.environment);
     let _ = ret.set_item("mode", &APPLICATION_CONFIG.mode);

--- a/rust/origen/pyapi/src/memory_map.rs
+++ b/rust/origen/pyapi/src/memory_map.rs
@@ -113,7 +113,7 @@ impl PyMappingProtocol for MemoryMaps {
         } else {
             Err(KeyError::py_err(format!(
                 "'{}' does not have a memory map called '{}'",
-                model.display_path, query
+                model.display_path(), query
             )))
         }
     }

--- a/rust/origen/pyapi/src/register.rs
+++ b/rust/origen/pyapi/src/register.rs
@@ -1,5 +1,5 @@
 use crate::dut::PyDUT;
-use origen::core::model::registers::Register;
+//use origen::core::model::registers::Register;
 use origen::DUT;
 use pyo3::prelude::*;
 
@@ -7,38 +7,20 @@ use pyo3::prelude::*;
 /// my_block.[.my_memory_map][.my_address_block].regs
 #[pymethods]
 impl PyDUT {
-    fn regs(
-        &self,
-        path: &str,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
-    ) -> PyResult<Registers> {
-        // Verify the model exists, though we don't need it for now
-        DUT.lock().unwrap().get_model(path)?;
-        // TODO: Verify the memory_map and address_block
+    fn regs(&self, address_block_id: usize) -> PyResult<Registers> {
         Ok(Registers {
-            model_path: path.to_string(),
-            memory_map: memory_map.unwrap_or("default").to_string(),
-            address_block: address_block.unwrap_or("default").to_string(),
+            address_block_id: address_block_id,
             i: 0,
         })
     }
 
-    fn reg(
-        &self,
-        path: &str,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
-        id: &str,
-    ) -> PyResult<BitCollection> {
-        // Verify the model exists, though we don't need it for now
-        DUT.lock().unwrap().get_model(path)?;
-        // TODO: Verify the memory_map and address_block
+    fn reg(&self, address_block_id: usize, name: &str) -> PyResult<BitCollection> {
         Ok(BitCollection {
-            model_path: path.to_string(),
-            memory_map: memory_map.unwrap_or("default").to_string(),
-            address_block: address_block.unwrap_or("default").to_string(),
-            reg_id: id.to_string(),
+            reg_id: DUT
+                .lock()
+                .unwrap()
+                .get_address_block(address_block_id)?
+                .get_register_id(name)?,
             whole: true,
             bit_numbers: Vec::new(),
             i: 0,
@@ -51,12 +33,8 @@ impl PyDUT {
 #[pyclass]
 #[derive(Debug, Clone)]
 pub struct Registers {
-    /// The path to the model which owns the contained registers
-    pub model_path: String,
-    /// The name of the model's memory map which contains these registers
-    pub memory_map: String,
-    /// The name of the memory map's address block which contains these register
-    pub address_block: String,
+    /// The ID of the address block which contains these registers
+    pub address_block_id: usize,
     /// Iterator index
     pub i: usize,
 }
@@ -65,61 +43,39 @@ pub struct Registers {
 #[pymethods]
 impl Registers {
     fn len(&self) -> PyResult<usize> {
-        let dut = DUT.lock().unwrap();
-        let model = dut.get_model(&self.model_path)?;
-        let map = model.memory_maps.get(&self.memory_map).unwrap();
-        let ab = map.address_blocks.get(&self.address_block).unwrap();
-        Ok(ab.registers.len())
+        Ok(DUT
+            .lock()
+            .unwrap()
+            .get_address_block(self.address_block_id)?
+            .registers
+            .len())
     }
 
     fn keys(&self) -> PyResult<Vec<String>> {
         let dut = DUT.lock().unwrap();
-        let model = dut.get_model(&self.model_path)?;
-        let map = model.memory_maps.get(&self.memory_map).unwrap();
-        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        let ab = dut.get_address_block(self.address_block_id)?;
         let keys: Vec<String> = ab.registers.keys().map(|x| x.clone()).collect();
         Ok(keys)
     }
 
     fn values(&self) -> PyResult<Vec<BitCollection>> {
         let dut = DUT.lock().unwrap();
-        let model = dut.get_model(&self.model_path)?;
-        let map = model.memory_maps.get(&self.memory_map).unwrap();
-        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        let ab = dut.get_address_block(self.address_block_id)?;
         let values: Vec<BitCollection> = ab
             .registers
-            .keys()
-            .map(|x| {
-                BitCollection::from_reg(
-                    &self.model_path,
-                    &self.memory_map,
-                    &self.address_block,
-                    &ab.registers.get(x).unwrap(),
-                )
-            })
+            .values()
+            .map(|x| BitCollection::from_reg_id(*x))
             .collect();
         Ok(values)
     }
 
     fn items(&self) -> PyResult<Vec<(String, BitCollection)>> {
         let dut = DUT.lock().unwrap();
-        let model = dut.get_model(&self.model_path)?;
-        let map = model.memory_maps.get(&self.memory_map).unwrap();
-        let ab = map.address_blocks.get(&self.address_block).unwrap();
+        let ab = dut.get_address_block(self.address_block_id)?;
         let items: Vec<(String, BitCollection)> = ab
             .registers
-            .keys()
-            .map(|x| {
-                (
-                    x.to_string(),
-                    BitCollection::from_reg(
-                        &self.model_path,
-                        &self.memory_map,
-                        &self.address_block,
-                        &ab.registers.get(x).unwrap(),
-                    ),
-                )
-            })
+            .iter()
+            .map(|(k, v)| (k.to_string(), BitCollection::from_reg_id(*v)))
             .collect();
         Ok(items)
     }
@@ -131,14 +87,8 @@ impl Registers {
 #[pyclass]
 #[derive(Debug)]
 pub struct BitCollection {
-    /// The path to the model which owns the parent register
-    model_path: String,
-    /// The name of the model's memory map which contains the register
-    memory_map: String,
-    /// The name of the memory map's address block which contains the register
-    address_block: String,
     /// The ID of the parent register
-    reg_id: String,
+    reg_id: usize,
     /// When true the BitCollection contains an entire register's worth of bits
     whole: bool,
     /// The index numbers of the bits from the register that are included in this
@@ -151,17 +101,9 @@ pub struct BitCollection {
 
 /// Rust-private methods, i.e. not accessible from Python
 impl BitCollection {
-    pub fn from_reg(
-        path: &str,
-        memory_map: &str,
-        address_block: &str,
-        reg: &Register,
-    ) -> BitCollection {
+    pub fn from_reg_id(id: usize) -> BitCollection {
         BitCollection {
-            model_path: path.to_string(),
-            memory_map: memory_map.to_string(),
-            address_block: address_block.to_string(),
-            reg_id: reg.id.clone(),
+            reg_id: id,
             whole: true,
             bit_numbers: Vec::new(),
             i: 0,

--- a/rust/origen/src/core/application/config.rs
+++ b/rust/origen/src/core/application/config.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 // * default function below to define the default value
 // * add an example of it to src/app_generators/templates/app/config/application.toml
 pub struct Config {
-    pub id: String,
+    pub name: String,
     pub target: Option<String>,
     pub environment: Option<String>,
     pub mode: String,
@@ -23,7 +23,7 @@ impl Default for Config {
 
         // Start off by specifying the default values for all attributes, seems fine
         // not to handle these errors
-        //let _ = s.set_default("id", "");
+        //let _ = s.set_default("name", "");
         //let _ = s.set_default("target", None::<String>);
         //let _ = s.set_default("environment", None::<String>);
         let _ = s.set_default("mode", "development".to_string());

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -188,7 +188,9 @@ impl Dut {
     /// via the parent model).
     pub fn create_model(&mut self, parent_id: usize, name: &str) -> Result<usize> {
         let id;
-        { id = self.models.len(); }
+        {
+            id = self.models.len();
+        }
         {
             let m = self.get_mut_model(parent_id)?;
             if m.sub_blocks.contains_key(name) {
@@ -205,29 +207,40 @@ impl Dut {
         Ok(id)
     }
 
-    //pub fn create_memory_map(&mut self, model_id: usize, name: &str, address_unit_bits: Option<u32>) -> Result<usize> {
-    //    if self.models[model_id].memory_maps.contains_key(name) {
-    //        return Err(Error::new(&format!(
-    //            //"The block '{}' already contains a sub-block called '{}'",
-    //            "The block  already contains a sub-block called '{}'",
-    //            name
-    //        )));
+    pub fn create_memory_map(
+        &mut self,
+        model_id: usize,
+        name: &str,
+        address_unit_bits: Option<u32>,
+    ) -> Result<usize> {
+        let id;
+        {
+            id = self.memory_maps.len();
+        }
+        {
+            let model = self.get_mut_model(model_id)?;
 
-    //    } else {
+            if model.memory_maps.contains_key(name) {
+                return Err(Error::new(&format!(
+                    "The block '{}' already contains a memory map called '{}'",
+                    model.name, name
+                )));
+            } else {
+                model.memory_maps.insert(name.to_string(), id);
+            }
+        }
 
-    //    let mut defaults = MemoryMap::default();
-    //    match address_unit_bits {
-    //        Some(v) => defaults.address_unit_bits = v,
-    //        None => {}
-    //    }
-    //    self.memory_maps.insert(
-    //        id.to_string(),
-    //        MemoryMap {
-    //            id: id.to_string(),
-    //            ..defaults
-    //        },
-    //    );
-    //}
+        let mut defaults = MemoryMap::default();
+        match address_unit_bits {
+            Some(v) => defaults.address_unit_bits = v,
+            None => {}
+        }
+        self.memory_maps.push(MemoryMap {
+            name: name.to_string(),
+            ..defaults
+        });
+        Ok(id)
+    }
 
     pub fn create_address_block(
         &mut self,
@@ -239,7 +252,9 @@ impl Dut {
         access: Option<AccessType>,
     ) -> Result<usize> {
         let id;
-        { id = self.address_blocks.len(); }
+        {
+            id = self.address_blocks.len();
+        }
         {
             let map = self.get_mut_memory_map(memory_map_id)?;
 
@@ -249,7 +264,6 @@ impl Dut {
                     map.name, name
                 )));
             } else {
-
                 map.address_blocks.insert(name.to_string(), id);
             }
         }
@@ -272,12 +286,10 @@ impl Dut {
             None => {}
         }
 
-        self.address_blocks.push(
-            AddressBlock {
-                name: name.to_string(),
-                ..defaults
-            },
-        );
+        self.address_blocks.push(AddressBlock {
+            name: name.to_string(),
+            ..defaults
+        });
         Ok(id)
     }
 
@@ -289,7 +301,9 @@ impl Dut {
         size: Option<u32>,
     ) -> Result<usize> {
         let id;
-        { id = self.registers.len(); }
+        {
+            id = self.registers.len();
+        }
         {
             let a = self.get_mut_address_block(address_block_id)?;
             if a.registers.contains_key(name) {

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -21,6 +21,8 @@ pub struct Dut {
 }
 
 impl Dut {
+    // This is called only once at the start of an Origen thread to create the global database,
+    // then the 'change' method is called every time a DUT is loaded
     pub fn new(name: &str) -> Dut {
         // TODO: reserve some size for these?
         Dut {
@@ -36,6 +38,7 @@ impl Dut {
     /// Change the DUT, this replaces the existing mode with a fresh one (i.e.
     /// deletes all current DUT metadata and state, and updates the name/ID field
     /// with the given value
+    // This is called once per DUT load
     pub fn change(&mut self, name: &str) {
         self.name = name.to_string();
         self.models.clear();
@@ -204,7 +207,7 @@ impl Dut {
                 }
             }
         }
-        let new_model = Model::new(name.to_string(), parent_id);
+        let new_model = Model::new(id, name.to_string(), parent_id);
         self.models.push(new_model);
         Ok(id)
     }

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -2,6 +2,7 @@ use crate::core::model::registers::{AccessType, AddressBlock, Bit, MemoryMap, Re
 use crate::core::model::Model;
 use crate::error::Error;
 use crate::Result;
+use crate::DUT;
 
 /// The DUT stores all objects associated with a particular device.
 /// Each object type is organized into vectors, where a particular object's position within the
@@ -200,7 +201,8 @@ impl Dut {
                 if m.sub_blocks.contains_key(name) {
                     return Err(Error::new(&format!(
                         "The block '{}' already contains a sub-block called '{}'",
-                        m.display_path(), name
+                        m.display_path(&DUT.lock().unwrap()),
+                        name
                     )));
                 } else {
                     m.sub_blocks.insert(name.to_string(), id);

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -13,11 +13,11 @@ use crate::Result;
 #[derive(Debug)]
 pub struct Dut {
     pub id: String,
-    pub models: Vec<Model>,
-    pub memory_maps: Vec<MemoryMap>,
-    pub address_blocks: Vec<AddressBlock>,
-    pub registers: Vec<Register>,
-    pub bits: Vec<Bit>,
+    models: Vec<Model>,
+    memory_maps: Vec<MemoryMap>,
+    address_blocks: Vec<AddressBlock>,
+    registers: Vec<Register>,
+    bits: Vec<Bit>,
 }
 
 impl Dut {

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -1,18 +1,36 @@
+use crate::core::model::registers::{AccessType, AddressBlock, Bit, MemoryMap, Register};
 use crate::core::model::Model;
 use crate::error::Error;
 use crate::Result;
 
+/// The DUT stores all objects associated with a particular device.
+/// Each object type is organized into vectors, where a particular object's position within the
+/// vector is considered its unique ID.
+/// A register then (for example) does not embed its bit objects but rather contains a list of
+/// bit IDs. This approach allows bits to be easily passed around by ID to enable the creation of
+/// bit collections that are small (a subset of a register's bits) or very large (all bits in
+/// a memory map).
 #[derive(Debug)]
 pub struct Dut {
     pub id: String,
-    pub model: Model,
+    pub models: Vec<Model>,
+    pub memory_maps: Vec<MemoryMap>,
+    pub address_blocks: Vec<AddressBlock>,
+    pub registers: Vec<Register>,
+    pub bits: Vec<Bit>,
 }
 
 impl Dut {
     pub fn new(id: &str) -> Dut {
+        // TODO: reserve some size for these?
         Dut {
             id: id.to_string(),
-            model: Model::new("".to_string(), "".to_string()),
+            //model: Model::new("".to_string(), "".to_string()),
+            models: Vec::<Model>::new(),
+            memory_maps: Vec::<MemoryMap>::new(),
+            address_blocks: Vec::<AddressBlock>::new(),
+            registers: Vec::<Register>::new(),
+            bits: Vec::<Bit>::new(),
         }
     }
 
@@ -21,74 +39,282 @@ impl Dut {
     /// with the given value
     pub fn change(&mut self, id: &str) {
         self.id = id.to_string();
-        self.model = Model::new("".to_string(), "".to_string());
+        //self.model = Model::new("".to_string(), "".to_string());
+        self.models.clear();
+        self.memory_maps.clear();
+        self.address_blocks.clear();
+        self.registers.clear();
+        self.bits.clear();
     }
 
-    /// Get a mutable reference to the model at the given path
-    /// Note that the path is relative to the DUT, i.e. it should not include 'dut.'
-    pub fn get_mut_model(&mut self, path: &str) -> Result<&mut Model> {
-        if path == "" {
-            return Ok(&mut self.model);
-        } else {
-            let mut m = &mut self.model;
-            for field in path.split(".") {
-                m = match m.sub_blocks.get_mut(field) {
-                    Some(x) => x,
-                    None => {
-                        return Err(Error::new(&format!(
-                            "The block '{}' does not contain a sub-block called '{}'",
-                            m.display_path, field
-                        )))
-                    }
-                }
+    /// Get a mutable reference to the model with the given ID
+    pub fn get_mut_model(&mut self, id: usize) -> Result<&mut Model> {
+        match self.models.get_mut(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no model exists with ID '{}'",
+                    id
+                )))
             }
-            return Ok(m);
         }
     }
 
-    /// Get a read-only reference to the model at the given path, use get_mut_model if
-    /// you need to modify the returned model
-    /// Note that the path is relative to the DUT, i.e. it should not include 'dut.'
-    pub fn get_model(&self, path: &str) -> Result<&Model> {
-        if path == "" {
-            return Ok(&self.model);
-        } else {
-            let mut m = &self.model;
-            for field in path.split(".") {
-                m = match m.sub_blocks.get(field) {
-                    Some(x) => x,
-                    None => {
-                        return Err(Error::new(&format!(
-                            "The block '{}' does not contain a sub-block called '{}'",
-                            m.display_path, field
-                        )))
-                    }
-                }
+    /// Get a read-only reference to the model with the given ID, use get_mut_model if
+    /// you need to modify it
+    pub fn get_model(&self, id: usize) -> Result<&Model> {
+        match self.models.get(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no model exists with ID '{}'",
+                    id
+                )))
             }
-            return Ok(m);
         }
     }
 
-    /// Add a new sub-block model to the existing model at the given hierarchical path
-    pub fn create_sub_block(&mut self, path: &str, id: &str) -> Result<()> {
-        //println!("create_sub_block called with {}, {}", path, id);
-        let model = self.get_mut_model(path)?;
-        let child = Model::new(id.to_string(), path.to_string());
+    /// Get a mutable reference to the memory map with the given ID
+    pub fn get_mut_memory_map(&mut self, id: usize) -> Result<&mut MemoryMap> {
+        match self.memory_maps.get_mut(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no memory_map exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
 
-        if model.sub_blocks.contains_key(id) {
-            let p;
-            if path == "" {
-                p = "dut";
+    /// Get a read-only reference to the memory map with the given ID, use get_mut_memory_map if
+    /// you need to modify it
+    pub fn get_memory_map(&self, id: usize) -> Result<&MemoryMap> {
+        match self.memory_maps.get(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no memory_map exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Get a mutable reference to the address block with the given ID
+    pub fn get_mut_address_block(&mut self, id: usize) -> Result<&mut AddressBlock> {
+        match self.address_blocks.get_mut(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no address_block exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Get a read-only reference to the address block with the given ID, use get_mut_address_block if
+    /// you need to modify it
+    pub fn get_address_block(&self, id: usize) -> Result<&AddressBlock> {
+        match self.address_blocks.get(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no address_block exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Get a mutable reference to the register with the given ID
+    pub fn get_mut_register(&mut self, id: usize) -> Result<&mut Register> {
+        match self.registers.get_mut(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no register exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Get a read-only reference to the register with the given ID, use get_mut_register if
+    /// you need to modify it
+    pub fn get_register(&self, id: usize) -> Result<&Register> {
+        match self.registers.get(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no register exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Get a mutable reference to the bit with the given ID
+    pub fn get_mut_bit(&mut self, id: usize) -> Result<&mut Bit> {
+        match self.bits.get_mut(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no bit exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Get a read-only reference to the bit with the given ID, use get_mut_bit if
+    /// you need to modify it
+    pub fn get_bit(&self, id: usize) -> Result<&Bit> {
+        match self.bits.get(id) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "Something has gone wrong, no bit exists with ID '{}'",
+                    id
+                )))
+            }
+        }
+    }
+
+    /// Create a new model adding it to the existing parent model with the given ID.
+    /// The ID of the newly created model is returned to the caller who should save it
+    /// if they want to access this model directly again (will also be accessible by name
+    /// via the parent model).
+    pub fn create_model(&mut self, parent_id: usize, name: &str) -> Result<usize> {
+        let id;
+        { id = self.models.len(); }
+        {
+            let m = self.get_mut_model(parent_id)?;
+            if m.sub_blocks.contains_key(name) {
+                return Err(Error::new(&format!(
+                    "The block '{}' already contains a sub-block called '{}'",
+                    m.display_path, name
+                )));
             } else {
-                p = "dut.";
+                m.sub_blocks.insert(name.to_string(), id);
             }
-            return Err(Error::new(&format!(
-                "The block '{}{}' already contains a sub-block called '{}'",
-                p, path, id
-            )));
-        } else {
-            model.sub_blocks.insert(id.to_string(), child);
-            return Ok(());
         }
+        let new_model = Model::new(name.to_string());
+        self.models.push(new_model);
+        Ok(id)
+    }
+
+    //pub fn create_memory_map(&mut self, model_id: usize, name: &str, address_unit_bits: Option<u32>) -> Result<usize> {
+    //    if self.models[model_id].memory_maps.contains_key(name) {
+    //        return Err(Error::new(&format!(
+    //            //"The block '{}' already contains a sub-block called '{}'",
+    //            "The block  already contains a sub-block called '{}'",
+    //            name
+    //        )));
+
+    //    } else {
+
+    //    let mut defaults = MemoryMap::default();
+    //    match address_unit_bits {
+    //        Some(v) => defaults.address_unit_bits = v,
+    //        None => {}
+    //    }
+    //    self.memory_maps.insert(
+    //        id.to_string(),
+    //        MemoryMap {
+    //            id: id.to_string(),
+    //            ..defaults
+    //        },
+    //    );
+    //}
+
+    pub fn create_address_block(
+        &mut self,
+        memory_map_id: usize,
+        name: &str,
+        base_address: Option<u64>,
+        range: Option<u64>,
+        width: Option<u64>,
+        access: Option<AccessType>,
+    ) -> Result<usize> {
+        let id;
+        { id = self.address_blocks.len(); }
+        {
+            let map = self.get_mut_memory_map(memory_map_id)?;
+
+            if map.address_blocks.contains_key(name) {
+                return Err(Error::new(&format!(
+                    "The memory map '{}' already contains an address block called '{}'",
+                    map.name, name
+                )));
+            } else {
+
+                map.address_blocks.insert(name.to_string(), id);
+            }
+        }
+
+        let mut defaults = AddressBlock::default();
+        match base_address {
+            Some(v) => defaults.base_address = v,
+            None => {}
+        }
+        match range {
+            Some(v) => defaults.range = v,
+            None => {}
+        }
+        match width {
+            Some(v) => defaults.width = v,
+            None => {}
+        }
+        match access {
+            Some(v) => defaults.access = v,
+            None => {}
+        }
+
+        self.address_blocks.push(
+            AddressBlock {
+                name: name.to_string(),
+                ..defaults
+            },
+        );
+        Ok(id)
+    }
+
+    pub fn create_reg(
+        &mut self,
+        address_block_id: usize,
+        name: &str,
+        offset: u32,
+        size: Option<u32>,
+    ) -> Result<usize> {
+        let id;
+        { id = self.registers.len(); }
+        {
+            let a = self.get_mut_address_block(address_block_id)?;
+            if a.registers.contains_key(name) {
+                return Err(Error::new(&format!(
+                    "The address block '{}' already contains a register called '{}'",
+                    a.name, name
+                )));
+            } else {
+                a.registers.insert(name.to_string(), id);
+            }
+        }
+        let mut defaults = Register::default();
+        match size {
+            Some(v) => defaults.size = v,
+            None => {}
+        }
+        let reg = Register {
+            name: name.to_string(),
+            offset: offset,
+            ..defaults
+        };
+
+        //reg.create_bits();
+
+        self.registers.push(reg);
+        Ok(id)
     }
 }

--- a/rust/origen/src/core/model/mod.rs
+++ b/rust/origen/src/core/model/mod.rs
@@ -1,8 +1,9 @@
 pub mod pins;
 pub mod registers;
 use crate::error::Error;
+use crate::Dut;
 use crate::Result;
-use crate::DUT;
+use std::sync::MutexGuard;
 
 use std::collections::HashMap;
 
@@ -34,8 +35,8 @@ impl Model {
     }
 
     /// Returns the hierarchical name of the model and the offset for console displays
-    pub fn console_header(&self) -> (String, usize) {
-        let l = format!("{}", self.display_path());
+    pub fn console_header(&self, dut: &MutexGuard<Dut>) -> (String, usize) {
+        let l = format!("{}", self.display_path(dut));
         let mut names: Vec<&str> = l.split(".").collect();
         names.pop();
         if names.is_empty() {
@@ -60,12 +61,11 @@ impl Model {
     }
 
     /// Returns the path to this model for displaying to a user, e.g. in error messages.
-    pub fn display_path(&self) -> String {
+    pub fn display_path(&self, dut: &MutexGuard<Dut>) -> String {
         match self.parent_id {
             Some(p) => {
-                let dut = DUT.lock().unwrap();
                 let parent = dut.get_model(p).unwrap();
-                return format!("{}.{}", parent.display_path(), self.name);
+                return format!("{}.{}", parent.display_path(dut), self.name);
             }
             None => return format!("{}", self.name),
         }

--- a/rust/origen/src/core/model/mod.rs
+++ b/rust/origen/src/core/model/mod.rs
@@ -1,7 +1,7 @@
 pub mod pins;
 pub mod registers;
-//use crate::error::Error;
-//use crate::Result;
+use crate::error::Error;
+use crate::Result;
 
 use std::collections::HashMap;
 
@@ -50,6 +50,19 @@ impl Model {
         } else {
             let s = names.join(".").chars().count() + 2;
             (l + "\n", s)
+        }
+    }
+
+    /// Get the ID for the given memory map name
+    pub fn get_memory_map_id(&self, name: &str) -> Result<&usize> {
+        match self.memory_maps.get(name) {
+            Some(x) => Ok(x),
+            None => {
+                return Err(Error::new(&format!(
+                    "The block '{}' does not have a memory map named '{}'",
+                    self.name, name
+                )))
+            }
         }
     }
 

--- a/rust/origen/src/core/model/mod.rs
+++ b/rust/origen/src/core/model/mod.rs
@@ -1,29 +1,20 @@
 pub mod pins;
 pub mod registers;
-use crate::error::Error;
-use crate::Result;
+//use crate::error::Error;
+//use crate::Result;
 
-use registers::{AccessType, AddressBlock, MemoryMap, Register};
 use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Model {
-    pub id: String,
-    /// Store a hierarchical reference to the parent model minus the leading 'dut',
-    /// e.g. if the given sub-block associated with this model was instantiated as
-    /// "dut.core0.ana.adc0" then the id would be "adc0" and the parent would be
-    /// "core0.ana".
-    /// This means that the model can be identified as the top-level if parent == "" and
-    /// also a model's parent can be found by fetching if from the DUT.
-    /// Other approaches by trying to store a direct reference to the parent object just
-    /// seem too scary in Rust, albeit a bit more efficient.
-    pub parent_path: String,
+    pub name: String,
+    //pub parent_id: usize,
     /// Returns the path to this model for displaying to a user, e.g. in error messages.
     pub display_path: String,
     /// All children of this block/model, which are themselves models
-    pub sub_blocks: HashMap<String, Model>,
+    pub sub_blocks: HashMap<String, usize>,
     /// All registers owned by this model are arranged within memory maps
-    pub memory_maps: HashMap<String, MemoryMap>,
+    pub memory_maps: HashMap<String, usize>,
     // Pins
     // Levels
     // Timing
@@ -31,18 +22,19 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(id: String, parent_path: String) -> Model {
-        let mut p = "dut".to_string();
-        if parent_path != "" {
-            p = format!("{}.{}", p, parent_path);
-        }
-        if id != "" {
-            p = format!("{}.{}", p, id);
-        }
+    //pub fn new(name: String, parent_id: usize) -> Model {
+    pub fn new(name: String) -> Model {
+        //let mut p = "dut".to_string();
+        //if parent_path != "" {
+        //    p = format!("{}.{}", p, parent_path);
+        //}
+        //if id != "" {
+        //    p = format!("{}.{}", p, id);
+        //}
         Model {
-            id: id,
-            parent_path: parent_path,
-            display_path: p,
+            name: name,
+            //parent_path: parent_path,
+            display_path: "TBD".to_string(),
             sub_blocks: HashMap::new(),
             memory_maps: HashMap::new(),
         }
@@ -61,166 +53,41 @@ impl Model {
         }
     }
 
-    pub fn add_memory_map(&mut self, id: &str, address_unit_bits: Option<u32>) {
-        let mut defaults = MemoryMap::default();
-        match address_unit_bits {
-            Some(v) => defaults.address_unit_bits = v,
-            None => {}
-        }
-        self.memory_maps.insert(
-            id.to_string(),
-            MemoryMap {
-                id: id.to_string(),
-                ..defaults
-            },
-        );
-    }
-
-    pub fn add_address_block(
-        &mut self,
-        memory_map_id: &str,
-        id: &str,
-        base_address: Option<u64>,
-        range: Option<u64>,
-        width: Option<u64>,
-        access: Option<AccessType>,
-    ) {
-        let mut defaults = AddressBlock::default();
-        match base_address {
-            Some(v) => defaults.base_address = v,
-            None => {}
-        }
-        match range {
-            Some(v) => defaults.range = v,
-            None => {}
-        }
-        match width {
-            Some(v) => defaults.width = v,
-            None => {}
-        }
-        match access {
-            Some(v) => defaults.access = v,
-            None => {}
-        }
-        if let Some(map) = self.memory_maps.get_mut(memory_map_id) {
-            map.address_blocks.insert(
-                id.to_string(),
-                AddressBlock {
-                    id: id.to_string(),
-                    ..defaults
-                },
-            );
-        } else {
-            panic!("Tried to add address block '{}' to memory map '{}' but the memory map does not exist!", id, memory_map_id);
-        }
-    }
-
-    /// Get a read-only reference to the model at the given path, use get_mut_model if
-    /// you need to modify the returned model
-    /// Note that the path is relative to the DUT, i.e. it should not include 'dut.'
-    pub fn get_reg(
-        &self,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
-        id: &str,
-    ) -> Result<&Register> {
-        let map_id = memory_map.unwrap_or("default");
-        let ab_id = address_block.unwrap_or("default");
-        // TODO: bubble the errors here
-        let map = match self.memory_maps.get(map_id) {
-            Some(x) => x,
-            None => {
-                return Err(Error::new(&format!(
-                    "The block '{}' does not contain a memory-map called '{}'",
-                    self.display_path, map_id
-                )))
-            }
-        };
-        let ab = match map.address_blocks.get(ab_id) {
-            Some(x) => x,
-            None => {
-                return Err(Error::new(&format!(
-                "The block '{}' does not contain an address-block called '{}' in memory-map '{}'",
-                self.display_path, ab_id, map_id
-            )))
-            }
-        };
-        match ab.registers.get(id) {
-            Some(x) => return Ok(x),
-            None => {
-                return Err(Error::new(&format!(
-                "The block '{}' does not contain a register called '{}' in address-block '{}.{}'",
-                self.display_path, id, map_id, ab_id
-            )))
-            }
-        };
-    }
-
-    pub fn create_reg(
-        &mut self,
-        memory_map: Option<&str>,
-        address_block: Option<&str>,
-        id: &str,
-        offset: u32,
-        size: Option<u32>,
-    ) -> Result<()> {
-        let map_id = memory_map.unwrap_or("default");
-        let ab_id = address_block.unwrap_or("default");
-
-        // Create the memory map if it doesn't exist
-        if !self.memory_maps.contains_key(map_id) {
-            self.add_memory_map(map_id, None);
-        }
-        // Create the address block if it doesn't exist
-        let exists;
-        {
-            exists = self
-                .memory_maps
-                .get(map_id)
-                .unwrap()
-                .address_blocks
-                .contains_key(ab_id);
-        }
-        if !exists {
-            self.add_address_block(map_id, ab_id, None, None, None, None);
-        }
-
-        // Now build the register
-        let mut defaults = Register::default();
-        match size {
-            Some(v) => defaults.size = v,
-            None => {}
-        }
-
-        let map = self.memory_maps.get_mut(map_id).unwrap();
-        let ab = map.address_blocks.get_mut(ab_id).unwrap();
-
-        if ab.registers.contains_key(id) {
-            return Err(Error::new(&format!(
-                "The block '{}' already contains a register called '{}' in address block {}.{}",
-                self.display_path, id, map_id, ab_id
-            )));
-        } else {
-            let mut reg = Register {
-                id: id.to_string(),
-                offset: offset,
-                ..defaults
-            };
-
-            reg.create_bits();
-
-            ab.registers.insert(id.to_string(), reg);
-        }
-        Ok(())
-    }
-
-    pub fn number_of_regs(&self) -> usize {
-        let mut count = 0;
-        for (_k, v) in self.memory_maps.iter() {
-            for (_k, v) in v.address_blocks.iter() {
-                count += v.registers.len();
-            }
-        }
-        count
-    }
+    //pub fn get_reg(
+    //    &self,
+    //    memory_map: Option<&str>,
+    //    address_block: Option<&str>,
+    //    id: &str,
+    //) -> Result<&Register> {
+    //    let map_id = memory_map.unwrap_or("default");
+    //    let ab_id = address_block.unwrap_or("default");
+    //    // TODO: bubble the errors here
+    //    let map = match self.memory_maps.get(map_id) {
+    //        Some(x) => x,
+    //        None => {
+    //            return Err(Error::new(&format!(
+    //                "The block '{}' does not contain a memory-map called '{}'",
+    //                self.display_path, map_id
+    //            )))
+    //        }
+    //    };
+    //    let ab = match map.address_blocks.get(ab_id) {
+    //        Some(x) => x,
+    //        None => {
+    //            return Err(Error::new(&format!(
+    //            "The block '{}' does not contain an address-block called '{}' in memory-map '{}'",
+    //            self.display_path, ab_id, map_id
+    //        )))
+    //        }
+    //    };
+    //    match ab.registers.get(id) {
+    //        Some(x) => return Ok(x),
+    //        None => {
+    //            return Err(Error::new(&format!(
+    //            "The block '{}' does not contain a register called '{}' in address-block '{}.{}'",
+    //            self.display_path, id, map_id, ab_id
+    //        )))
+    //        }
+    //    };
+    //}
 }

--- a/rust/origen/src/core/model/mod.rs
+++ b/rust/origen/src/core/model/mod.rs
@@ -2,15 +2,15 @@ pub mod pins;
 pub mod registers;
 use crate::error::Error;
 use crate::Result;
+use crate::DUT;
 
 use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Model {
     pub name: String,
-    //pub parent_id: usize,
-    /// Returns the path to this model for displaying to a user, e.g. in error messages.
-    pub display_path: String,
+    /// The only one without a parent is the top-level DUT model
+    pub parent_id: Option<usize>,
     /// All children of this block/model, which are themselves models
     pub sub_blocks: HashMap<String, usize>,
     /// All registers owned by this model are arranged within memory maps
@@ -22,19 +22,10 @@ pub struct Model {
 }
 
 impl Model {
-    //pub fn new(name: String, parent_id: usize) -> Model {
-    pub fn new(name: String) -> Model {
-        //let mut p = "dut".to_string();
-        //if parent_path != "" {
-        //    p = format!("{}.{}", p, parent_path);
-        //}
-        //if id != "" {
-        //    p = format!("{}.{}", p, id);
-        //}
+    pub fn new(name: String, parent_id: Option<usize>) -> Model {
         Model {
             name: name,
-            //parent_path: parent_path,
-            display_path: "TBD".to_string(),
+            parent_id: parent_id,
             sub_blocks: HashMap::new(),
             memory_maps: HashMap::new(),
         }
@@ -42,7 +33,7 @@ impl Model {
 
     /// Returns the hierarchical name of the model and the offset for console displays
     pub fn console_header(&self) -> (String, usize) {
-        let l = format!("{}", self.display_path);
+        let l = format!("{}", self.display_path());
         let mut names: Vec<&str> = l.split(".").collect();
         names.pop();
         if names.is_empty() {
@@ -66,41 +57,15 @@ impl Model {
         }
     }
 
-    //pub fn get_reg(
-    //    &self,
-    //    memory_map: Option<&str>,
-    //    address_block: Option<&str>,
-    //    id: &str,
-    //) -> Result<&Register> {
-    //    let map_id = memory_map.unwrap_or("default");
-    //    let ab_id = address_block.unwrap_or("default");
-    //    // TODO: bubble the errors here
-    //    let map = match self.memory_maps.get(map_id) {
-    //        Some(x) => x,
-    //        None => {
-    //            return Err(Error::new(&format!(
-    //                "The block '{}' does not contain a memory-map called '{}'",
-    //                self.display_path, map_id
-    //            )))
-    //        }
-    //    };
-    //    let ab = match map.address_blocks.get(ab_id) {
-    //        Some(x) => x,
-    //        None => {
-    //            return Err(Error::new(&format!(
-    //            "The block '{}' does not contain an address-block called '{}' in memory-map '{}'",
-    //            self.display_path, ab_id, map_id
-    //        )))
-    //        }
-    //    };
-    //    match ab.registers.get(id) {
-    //        Some(x) => return Ok(x),
-    //        None => {
-    //            return Err(Error::new(&format!(
-    //            "The block '{}' does not contain a register called '{}' in address-block '{}.{}'",
-    //            self.display_path, id, map_id, ab_id
-    //        )))
-    //        }
-    //    };
-    //}
+    /// Returns the path to this model for displaying to a user, e.g. in error messages.
+    pub fn display_path(&self) -> String {
+        match self.parent_id {
+            Some(p) => {
+                let dut = DUT.lock().unwrap();
+                let parent = dut.get_model(p).unwrap();
+                return format!("{}.{}", parent.display_path(), self.name);
+            }
+            None => return format!("{}", self.name),
+        }
+    }
 }

--- a/rust/origen/src/core/model/mod.rs
+++ b/rust/origen/src/core/model/mod.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct Model {
+    pub id: usize,
     pub name: String,
     /// The only one without a parent is the top-level DUT model
     pub parent_id: Option<usize>,
@@ -22,8 +23,9 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn new(name: String, parent_id: Option<usize>) -> Model {
+    pub fn new(id: usize, name: String, parent_id: Option<usize>) -> Model {
         Model {
+            id: id,
             name: name,
             parent_id: parent_id,
             sub_blocks: HashMap::new(),
@@ -44,10 +46,10 @@ impl Model {
         }
     }
 
-    /// Get the ID for the given memory map name
-    pub fn get_memory_map_id(&self, name: &str) -> Result<&usize> {
+    /// Get the ID for the given memory map name, throw an error if it doesn't exist
+    pub fn get_memory_map_id(&self, name: &str) -> Result<usize> {
         match self.memory_maps.get(name) {
-            Some(x) => Ok(x),
+            Some(x) => Ok(*x),
             None => {
                 return Err(Error::new(&format!(
                     "The block '{}' does not have a memory map named '{}'",

--- a/rust/origen/src/core/model/registers.rs
+++ b/rust/origen/src/core/model/registers.rs
@@ -22,18 +22,18 @@ pub enum Usage {
 
 #[derive(Debug)]
 pub struct MemoryMap {
-    pub id: String,
+    pub name: String,
     /// Represents the number of bits of an address increment between two
     /// consecutive addressable units in the memory map.
     /// Its value defaults to 8 indicating a byte addressable memory map.
     pub address_unit_bits: u32,
-    pub address_blocks: HashMap<String, AddressBlock>,
+    pub address_blocks: HashMap<String, usize>,
 }
 
 impl Default for MemoryMap {
     fn default() -> MemoryMap {
         MemoryMap {
-            id: "Default".to_string(),
+            name: "Default".to_string(),
             address_unit_bits: 8,
             address_blocks: HashMap::new(),
         }
@@ -43,7 +43,7 @@ impl Default for MemoryMap {
 #[derive(Debug)]
 /// Represents a single, contiguous block of memory in a memory map.
 pub struct AddressBlock {
-    pub id: String,
+    pub name: String,
     /// The starting address of the address block expressed in address_unit_bits
     /// from the parent memory map.
     pub base_address: u64,
@@ -53,13 +53,13 @@ pub struct AddressBlock {
     /// address block.
     pub width: u64,
     pub access: AccessType,
-    pub registers: HashMap<String, Register>,
+    pub registers: HashMap<String, usize>,
 }
 
 impl Default for AddressBlock {
     fn default() -> AddressBlock {
         AddressBlock {
-            id: "Default".to_string(),
+            name: "Default".to_string(),
             base_address: 0,
             range: 0,
             width: 0,
@@ -71,7 +71,7 @@ impl Default for AddressBlock {
 
 #[derive(Debug)]
 pub struct Register {
-    pub id: String,
+    pub name: String,
     pub description: String,
     // TODO: What is this?!
     /// The dimension of the register, defaults to 1.
@@ -90,7 +90,7 @@ pub struct Register {
 impl Default for Register {
     fn default() -> Register {
         Register {
-            id: "Default".to_string(),
+            name: "Default".to_string(),
             description: "".to_string(),
             dim: 1,
             offset: 0,
@@ -113,7 +113,7 @@ impl Register {
 #[derive(Debug)]
 /// Named collections of bits within a register
 pub struct Field {
-    pub id: String,
+    pub name: String,
     pub description: String,
     /// Offset from the start of the register in bits.
     pub offset: u32,
@@ -139,7 +139,7 @@ pub struct Reset {
 
 #[derive(Debug)]
 pub struct EnumeratedValue {
-    pub id: String,
+    pub name: String,
     pub description: String,
     pub usage: Usage,
     /// The size of this vector corresponds to the size of the parent field.

--- a/rust/origen/src/core/model/registers.rs
+++ b/rust/origen/src/core/model/registers.rs
@@ -2,6 +2,8 @@
 //! structures upon which this is based:
 //! https://www.accellera.org/images/downloads/standards/ip-xact/IP-XACT_User_Guide_2018-02-16.pdf
 
+use crate::error::Error;
+use crate::Result as OrigenResult;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -11,6 +13,24 @@ pub enum AccessType {
     WriteOnly,
     ReadWriteOnce,
     WriteOnce,
+}
+
+impl std::str::FromStr for AccessType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ReadWrite" => Ok(AccessType::ReadWrite),
+            "ReadOnly" => Ok(AccessType::ReadOnly),
+            "WriteOnly" => Ok(AccessType::WriteOnly),
+            "ReadWriteOnce" => Ok(AccessType::ReadWriteOnce),
+            "WriteOnce" => Ok(AccessType::WriteOnce),
+            _ => Err(format!(
+                "'{}' is not a valid value for AccessType",
+                s
+            )),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -40,6 +60,21 @@ impl Default for MemoryMap {
     }
 }
 
+impl MemoryMap {
+    /// Get the ID from the given address block name
+    pub fn get_address_block_id(&self, name: &str) -> OrigenResult<usize> {
+        match self.address_blocks.get(name) {
+            Some(x) => Ok(*x),
+            None => {
+                return Err(Error::new(&format!(
+                    "The memory map '{}' does not have an address block named '{}'",
+                    self.name, name
+                )))
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 /// Represents a single, contiguous block of memory in a memory map.
 pub struct AddressBlock {
@@ -65,6 +100,21 @@ impl Default for AddressBlock {
             width: 0,
             access: AccessType::ReadWrite,
             registers: HashMap::new(),
+        }
+    }
+}
+
+impl AddressBlock {
+    /// Get the ID from the given register name
+    pub fn get_register_id(&self, name: &str) -> OrigenResult<usize> {
+        match self.registers.get(name) {
+            Some(x) => Ok(*x),
+            None => {
+                return Err(Error::new(&format!(
+                    "The address block '{}' does not have a register named '{}'",
+                    self.name, name
+                )))
+            }
         }
     }
 }

--- a/rust/origen/src/core/model/registers.rs
+++ b/rust/origen/src/core/model/registers.rs
@@ -25,10 +25,7 @@ impl std::str::FromStr for AccessType {
             "WriteOnly" => Ok(AccessType::WriteOnly),
             "ReadWriteOnce" => Ok(AccessType::ReadWriteOnce),
             "WriteOnce" => Ok(AccessType::WriteOnce),
-            _ => Err(format!(
-                "'{}' is not a valid value for AccessType",
-                s
-            )),
+            _ => Err(format!("'{}' is not a valid value for AccessType", s)),
         }
     }
 }

--- a/rust/origen/src/core/status.rs
+++ b/rust/origen/src/core/status.rs
@@ -64,8 +64,9 @@ fn search_for_app_root() -> (bool, PathBuf) {
 fn get_home_dir() -> PathBuf {
     if cfg!(windows) {
         PathBuf::from(env::var("USERPROFILE").expect("Please set environment variable USERPROFILE to point to your home directory, then try again"))
-    }
-    else {
-        PathBuf::from(env::var("HOME").expect("Please set environment variable HOME to point to your home directory, then try again"))
+    } else {
+        PathBuf::from(env::var("HOME").expect(
+            "Please set environment variable HOME to point to your home directory, then try again",
+        ))
     }
 }

--- a/rust/origen/src/core/utility/logger.rs
+++ b/rust/origen/src/core/utility/logger.rs
@@ -145,7 +145,8 @@ impl Logger {
             pb = (STATUS.home).to_path_buf().join(".origen").join("log");
         }
         // create all missing directories to avoid panics
-        fs::create_dir_all(pb.as_path()).expect(&(format!("Could not create the log directory {}",pb.display())));
+        fs::create_dir_all(pb.as_path())
+            .expect(&(format!("Could not create the log directory {}", pb.display())));
         pb
     }
 

--- a/rust/origen/src/lib.rs
+++ b/rust/origen/src/lib.rs
@@ -12,7 +12,7 @@ use self::core::dut::Dut;
 use self::core::status::Status;
 use self::core::utility::logger::Logger;
 use crate::error::Error;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -39,6 +39,10 @@ lazy_static! {
 pub mod built_info {
     // The file has been placed there by the build script.
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
+pub fn dut() -> MutexGuard<'static, Dut> {
+    DUT.lock().unwrap()
 }
 
 /// Sanitizes the given mode string and returns it, but will exit the process if it is invalid


### PR DESCRIPTION
This update overhauls how the DUT data and state are stored within Rust.
Originally it was stored in a hierarchical tree structure that closely followed the logical structure of the device  (an OO approach, similar to the model architecture from O1) and this changes it to be more like a traditional database where each object type is stored in a dedicated collection, analogous to a database table. 

The driver for this change was that it was becoming increasingly convoluted to get an object that was deeply nested within the DUT. For example, something like this was required to get a register object:

~~~rust
// The caller would have to supply the names of all objects in the hierarchy, something like:
// get_reg("dut.core0.adc0", "my_memory_map", "my_address_block", "my_reg");
let dut = DUT.lock().unwrap();
let model = dut.get_model(&self.model_path)?;
let map = model.memory_maps.get(&self.memory_map).unwrap();
let ab = map.address_blocks.get(&self.address_block).unwrap();
let reg = ab.registers.get(&self.reg).unwrap();
~~~

Whereas, now a reg can be extracted directly if you have it's ID:

~~~rust
// Simply called via something like:
// get_reg(5);
let dut = DUT.lock().unwrap();
let reg = dut.get_reg(self.reg_id)?;
~~~

Another problem was that it became clear that it was going to be really difficult to create collections of objects with different parentage, for example to create a bit collection containing bits from multiple registers. With this update such things become trivial - a bit collection is simply a vector of bit IDs and that can be easily resolved to bit objects by fetching them from the database table.

The crux of this change is contained in https://github.com/Origen-SDK/o2/blob/ids/rust/origen/src/core/dut.rs

The DUT now contains collections (vectors) for each primary object type.
Note that nesting can still be employed within each object type, however this should be reserved for cases where there is tight coupling and it doesn't make much sense to ever hold the child object without the parent. e.g. for regs I plan to have the data about the named fields stored as a child of the reg instead of in a dedicated collection.

Each collection is simply a regular Rust vector and the ID of an object is its position within the vector.

The vectors are intentionally not made public to ensure that we have an abstraction in case we need to tweak the internal structure in future and to guard against un-intentional corruption of the database (e.g. by deleting an object which would screw up all IDs). Instead, access to the database is via a common set of methods implemented at the DUT top-level - each type has a `create_<type>`, `get_<type>` and `get_mut_<type>` methods.

I took a look at [this id_arena create](https://docs.rs/id-arena/2.2.1/id_arena/) as an alternative approach but I couldn't really see the point in it. It has the same constraints as the vector approach - you can't delete records and each collection can contain only one type.
The major problem with it though is that there is no way to clear/empty it, which would be a problem for us since we use a global/static DUT and need to clear out the database when the target is changed. With the vector approach that is trivial by keeping the same vectors but simply calling `clear()` on them to get rid of the previous DUT's data.
@pderouen, note that in the `id_arena` documentation it shows an example of building up an AST structure, however you could equally use a std vector as I have done here.

@coreyeng, I'm afraid that one consequence of this change (having already asked you to change `name` references to `id`), is that I have had to go back to using `name` for the main string identifier for objects. `id` is used to refer to the numeric ID. Sorry.

Objects may or may not contain their own ID, but that can be easily added if there is a need for it. Objects can easily store references to other objects through their ID - e.g. a register contains a vector of bit IDs.
I think that in general this approach is going to nicely sidestep all of the borrow checker pain that would come from storing direct references to objects in Rust.

## Avoiding Deadlocks on DUT

In the course of making this update I came across an issue whereby Rust can deadlock if a higher level method locks the DUT and then a called lower-level method tries to do the same.

The solution for this is that we will need to be strict about only allowing top-level functions (i.e. those invoked from Python) to lock the DUT and these will then pass the dut reference down to lower level functions that need it.

Here is an example of how to implement a function that takes a dut reference - https://github.com/Origen-SDK/o2/blob/ids/rust/origen/src/core/model/mod.rs#L64





