### PR TITLE
Pins wip

### DIFF
--- a/example/tests/pin_api_test.py
+++ b/example/tests/pin_api_test.py
@@ -818,6 +818,13 @@ def test_collecting_with_mixed_inputs():
   c = origen.dut.pins.collect("/port.1/", "p1", r)
   assert c.pin_names == ["porta1", "portb1", "p1", "porta0", "portb0"]
 
+# def test_pins_have_empty_metadata():
+#   assert origen.dut.pin("porta1").metadata == {}
+#   assert origen.dut.physical_pin("porta1").metadata == {}
+#   assert origen.dut.pin("porta1").physical_pin_metadata == [{}]
+  
+
+
 # def test_in_progress_pin_api():
 #   import re
 #   r = re.compile("port.0")

--- a/example/tests/pin_api_test.py
+++ b/example/tests/pin_api_test.py
@@ -11,10 +11,10 @@ def is_pin_collection(obj):
 def is_pin(obj):
   assert isinstance(obj, _origen.dut.pins.Pin)
 
-def check_alias(pin_id, alias_id):
-  assert alias_id in origen.dut.pins
-  assert origen.dut.pins[alias_id].pin_ids == [pin_id]
-  assert alias_id in origen.dut.physical_pin(pin_id).aliases
+def check_alias(pin_name, alias_name):
+  assert alias_name in origen.dut.pins
+  assert origen.dut.pins[alias_name].pin_names == [pin_name]
+  assert alias_name in origen.dut.physical_pin(pin_name).aliases
 
 def pins():
   origen.dut.pins
@@ -44,28 +44,28 @@ def test_add_and_retrieving_pins():
 def test_retrieving_pins_using_pin_method():
   p1 = origen.dut.pin("p1")
   is_pin_group(p1)
-  assert p1.id == "p1"
+  assert p1.name == "p1"
 
-def test_exception_on_duplicate_id():
+def test_exception_on_duplicate_name():
   with pytest.raises(OSError):
     origen.dut.add_pin("p1")
 
 def test_pin_group_default_state():
   p1 = origen.dut.pin("p1")
-  assert p1.id == "p1"
+  assert p1.name == "p1"
   assert len(p1) == 1
   assert p1._path == ""
   assert p1.data == 0
   assert p1.pin_actions == "Z"
-  assert p1.pin_ids == ["p1"]
-  assert p1.physical_ids == ["p1"]
+  assert p1.pin_names == ["p1"]
+  assert p1.physical_names == ["p1"]
   assert p1.little_endian
   assert not p1.big_endian
 
 def test_retrieving_pins_using_indexing():
   p1 = origen.dut.pins["p1"]
   is_pin_group(p1)
-  assert p1.id == "p1"
+  assert p1.name == "p1"
 
 def test_retrieving_missing_pins():
   assert origen.dut.pin("blah") is None
@@ -84,18 +84,18 @@ def test_adding_more_pins():
   _p3 = origen.dut.pin("p3")
   is_pin_group(_p2)
   is_pin_group(_p3)
-  assert _p2.id == "p2"
-  assert _p3.id == "p3"
+  assert _p2.name == "p2"
+  assert _p3.name == "p3"
 
 def test_grouping_pins():
   grp = origen.dut.group_pins("grp", "p1", "p2", "p3")
   is_pin_group(grp)
-  assert grp.id == "grp"
+  assert grp.name == "grp"
   assert grp._path == ""
   assert len(origen.dut.pins) == 4
   assert len(grp) == 3
   assert len(origen.dut.physical_pins) == 3
-  assert grp.pin_ids == ["p1", "p2", "p3"]
+  assert grp.pin_names == ["p1", "p2", "p3"]
   assert grp.data == 0
   assert grp.pin_actions == "ZZZ"
 
@@ -110,10 +110,10 @@ def test_retrieving_groups():
   is_pin_group(grp)
   _grp = origen.dut.pins["grp"]
   is_pin_group(_grp)
-  assert grp.id == "grp"
-  assert _grp.id == "grp"
+  assert grp.name == "grp"
+  assert _grp.name == "grp"
 
-def test_checking_ids_within_group():
+def test_checking_names_within_group():
   grp = origen.dut.pins["grp"]
   is_pin_group(grp)
   assert "p1" in grp
@@ -238,7 +238,7 @@ def test_adding_aliases():
   a1 = origen.dut.pin("a1")
   is_pin_group(a1)
   assert len(a1) == 1
-  assert a1.pin_ids == ["p1"]
+  assert a1.pin_names == ["p1"]
 
 def test_driving_an_alias():
   a1 = origen.dut.pin("a1")
@@ -272,7 +272,7 @@ def test_exception_when_aliasing_missing_pin():
 def test_aliasing_an_alias():
   origen.dut.add_pin_alias("a1", "_a1")
   assert "_a1" in origen.dut.pins
-  assert origen.dut.pins["_a1"].pin_ids == ["p1"]
+  assert origen.dut.pins["_a1"].pin_names == ["p1"]
 
 def test_exception_on_grouping_the_same_pin():
   with pytest.raises(OSError):
@@ -348,7 +348,7 @@ def test_pins_dict_like_api():
   assert "p1" in origen.dut.pins
 
   # Check '__getitem__' (indexing)
-  assert origen.dut.pins["p1"].id == "p1"
+  assert origen.dut.pins["p1"].name == "p1"
 
   # Check 'keys()'
   keys = origen.dut.pins.keys()
@@ -359,8 +359,8 @@ def test_pins_dict_like_api():
   values = origen.dut.pins.values()
   assert len(values) == 9
   assert isinstance(values[0], _origen.dut.pins.PinGroup)
-  for id in origen.dut.pins:
-    assert id in keys
+  for name in origen.dut.pins:
+    assert name in keys
 
   # Check 'items()'
   for n, p in origen.dut.pins.items():
@@ -388,14 +388,14 @@ def test_physical_pins_dict_like_api():
   pin = origen.dut.physical_pins["p1"]
   is_pin(pin)
 
-  pin_ids = ["p1", "p2", "p3"]
+  pin_names = ["p1", "p2", "p3"]
   # Check keys()
-  assert set(origen.dut.physical_pins.keys()) == set(pin_ids)
+  assert set(origen.dut.physical_pins.keys()) == set(pin_names)
 
   # Check values()
   for v in origen.dut.physical_pins.values():
     is_pin(v)
-    assert v.id in pin_ids
+    assert v.name in pin_names
 
   # Check items()
   for n, p in origen.dut.physical_pins.items():
@@ -403,8 +403,8 @@ def test_physical_pins_dict_like_api():
     is_pin(p)
 
   # Check iterating
-  for id in origen.dut.physical_pins:
-    assert id in pin_ids
+  for name in origen.dut.physical_pins:
+    assert name in pin_names
 
   # Check 'to_dict' conversion
   d = dict(origen.dut.physical_pins)
@@ -421,34 +421,34 @@ def test_pin_group_list_like_api():
 
   # Check '__getitem__' (indexing)
   is_pin_collection(grp[0])
-  assert grp[0].ids == ["p1"]
+  assert grp[0].pin_names == ["p1"]
 
   # Check __len__
   assert len(grp) == 3
 
   # Check iterating
   # Note: Unlike the dictionary, this is ordered.
-  ids = [["p1"], ["p2"], ["p3"]]
-  for i, id in enumerate(grp):
-    is_pin_collection(id)
-    assert id.ids == ids[i]
+  names = [["p1"], ["p2"], ["p3"]]
+  for i, name in enumerate(grp):
+    is_pin_collection(name)
+    assert name.pin_names == names[i]
 
   # Check 'to_list'
   as_list = list(grp)
   assert isinstance(as_list, list)
   for i, item in enumerate(as_list):
     is_pin_collection(item)
-    assert item.ids == ids[i]
+    assert item.pin_names == names[i]
 
 def test_pin_collection_from_pin_group():
   origen.dut.add_pin("p0")
   origen.dut.group_pins("p", "p0", "p1", "p2", "p3")
   grp = origen.dut.pins["p"]
 
-  assert grp[0].ids == ["p0"]
-  assert grp[1].ids == ["p1"]
-  assert grp[0:1].ids == ["p0", "p1"]
-  assert grp[1:3:2].ids == ["p1", "p3"]
+  assert grp[0].pin_names == ["p0"]
+  assert grp[1].pin_names == ["p1"]
+  assert grp[0:1].pin_names == ["p0", "p1"]
+  assert grp[1:3:2].pin_names == ["p1", "p3"]
 
 def test_pin_collection_list_like_api():
   c = origen.dut.pins.collect("p0", "p1", "p2", "p3")
@@ -459,21 +459,21 @@ def test_pin_collection_list_like_api():
   assert "p3" in c
 
   # Check __getitem__ (indexing)
-  assert c[0].ids == ["p0"]
-  assert c[1].ids == ["p1"]
+  assert c[0].pin_names == ["p0"]
+  assert c[1].pin_names == ["p1"]
 
   # Check Slicing
-  assert c[0:1].ids == ["p0", "p1"]
-  assert c[1:3:2].ids == ["p1", "p3"]
+  assert c[0:1].pin_names == ["p0", "p1"]
+  assert c[1:3:2].pin_names == ["p1", "p3"]
 
   # Check __len__
   assert len(c) == 4
 
   # Check iterating
-  ids = ["p0", "p1", "p2", "p3"]
+  names = ["p0", "p1", "p2", "p3"]
   for i, _c in enumerate(c):
     is_pin_collection(_c)
-    _c.ids == list(ids[i])
+    _c.pin_names == list(names[i])
 
 def test_exception_on_out_of_bounds_indexing():
   # Covers both pin collection and pin groups
@@ -539,22 +539,22 @@ def test_adding_multiple_pins():
   # !!!
   porta = origen.dut.add_pin("porta", width=2)
   is_pin_group(porta)
-  assert porta.id == "porta"
+  assert porta.name == "porta"
   assert len(porta) == 2
   assert len(origen.dut.physical_pins) == 2
   assert len(origen.dut.pins) == 3
-  assert set(origen.dut.physical_pins.ids) == {"porta0", "porta1"}
-  assert set(origen.dut.pins.ids) == {"porta0", "porta1", "porta"}
+  assert set(origen.dut.physical_pins.pin_names) == {"porta0", "porta1"}
+  assert set(origen.dut.pins.pin_names) == {"porta0", "porta1", "porta"}
 
   # This should add four physical pins and one pin group, but the indexing should start a 1 instead of 0.
   portb = origen.dut.add_pin("portb", width=4, offset=1)
   is_pin_group(portb)
-  assert portb.id == "portb"
+  assert portb.name == "portb"
   assert len(portb) == 4
   assert len(origen.dut.physical_pins) == 6
   assert len(origen.dut.pins) == 8
-  assert set(origen.dut.physical_pins.ids) == {"porta0", "porta1", "portb1", "portb2", "portb3", "portb4"}
-  assert set(origen.dut.pins.ids) == {"porta0", "porta1", "porta", "portb1", "portb2", "portb3", "portb4", "portb"}
+  assert set(origen.dut.physical_pins.pin_names) == {"porta0", "porta1", "portb1", "portb2", "portb3", "portb4"}
+  assert set(origen.dut.pins.pin_names) == {"porta0", "porta1", "porta", "portb1", "portb2", "portb3", "portb4", "portb"}
 
 def test_adding_single_pins_with_width_and_offset():
   # Corner case for adding single pins. Normally, you'd not use these options for a single one, but there's no reason why
@@ -684,43 +684,43 @@ def test_exception_on_collecting_duplicates_when_nested_2():
 
 def test_big_endian():
   pins = origen.dut.add_pin("portc", width=4, little_endian=False)
-  assert pins.pin_ids == ["portc3", "portc2", "portc1", "portc0"]
+  assert pins.pin_names == ["portc3", "portc2", "portc1", "portc0"]
   assert not pins.little_endian
   assert pins.big_endian
 
 def test_little_endian():
   pins = origen.dut.add_pin("portd", width=4, little_endian=True)
-  assert pins.pin_ids == ["portd0", "portd1", "portd2", "portd3"]
+  assert pins.pin_names == ["portd0", "portd1", "portd2", "portd3"]
   assert pins.little_endian
   assert not pins.big_endian
 
 def test_big_endian_with_offset():
   pins = origen.dut.add_pin("porte", width=2, little_endian=False, offset=2)
-  assert pins.pin_ids == ["porte3", "porte2"]
+  assert pins.pin_names == ["porte3", "porte2"]
   assert not pins.little_endian
   assert pins.big_endian
 
 def test_grouping_mixed_endianness():
   grp = origen.dut.group_pins("mixed_endianness", "portc", "portd")
-  assert grp.pin_ids == ["portc3", "portc2", "portc1", "portc0", "portd0", "portd1", "portd2", "portd3"]
+  assert grp.pin_names == ["portc3", "portc2", "portc1", "portc0", "portd0", "portd1", "portd2", "portd3"]
   assert grp.little_endian == True
   assert grp.big_endian == False
 
 def test_grouping_big_endian():
   grp = origen.dut.group_pins("big_endian", "portc", "portd", little_endian=False)
-  assert grp.pin_ids == ["portd3", "portd2", "portd1", "portd0", "portc0", "portc1", "portc2", "portc3"]
+  assert grp.pin_names == ["portd3", "portd2", "portd1", "portd0", "portc0", "portc1", "portc2", "portc3"]
   assert grp.little_endian == False
   assert grp.big_endian == True
 
 def test_collecting_mixed_endianness():
   c = origen.dut.pins.collect("portc", "portd")
-  assert c.ids == ["portc3", "portc2", "portc1", "portc0", "portd0", "portd1", "portd2", "portd3"]
+  assert c.pin_names == ["portc3", "portc2", "portc1", "portc0", "portd0", "portd1", "portd2", "portd3"]
   assert c.little_endian == True
   assert c.big_endian == False
 
 def test_collecting_big_endian():
   c = origen.dut.pins.collect("portc", "portd", little_endian=False)
-  assert c.ids == ["portd3", "portd2", "portd1", "portd0", "portc0", "portc1", "portc2", "portc3"]
+  assert c.pin_names == ["portd3", "portd2", "portd1", "portd0", "portc0", "portc1", "portc2", "portc3"]
   assert c.little_endian == False
   assert c.big_endian == True
 
@@ -806,17 +806,17 @@ def test_collecting_with_single_regex():
   import re
   r = re.compile("port.0")
   c = origen.dut.pins.collect(r)
-  assert c.ids == ["porta0", "portb0"]
+  assert c.pin_names == ["porta0", "portb0"]
 
 def test_collecting_using_ruby_like_syntax():
   c = origen.dut.pins.collect("/port.0/")
-  assert c.ids == ["porta0", "portb0"]
+  assert c.pin_names == ["porta0", "portb0"]
 
 def test_collecting_with_mixed_inputs():
   import re
   r = re.compile("port.0")
   c = origen.dut.pins.collect("/port.1/", "p1", r)
-  assert c.ids == ["porta1", "portb1", "p1", "porta0", "portb0"]
+  assert c.pin_names == ["porta1", "portb1", "p1", "porta0", "portb0"]
 
 # def test_in_progress_pin_api():
 #   import re
@@ -824,7 +824,7 @@ def test_collecting_with_mixed_inputs():
 #   print(r.__class__)
 #   print(r.pattern)
 #   c = origen.dut.pins.collect(r)
-#   print(c.ids)
+#   print(c.pin_names)
 #   assert 0 == 1
   # !!!
   # Experimental Stuff. Still in progress.

--- a/rust/origen/pyapi/src/pins.rs
+++ b/rust/origen/pyapi/src/pins.rs
@@ -32,7 +32,7 @@ pub fn pins(_py: Python, m: &PyModule) -> PyResult<()> {
 impl PyDUT {
 
     #[args(kwargs = "**")]
-    fn add_pin(&self, model_id: usize, id: &str, kwargs: Option<&PyDict>) -> PyResult<PyObject> {
+    fn add_pin(&self, model_id: usize, name: &str, kwargs: Option<&PyDict>) -> PyResult<PyObject> {
         let path = "";
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(model_id)?;
@@ -61,15 +61,15 @@ impl PyDUT {
             },
             None => {},
         }
-        model.add_pin(id, path, width, offset, reset_data, reset_action, endianness)?;
+        model.add_pin(name, path, width, offset, reset_data, reset_action, endianness)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.get_pin_group(id);
+        let p = model.get_pin_group(name);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
-                    id: String::from(id),
+                    name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
                 }).unwrap().to_object(py))
@@ -78,18 +78,18 @@ impl PyDUT {
         }
     }
 
-    fn pin(&self, model_id: usize, id: &str) -> PyResult<PyObject> {
+    fn pin(&self, model_id: usize, name: &str) -> PyResult<PyObject> {
         let path = "";
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(model_id)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.get_pin_group(id);
+        let p = model.get_pin_group(name);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
-                    id: String::from(id),
+                    name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
                 }).unwrap().to_object(py))
@@ -99,13 +99,13 @@ impl PyDUT {
     }
 
     #[args(aliases = "*")]
-    fn add_pin_alias(&self, model_id: usize, id: &str, aliases: &PyTuple) -> PyResult<()> {
+    fn add_pin_alias(&self, model_id: usize, name: &str, aliases: &PyTuple) -> PyResult<()> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(model_id)?;
 
         for alias in aliases {
             let _alias: String = alias.extract()?;
-            model.add_pin_alias(id, &_alias)?;
+            model.add_pin_alias(name, &_alias)?;
         }
         Ok(())
     }
@@ -122,7 +122,7 @@ impl PyDUT {
     }
 
     #[args(pins = "*", options = "**")]
-    fn group_pins(&self, model_id: usize, id: &str, pins: &PyTuple, options: Option<&PyDict>) -> PyResult<PyObject> {
+    fn group_pins(&self, model_id: usize, name: &str, pins: &PyTuple, options: Option<&PyDict>) -> PyResult<PyObject> {
         let path = "";
         let mut dut = DUT.lock().unwrap();
         let mut endianness = Option::None;
@@ -139,15 +139,15 @@ impl PyDUT {
             None => {}
         }
         let model = dut.get_mut_model(model_id)?;
-        model.group_pins(id, path, pins.extract()?, endianness)?;
+        model.group_pins(name, path, pins.extract()?, endianness)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.get_pin_group(id);
+        let p = model.get_pin_group(name);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
-                    id: String::from(id),
+                    name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
                 }).unwrap().to_object(py))
@@ -167,18 +167,18 @@ impl PyDUT {
         Ok(Py::new(py, PhysicalPinContainer {path: String::from(path), model_id: model_id}).unwrap())
     }
 
-    fn physical_pin(&self, model_id: usize, id: &str) -> PyResult<PyObject> {
+    fn physical_pin(&self, model_id: usize, name: &str) -> PyResult<PyObject> {
         let path = "";
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(model_id)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.get_physical_pin(id);
+        let p = model.get_physical_pin(name);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, Pin {
-                    id: String::from(id),
+                    name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
                 }).unwrap().to_object(py))

--- a/rust/origen/pyapi/src/pins.rs
+++ b/rust/origen/pyapi/src/pins.rs
@@ -65,7 +65,7 @@ impl PyDUT {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.pin(id);
+        let p = model.get_pin_group(id);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
@@ -85,7 +85,7 @@ impl PyDUT {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.pin(id);
+        let p = model.get_pin_group(id);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
@@ -143,7 +143,7 @@ impl PyDUT {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.pin(id);
+        let p = model.get_pin_group(id);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
@@ -174,7 +174,7 @@ impl PyDUT {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.physical_pin(id);
+        let p = model.get_physical_pin(id);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, Pin {

--- a/rust/origen/pyapi/src/pins.rs
+++ b/rust/origen/pyapi/src/pins.rs
@@ -2,21 +2,24 @@ use crate::dut::PyDUT;
 use origen::DUT;
 use pyo3::prelude::*;
 
-#[macro_use] mod pin;
-#[macro_use] mod pin_group;
-#[macro_use] mod pin_collection;
-mod pin_container;
+#[macro_use]
+mod pin;
+#[macro_use]
+mod pin_group;
+#[macro_use]
+mod pin_collection;
 mod physical_pin_container;
+mod pin_container;
 
-use pin::{Pin};
-use pin_group::PinGroup;
-use pin_container::PinContainer;
-use pin_collection::PinCollection;
-use physical_pin_container::PhysicalPinContainer;
 use origen::core::model::pins::Endianness;
+use physical_pin_container::PhysicalPinContainer;
+use pin::Pin;
+use pin_collection::PinCollection;
+use pin_container::PinContainer;
+use pin_group::PinGroup;
 
 #[allow(unused_imports)]
-use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes};
+use pyo3::types::{PyAny, PyBytes, PyDict, PyIterator, PyList, PyTuple};
 
 #[pymodule]
 /// Implements the module _origen.model in Python
@@ -30,13 +33,24 @@ pub fn pins(_py: Python, m: &PyModule) -> PyResult<()> {
 
 #[pymethods]
 impl PyDUT {
-
     #[args(kwargs = "**")]
     fn add_pin(&self, model_id: usize, name: &str, kwargs: Option<&PyDict>) -> PyResult<PyObject> {
         let path = "";
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(model_id)?;
-        let (mut reset_data, mut reset_action, mut width, mut offset, mut endianness): (Option<u32>, Option<String>, Option<u32>, Option<u32>, Option<Endianness>) = (Option::None, Option::None, Option::None, Option::None, Option::None);
+        let (mut reset_data, mut reset_action, mut width, mut offset, mut endianness): (
+            Option<u32>,
+            Option<String>,
+            Option<u32>,
+            Option<u32>,
+            Option<Endianness>,
+        ) = (
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+            Option::None,
+        );
         match kwargs {
             Some(args) => {
                 if let Some(arg) = args.get_item("reset_data") {
@@ -58,23 +72,34 @@ impl PyDUT {
                         endianness = Option::Some(Endianness::BigEndian);
                     }
                 }
-            },
-            None => {},
+            }
+            None => {}
         }
-        model.add_pin(name, path, width, offset, reset_data, reset_action, endianness)?;
+        model.add_pin(
+            name,
+            path,
+            width,
+            offset,
+            reset_data,
+            reset_action,
+            endianness,
+        )?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
         let p = model.get_pin_group(name);
         match p {
-            Some(_p) => {
-                Ok(Py::new(py, PinGroup {
+            Some(_p) => Ok(Py::new(
+                py,
+                PinGroup {
                     name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
-                }).unwrap().to_object(py))
-            },
-            None => Ok(py.None())
+                },
+            )
+            .unwrap()
+            .to_object(py)),
+            None => Ok(py.None()),
         }
     }
 
@@ -87,14 +112,17 @@ impl PyDUT {
         let py = gil.python();
         let p = model.get_pin_group(name);
         match p {
-            Some(_p) => {
-                Ok(Py::new(py, PinGroup {
+            Some(_p) => Ok(Py::new(
+                py,
+                PinGroup {
                     name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
-                }).unwrap().to_object(py))
-            },
-            None => Ok(py.None())
+                },
+            )
+            .unwrap()
+            .to_object(py)),
+            None => Ok(py.None()),
         }
     }
 
@@ -118,11 +146,24 @@ impl PyDUT {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        Ok(Py::new(py, PinContainer {path: String::from(path), model_id: model_id}).unwrap())
+        Ok(Py::new(
+            py,
+            PinContainer {
+                path: String::from(path),
+                model_id: model_id,
+            },
+        )
+        .unwrap())
     }
 
     #[args(pins = "*", options = "**")]
-    fn group_pins(&self, model_id: usize, name: &str, pins: &PyTuple, options: Option<&PyDict>) -> PyResult<PyObject> {
+    fn group_pins(
+        &self,
+        model_id: usize,
+        name: &str,
+        pins: &PyTuple,
+        options: Option<&PyDict>,
+    ) -> PyResult<PyObject> {
         let path = "";
         let mut dut = DUT.lock().unwrap();
         let mut endianness = Option::None;
@@ -135,7 +176,7 @@ impl PyDUT {
                         endianness = Option::Some(Endianness::BigEndian);
                     }
                 }
-            },
+            }
             None => {}
         }
         let model = dut.get_mut_model(model_id)?;
@@ -145,14 +186,17 @@ impl PyDUT {
         let py = gil.python();
         let p = model.get_pin_group(name);
         match p {
-            Some(_p) => {
-                Ok(Py::new(py, PinGroup {
+            Some(_p) => Ok(Py::new(
+                py,
+                PinGroup {
                     name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
-                }).unwrap().to_object(py))
-            },
-            None => Ok(py.None())
+                },
+            )
+            .unwrap()
+            .to_object(py)),
+            None => Ok(py.None()),
         }
     }
 
@@ -164,7 +208,14 @@ impl PyDUT {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        Ok(Py::new(py, PhysicalPinContainer {path: String::from(path), model_id: model_id}).unwrap())
+        Ok(Py::new(
+            py,
+            PhysicalPinContainer {
+                path: String::from(path),
+                model_id: model_id,
+            },
+        )
+        .unwrap())
     }
 
     fn physical_pin(&self, model_id: usize, name: &str) -> PyResult<PyObject> {
@@ -176,14 +227,17 @@ impl PyDUT {
         let py = gil.python();
         let p = model.get_physical_pin(name);
         match p {
-            Some(_p) => {
-                Ok(Py::new(py, Pin {
+            Some(_p) => Ok(Py::new(
+                py,
+                Pin {
                     name: String::from(name),
                     path: String::from(path),
                     model_id: model_id,
-                }).unwrap().to_object(py))
-            },
-            None => Ok(py.None())
+                },
+            )
+            .unwrap()
+            .to_object(py)),
+            None => Ok(py.None()),
         }
     }
 }

--- a/rust/origen/pyapi/src/pins/physical_pin_container.rs
+++ b/rust/origen/pyapi/src/pins/physical_pin_container.rs
@@ -79,7 +79,7 @@ impl PyMappingProtocol for PhysicalPinContainer {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.physical_pin(id);
+        let p = model.get_physical_pin(id);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, Pin {
@@ -96,7 +96,7 @@ impl PyMappingProtocol for PhysicalPinContainer {
     fn __len__(&self) -> PyResult<usize> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        Ok(model.number_of_physical_pins())
+        Ok(model.physical_pins.len())
     }
 }
 

--- a/rust/origen/pyapi/src/pins/physical_pin_container.rs
+++ b/rust/origen/pyapi/src/pins/physical_pin_container.rs
@@ -1,10 +1,10 @@
-use origen::DUT;
-use pyo3::prelude::*;
-use pyo3::{exceptions};
-#[allow(unused_imports)]
-use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes};
-use pyo3::class::mapping::*;
 use super::pin::Pin;
+use origen::DUT;
+use pyo3::class::mapping::*;
+use pyo3::exceptions;
+use pyo3::prelude::*;
+#[allow(unused_imports)]
+use pyo3::types::{PyAny, PyBytes, PyDict, PyIterator, PyList, PyTuple};
 
 #[pyclass]
 pub struct PhysicalPinContainer {
@@ -35,14 +35,20 @@ impl PhysicalPinContainer {
         let py = gil.python();
         let mut v: Vec<Py<Pin>> = Vec::new();
         for (n, _p) in physical_pins {
-            v.push(Py::new(py, Pin {
-                name: String::from(n.clone()),
-                path: String::from(self.path.clone()),
-                model_id: self.model_id,
-            }).unwrap())
+            v.push(
+                Py::new(
+                    py,
+                    Pin {
+                        name: String::from(n.clone()),
+                        path: String::from(self.path.clone()),
+                        model_id: self.model_id,
+                    },
+                )
+                .unwrap(),
+            )
         }
         Ok(v)
-    } 
+    }
 
     fn items(&self) -> PyResult<Vec<(String, Py<Pin>)>> {
         let mut dut = DUT.lock().unwrap();
@@ -55,11 +61,15 @@ impl PhysicalPinContainer {
         for (n, _p) in pins {
             items.push((
                 n.clone(),
-                Py::new(py, Pin {
-                    name: String::from(n.clone()),
-                    path: String::from(self.path.clone()),
-                    model_id: self.model_id,
-                }).unwrap(),
+                Py::new(
+                    py,
+                    Pin {
+                        name: String::from(n.clone()),
+                        path: String::from(self.path.clone()),
+                        model_id: self.model_id,
+                    },
+                )
+                .unwrap(),
             ));
         }
         Ok(items)
@@ -81,15 +91,20 @@ impl PyMappingProtocol for PhysicalPinContainer {
         let py = gil.python();
         let p = model.get_physical_pin(name);
         match p {
-            Some(_p) => {
-                Ok(Py::new(py, Pin {
-                  name: String::from(name),
-                  path: String::from(&self.path),
-                  model_id: self.model_id,
-              }).unwrap())
-            },
+            Some(_p) => Ok(Py::new(
+                py,
+                Pin {
+                    name: String::from(name),
+                    path: String::from(&self.path),
+                    model_id: self.model_id,
+                },
+            )
+            .unwrap()),
             // Stay in sync with Python's Hash - Raise a KeyError if no pin is found.
-            None => Err(exceptions::KeyError::py_err(format!("No pin or pin alias found for {}", name)))
+            None => Err(exceptions::KeyError::py_err(format!(
+                "No pin or pin alias found for {}",
+                name
+            ))),
         }
     }
 
@@ -129,7 +144,6 @@ pub struct PhysicalPinContainerIter {
 
 #[pyproto]
 impl pyo3::class::iter::PyIterProtocol for PhysicalPinContainerIter {
-
     fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
         let gil = Python::acquire_gil();
         let py = gil.python();
@@ -143,7 +157,7 @@ impl pyo3::class::iter::PyIterProtocol for PhysicalPinContainerIter {
     /// Todo: Fix the above using iterators. My Rust skills aren't there yet though... - Coreyeng
     fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<String>> {
         if slf.i >= slf.keys.len() {
-            return Ok(None)
+            return Ok(None);
         }
         let name = slf.keys[slf.i].clone();
         slf.i += 1;

--- a/rust/origen/pyapi/src/pins/pin.rs
+++ b/rust/origen/pyapi/src/pins/pin.rs
@@ -1,7 +1,7 @@
 use origen::DUT;
 use pyo3::prelude::*;
 #[allow(unused_imports)]
-use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes};
+use pyo3::types::{PyAny, PyBytes, PyDict, PyIterator, PyList, PyTuple};
 
 #[pyclass]
 pub struct Pin {
@@ -12,13 +12,17 @@ pub struct Pin {
 
 #[macro_export]
 macro_rules! pypin {
-  ($py:expr, $name:expr, $model_id:expr) => {
-      Py::new($py, crate::pins::pin::Pin {
-        name: String::from($name),
-        path: String::from(""),
-        model_id: model_id,
-      }).unwrap()
-  }
+    ($py:expr, $name:expr, $model_id:expr) => {
+        Py::new(
+            $py,
+            crate::pins::pin::Pin {
+                name: String::from($name),
+                path: String::from(""),
+                model_id: model_id,
+            },
+        )
+        .unwrap()
+    };
 }
 
 #[pymethods]
@@ -88,46 +92,38 @@ impl Pin {
 
     #[getter]
     fn get_aliases(&self) -> PyResult<Vec<String>> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      let pin = model._pin(&self.name)?;
-      Ok(pin.aliases.clone())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        let pin = model._pin(&self.name)?;
+        Ok(pin.aliases.clone())
     }
 
     #[getter]
     fn get_reset_data(&self) -> PyResult<PyObject> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      let pin = model._get_physical_pin(&self.name)?;
-      
-      let gil = Python::acquire_gil();
-      let py = gil.python();
-      match pin.reset_data {
-        Some(d) => {
-          Ok(d.to_object(py))
-        },
-        None => {
-          Ok(py.None())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        let pin = model._get_physical_pin(&self.name)?;
+
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        match pin.reset_data {
+            Some(d) => Ok(d.to_object(py)),
+            None => Ok(py.None()),
         }
-      }
     }
 
     #[getter]
     fn get_reset_action(&self) -> PyResult<PyObject> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      let pin = model._get_physical_pin(&self.name)?;
-      
-      let gil = Python::acquire_gil();
-      let py = gil.python();
-      match pin.reset_action {
-        Some(a) => {
-          Ok(String::from(a.as_char().to_string()).to_object(py))
-        },
-        None => {
-          Ok(py.None())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        let pin = model._get_physical_pin(&self.name)?;
+
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        match pin.reset_action {
+            Some(a) => Ok(String::from(a.as_char().to_string()).to_object(py)),
+            None => Ok(py.None()),
         }
-      }
     }
 
     // Debug helper: Get the name held by this instance.

--- a/rust/origen/pyapi/src/pins/pin.rs
+++ b/rust/origen/pyapi/src/pins/pin.rs
@@ -5,16 +5,16 @@ use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes};
 
 #[pyclass]
 pub struct Pin {
-    pub id: String,
+    pub name: String,
     pub path: String,
     pub model_id: usize,
 }
 
 #[macro_export]
 macro_rules! pypin {
-  ($py:expr, $id:expr, $model_id:expr) => {
+  ($py:expr, $name:expr, $model_id:expr) => {
       Py::new($py, crate::pins::pin::Pin {
-        id: String::from($id),
+        name: String::from($name),
         path: String::from(""),
         model_id: model_id,
       }).unwrap()
@@ -24,20 +24,20 @@ macro_rules! pypin {
 #[pymethods]
 impl Pin {
 
-    // Even though we're storing the id in this instance, we're going to go back to the core anyway.
+    // Even though we're storing the name in this instance, we're going to go back to the core anyway.
     #[getter]
-    fn get_id(&self) -> PyResult<String> {
+    fn get_name(&self) -> PyResult<String> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let pin = model._pin(&self.id)?;
-        Ok(pin.id.clone())
+        let pin = model._pin(&self.name)?;
+        Ok(pin.name.clone())
     }
 
     #[getter]
     fn get_data(&self) -> PyResult<u8> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let pin = model._pin(&self.id)?;
+        let pin = model._pin(&self.name)?;
         Ok(pin.data)
     }
 
@@ -45,7 +45,7 @@ impl Pin {
     fn get_action(&self) -> PyResult<String> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let pin = model._pin(&self.id)?;
+        let pin = model._pin(&self.name)?;
         Ok(String::from(pin.action.as_str()))
     }
 
@@ -53,7 +53,7 @@ impl Pin {
     fn get_aliases(&self) -> PyResult<Vec<String>> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      let pin = model._pin(&self.id)?;
+      let pin = model._pin(&self.name)?;
       Ok(pin.aliases.clone())
     }
 
@@ -61,7 +61,7 @@ impl Pin {
     fn get_reset_data(&self) -> PyResult<PyObject> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      let pin = model._get_physical_pin(&self.id)?;
+      let pin = model._get_physical_pin(&self.name)?;
       
       let gil = Python::acquire_gil();
       let py = gil.python();
@@ -79,7 +79,7 @@ impl Pin {
     fn get_reset_action(&self) -> PyResult<PyObject> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      let pin = model._get_physical_pin(&self.id)?;
+      let pin = model._get_physical_pin(&self.name)?;
       
       let gil = Python::acquire_gil();
       let py = gil.python();
@@ -93,14 +93,14 @@ impl Pin {
       }
     }
 
-    // Debug helper: Get the id held by this instance.
+    // Debug helper: Get the name held by this instance.
     #[allow(non_snake_case)]
     #[getter]
-    fn get__id(&self) -> PyResult<String> {
-        Ok(self.id.clone())
+    fn get__name(&self) -> PyResult<String> {
+        Ok(self.name.clone())
     }
 
-    // Debug helper: Get the id held by this instance.
+    // Debug helper: Get the path held by this instance.
     #[allow(non_snake_case)]
     #[getter]
     fn get__path(&self) -> PyResult<String> {

--- a/rust/origen/pyapi/src/pins/pin.rs
+++ b/rust/origen/pyapi/src/pins/pin.rs
@@ -23,6 +23,43 @@ macro_rules! pypin {
 
 #[pymethods]
 impl Pin {
+    // fn add_metadata(&self, meta_name: &str, obj: &PyAny) -> PyResult<()> {
+    //   let mut dut = DUT.lock().unwrap();
+    //   let model = dut.get_mut_model(self.model_id)?;
+    //   let pin = model._pin(&self.name)?;
+
+    //   let gil = Python::acquire_gil();
+    //   let py = gil.python();
+    //   //let o = Box::new(obj.to_object(py));
+    //   let o = Box::new(PyRef::new(py, obj));
+    //   pin.meta.insert(String::from(meta_name), o);
+    //   Ok(())
+    // }
+
+    // // fn get_meta(&self, meta_name: &str) -> PyResult<PyObject> {
+    // //   let mut dut = DUT.lock().unwrap();
+    // //   let model = dut.get_mut_model(self.model_id)?;
+    // //   let pin = model._pin(&self.name)?;
+
+    // //   let gil = Python::acquire_gil();
+    // //   let py = gil.python();
+    // //   pin.get_meta()
+    // // }
+
+    // #[getter]
+    // fn get_metadata(&self) -> PyResult<PyObject> {
+    //   let mut dut = DUT.lock().unwrap();
+    //   let model = dut.get_mut_model(self.model_id)?;
+    //   let pin = model._pin(&self.name)?;
+
+    //   let gil = Python::acquire_gil();
+    //   let py = gil.python();
+    //   let metadata = PyDict::new(py);
+    //   for (meta_name, meta_item) in pin.meta.iter() {
+    //     metadata.set_item(meta_name, *meta_item.downcast::<PyRef>().unwrap());
+    //   }
+    //   Ok(metadata.into())
+    // }
 
     // Even though we're storing the name in this instance, we're going to go back to the core anyway.
     #[getter]

--- a/rust/origen/pyapi/src/pins/pin.rs
+++ b/rust/origen/pyapi/src/pins/pin.rs
@@ -61,7 +61,7 @@ impl Pin {
     fn get_reset_data(&self) -> PyResult<PyObject> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      let pin = model.physical_pin(&self.id).unwrap();
+      let pin = model._get_physical_pin(&self.id)?;
       
       let gil = Python::acquire_gil();
       let py = gil.python();
@@ -79,7 +79,7 @@ impl Pin {
     fn get_reset_action(&self) -> PyResult<PyObject> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      let pin = model.physical_pin(&self.id).unwrap();
+      let pin = model._get_physical_pin(&self.id)?;
       
       let gil = Python::acquire_gil();
       let py = gil.python();

--- a/rust/origen/pyapi/src/pins/pin_collection.rs
+++ b/rust/origen/pyapi/src/pins/pin_collection.rs
@@ -1,29 +1,33 @@
-use origen::{DUT, lock};
-use origen::error::Error;
-use pyo3::prelude::*;
-#[allow(unused_imports)]
-use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes, PySlice};
 use origen::core::model::pins::pin_collection::PinCollection as OrigenPinCollection;
 use origen::core::model::pins::Endianness;
+use origen::error::Error;
+use origen::{lock, DUT};
+use pyo3::prelude::*;
+#[allow(unused_imports)]
+use pyo3::types::{PyAny, PyBytes, PyDict, PyIterator, PyList, PySlice, PyTuple};
 
 #[pyclass]
 pub struct PinCollection {
     path: String,
     model_id: usize,
-    pin_collection: OrigenPinCollection
+    pin_collection: OrigenPinCollection,
 }
 
-impl PinCollection{
-  pub fn new(model_id: usize, names: Vec<String>, endianness: Option<Endianness>) -> Result<PinCollection, Error> {
-    let mut dut = lock!()?;
-    let model = dut.get_mut_model(model_id)?;
-    let collection = model.collect(model_id, "", names, endianness)?;
-    Ok(PinCollection {
-        path: String::from(""),
-        pin_collection: collection,
-        model_id: model_id,
-      })
-  }
+impl PinCollection {
+    pub fn new(
+        model_id: usize,
+        names: Vec<String>,
+        endianness: Option<Endianness>,
+    ) -> Result<PinCollection, Error> {
+        let mut dut = lock!()?;
+        let model = dut.get_mut_model(model_id)?;
+        let collection = model.collect(model_id, "", names, endianness)?;
+        Ok(PinCollection {
+            path: String::from(""),
+            pin_collection: collection,
+            model_id: model_id,
+        })
+    }
 }
 
 #[pymethods]
@@ -46,11 +50,15 @@ impl PinCollection {
 
         // I'm sure there's a better way to return self, but I wasn't able to get anything to work.
         // Just copying self and returning that for now.
-        Ok(Py::new(py, PinCollection {
-          path: self.path.clone(),
-          pin_collection: self.pin_collection.clone(),
-          model_id: self.model_id,
-        }).unwrap())
+        Ok(Py::new(
+            py,
+            PinCollection {
+                path: self.path.clone(),
+                pin_collection: self.pin_collection.clone(),
+                model_id: self.model_id,
+            },
+        )
+        .unwrap())
     }
 
     fn with_mask(&mut self, mask: usize) -> PyResult<Py<Self>> {
@@ -60,11 +68,15 @@ impl PinCollection {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        Ok(Py::new(py, PinCollection {
-          path: self.path.clone(),
-          pin_collection: self.pin_collection.clone(),
-          model_id: self.model_id,
-        }).unwrap())
+        Ok(Py::new(
+            py,
+            PinCollection {
+                path: self.path.clone(),
+                pin_collection: self.pin_collection.clone(),
+                model_id: self.model_id,
+            },
+        )
+        .unwrap())
     }
 
     fn set(&self, data: u32) -> PyResult<Py<Self>> {
@@ -73,44 +85,44 @@ impl PinCollection {
 
     #[getter]
     fn get_pin_actions(&self) -> PyResult<String> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.get_pin_actions(&self.pin_collection.pin_names)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.get_pin_actions(&self.pin_collection.pin_names)?)
     }
 
     fn drive(&mut self, data: Option<u32>) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      model.drive_pin_collection(&mut self.pin_collection, data)?;
-      Ok(())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        model.drive_pin_collection(&mut self.pin_collection, data)?;
+        Ok(())
     }
 
     fn verify(&mut self, data: Option<u32>) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      model.verify_pin_collection(&mut self.pin_collection, data)?;
-      Ok(())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        model.verify_pin_collection(&mut self.pin_collection, data)?;
+        Ok(())
     }
 
     fn capture(&mut self) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      model.capture_pin_collection(&mut self.pin_collection)?;
-      Ok(())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        model.capture_pin_collection(&mut self.pin_collection)?;
+        Ok(())
     }
 
     fn highz(&mut self) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      model.highz_pin_collection(&mut self.pin_collection)?;
-      Ok(())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        model.highz_pin_collection(&mut self.pin_collection)?;
+        Ok(())
     }
 
     fn reset(&mut self) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      model.reset_pin_collection(&mut self.pin_collection)?;
-      Ok(())
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        model.reset_pin_collection(&mut self.pin_collection)?;
+        Ok(())
     }
 
     #[getter]
@@ -120,21 +132,21 @@ impl PinCollection {
 
     #[getter]
     fn get_width(&self) -> PyResult<usize> {
-      Ok(self.pin_collection.len())
+        Ok(self.pin_collection.len())
     }
 
     #[getter]
     fn get_reset_data(&self) -> PyResult<u32> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.get_pin_collection_reset_data(&self.pin_collection))
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.get_pin_collection_reset_data(&self.pin_collection))
     }
- 
+
     #[getter]
     fn get_reset_actions(&self) -> PyResult<String> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.get_pin_collection_reset_actions(&self.pin_collection)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.get_pin_collection_reset_actions(&self.pin_collection)?)
     }
 
     #[allow(non_snake_case)]
@@ -145,12 +157,12 @@ impl PinCollection {
 
     #[getter]
     fn get_big_endian(&self) -> PyResult<bool> {
-      Ok(!self.pin_collection.is_little_endian())
+        Ok(!self.pin_collection.is_little_endian())
     }
 
     #[getter]
     fn get_little_endian(&self) -> PyResult<bool> {
-      Ok(self.pin_collection.is_little_endian())
+        Ok(self.pin_collection.is_little_endian())
     }
 }
 
@@ -161,10 +173,10 @@ impl pyo3::class::sequence::PySequenceProtocol for PinCollection {
     }
 
     fn __contains__(&self, item: &str) -> PyResult<bool> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.pin_names_contain(&self.pin_collection.pin_names, item)?)
-  }
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.pin_names_contain(&self.pin_collection.pin_names, item)?)
+    }
 }
 
 #[pyproto]
@@ -174,16 +186,24 @@ impl<'p> pyo3::class::PyMappingProtocol<'p> for PinCollection {
         let gil = Python::acquire_gil();
         let py = gil.python();
         if let Ok(slice) = idx.cast_as::<PySlice>() {
-          // Indices requires (what I think is) a max size. Should be plenty.
-          let indices = slice.indices(8192)?;
-          let collection = self.pin_collection.slice_names(indices.start as usize, indices.stop as usize, indices.step as usize)?;
-          Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
+            // Indices requires (what I think is) a max size. Should be plenty.
+            let indices = slice.indices(8192)?;
+            let collection = self.pin_collection.slice_names(
+                indices.start as usize,
+                indices.stop as usize,
+                indices.step as usize,
+            )?;
+            Ok(Py::new(py, PinCollection::from(collection))
+                .unwrap()
+                .to_object(py))
         } else {
-          let i = idx.extract::<isize>().unwrap();
-          let collection = self.pin_collection.slice_names(i as usize, i as usize, 1)?;
-          Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
+            let i = idx.extract::<isize>().unwrap();
+            let collection = self.pin_collection.slice_names(i as usize, i as usize, 1)?;
+            Ok(Py::new(py, PinCollection::from(collection))
+                .unwrap()
+                .to_object(py))
         }
-      }
+    }
 }
 
 #[pyproto]
@@ -198,37 +218,37 @@ impl pyo3::class::iter::PyIterProtocol for PinCollection {
 }
 
 impl From<OrigenPinCollection> for PinCollection {
-  fn from(collection: OrigenPinCollection) -> Self {
-    PinCollection {
-      path: collection.path.clone(),
-      model_id: collection.model_id.clone(),
-      pin_collection: collection,
+    fn from(collection: OrigenPinCollection) -> Self {
+        PinCollection {
+            path: collection.path.clone(),
+            model_id: collection.model_id.clone(),
+            pin_collection: collection,
+        }
     }
-  }
 }
 
 #[pyclass]
 pub struct PinCollectionIter {
-  keys: Vec<String>,
-  i: usize,
-  model_id: usize,
+    keys: Vec<String>,
+    i: usize,
+    model_id: usize,
 }
 
 #[pyproto]
 impl pyo3::class::iter::PyIterProtocol for PinCollectionIter {
-  fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    Ok(slf.to_object(py))
-  }
-
-  fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PinCollection>> {
-    if slf.i >= slf.keys.len() {
-        return Ok(None)
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        Ok(slf.to_object(py))
     }
-    let name = slf.keys[slf.i].clone();
-    let collection = PinCollection::new(slf.model_id, vec!(name), Option::None)?;
-    slf.i += 1;
-    Ok(Some(collection))
-  }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PinCollection>> {
+        if slf.i >= slf.keys.len() {
+            return Ok(None);
+        }
+        let name = slf.keys[slf.i].clone();
+        let collection = PinCollection::new(slf.model_id, vec![name], Option::None)?;
+        slf.i += 1;
+        Ok(Some(collection))
+    }
 }

--- a/rust/origen/pyapi/src/pins/pin_collection.rs
+++ b/rust/origen/pyapi/src/pins/pin_collection.rs
@@ -14,10 +14,10 @@ pub struct PinCollection {
 }
 
 impl PinCollection{
-  pub fn new(model_id: usize, ids: Vec<String>, endianness: Option<Endianness>) -> Result<PinCollection, Error> {
+  pub fn new(model_id: usize, names: Vec<String>, endianness: Option<Endianness>) -> Result<PinCollection, Error> {
     let mut dut = lock!()?;
     let model = dut.get_mut_model(model_id)?;
-    let collection = model.collect(model_id, "", ids, endianness)?;
+    let collection = model.collect(model_id, "", names, endianness)?;
     Ok(PinCollection {
         path: String::from(""),
         pin_collection: collection,
@@ -32,7 +32,7 @@ impl PinCollection {
     fn get_data(&self) -> PyResult<u32> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.pin_collection.model_id)?;
-        Ok(model.get_pin_data(&self.pin_collection.ids))
+        Ok(model.get_pin_data(&self.pin_collection.pin_names))
     }
 
     #[setter]
@@ -75,7 +75,7 @@ impl PinCollection {
     fn get_pin_actions(&self) -> PyResult<String> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.get_pin_actions(&self.pin_collection.ids)?)
+      Ok(model.get_pin_actions(&self.pin_collection.pin_names)?)
     }
 
     fn drive(&mut self, data: Option<u32>) -> PyResult<()> {
@@ -114,8 +114,8 @@ impl PinCollection {
     }
 
     #[getter]
-    fn get_ids(&self) -> PyResult<Vec<String>> {
-        Ok(self.pin_collection.ids.clone())
+    fn get_pin_names(&self) -> PyResult<Vec<String>> {
+        Ok(self.pin_collection.pin_names.clone())
     }
 
     #[getter]
@@ -163,7 +163,7 @@ impl pyo3::class::sequence::PySequenceProtocol for PinCollection {
     fn __contains__(&self, item: &str) -> PyResult<bool> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.pin_ids_contain(&self.pin_collection.ids, item)?)
+      Ok(model.pin_names_contain(&self.pin_collection.pin_names, item)?)
   }
 }
 
@@ -176,11 +176,11 @@ impl<'p> pyo3::class::PyMappingProtocol<'p> for PinCollection {
         if let Ok(slice) = idx.cast_as::<PySlice>() {
           // Indices requires (what I think is) a max size. Should be plenty.
           let indices = slice.indices(8192)?;
-          let collection = self.pin_collection.slice_ids(indices.start as usize, indices.stop as usize, indices.step as usize)?;
+          let collection = self.pin_collection.slice_names(indices.start as usize, indices.stop as usize, indices.step as usize)?;
           Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
         } else {
           let i = idx.extract::<isize>().unwrap();
-          let collection = self.pin_collection.slice_ids(i as usize, i as usize, 1)?;
+          let collection = self.pin_collection.slice_names(i as usize, i as usize, 1)?;
           Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
         }
       }
@@ -190,7 +190,7 @@ impl<'p> pyo3::class::PyMappingProtocol<'p> for PinCollection {
 impl pyo3::class::iter::PyIterProtocol for PinCollection {
     fn __iter__(slf: PyRefMut<Self>) -> PyResult<PinCollectionIter> {
         Ok(PinCollectionIter {
-            keys: slf.pin_collection.ids.clone(),
+            keys: slf.pin_collection.pin_names.clone(),
             i: 0,
             model_id: slf.model_id,
         })
@@ -226,8 +226,8 @@ impl pyo3::class::iter::PyIterProtocol for PinCollectionIter {
     if slf.i >= slf.keys.len() {
         return Ok(None)
     }
-    let id = slf.keys[slf.i].clone();
-    let collection = PinCollection::new(slf.model_id, vec!(id), Option::None)?;
+    let name = slf.keys[slf.i].clone();
+    let collection = PinCollection::new(slf.model_id, vec!(name), Option::None)?;
     slf.i += 1;
     Ok(Some(collection))
   }

--- a/rust/origen/pyapi/src/pins/pin_collection.rs
+++ b/rust/origen/pyapi/src/pins/pin_collection.rs
@@ -134,7 +134,7 @@ impl PinCollection {
     fn get_reset_actions(&self) -> PyResult<String> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.get_pin_reset_actions_for_collection(&self.pin_collection)?)
+      Ok(model.get_pin_collection_reset_actions(&self.pin_collection)?)
     }
 
     #[allow(non_snake_case)]

--- a/rust/origen/pyapi/src/pins/pin_container.rs
+++ b/rust/origen/pyapi/src/pins/pin_container.rs
@@ -115,7 +115,7 @@ impl PyMappingProtocol for PinContainer {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.pin(id);
+        let p = model.get_pin_group(id);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
@@ -132,7 +132,7 @@ impl PyMappingProtocol for PinContainer {
     fn __len__(&self) -> PyResult<usize> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        Ok(model.number_of_ids())
+        Ok(model.pins.len())
     }
 }
 

--- a/rust/origen/pyapi/src/pins/pin_container.rs
+++ b/rust/origen/pyapi/src/pins/pin_container.rs
@@ -20,10 +20,10 @@ impl PinContainer {
     fn keys(&self) -> PyResult<Vec<String>> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let ids = &model.pins;
+        let names = &model.pins;
 
         let mut v: Vec<String> = Vec::new();
-        for (n, _p) in ids {
+        for (n, _p) in names {
             v.push(n.clone());
         }
         Ok(v)
@@ -39,7 +39,7 @@ impl PinContainer {
         let mut v: Vec<Py<PinGroup>> = Vec::new();
         for (n, _p) in pins {
             v.push(Py::new(py, PinGroup {
-                id: String::from(n.clone()),
+                name: String::from(n.clone()),
                 path: String::from(self.path.clone()),
                 model_id: self.model_id,
               }).unwrap())
@@ -59,7 +59,7 @@ impl PinContainer {
             items.push((
                 n.clone(),
                 Py::new(py, PinGroup {
-                    id: String::from(n.clone()),
+                    name: String::from(n.clone()),
                     path: String::from(self.path.clone()),
                     model_id: self.model_id,
                   }).unwrap(),
@@ -69,12 +69,12 @@ impl PinContainer {
     }
 
     #[getter]
-    fn get_ids(&self) -> PyResult<Vec<String>> {
+    fn get_pin_names(&self) -> PyResult<Vec<String>> {
         self.keys()
     }
 
-    #[args(ids = "*", options = "**")]
-    fn collect(&self, ids: &PyTuple, options: Option<&PyDict>) -> PyResult<Py<PinCollection>> {
+    #[args(names = "*", options = "**")]
+    fn collect(&self, names: &PyTuple, options: Option<&PyDict>) -> PyResult<Py<PinCollection>> {
       let gil = Python::acquire_gil();
       let py = gil.python();
       let mut endianness = Option::None;
@@ -91,17 +91,17 @@ impl PinContainer {
         None => {}
       }
 
-      let mut id_strs: Vec<String> = vec!();
-      for (_i, id) in ids.iter().enumerate() {
-        if id.get_type().name() == "re.Pattern" {
-          let r = id.getattr("pattern").unwrap();
-          id_strs.push(format!("/{}/", r));
+      let mut name_strs: Vec<String> = vec!();
+      for (_i, n) in names.iter().enumerate() {
+        if n.get_type().name() == "re.Pattern" {
+          let r = n.getattr("pattern").unwrap();
+          name_strs.push(format!("/{}/", r));
         } else {
-          let _id = id.extract::<String>()?;
-          id_strs.push(_id.clone());
+          let _n = n.extract::<String>()?;
+          name_strs.push(_n.clone());
         }
       }
-      let collection = PinCollection::new(self.model_id, id_strs, endianness)?;
+      let collection = PinCollection::new(self.model_id, name_strs, endianness)?;
       let c = Py::new(py, collection).unwrap();
       Ok(c)
   }
@@ -109,23 +109,23 @@ impl PinContainer {
 
 #[pyproto]
 impl PyMappingProtocol for PinContainer {
-    fn __getitem__(&self, id: &str) -> PyResult<Py<PinGroup>> {
+    fn __getitem__(&self, name: &str) -> PyResult<Py<PinGroup>> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        let p = model.get_pin_group(id);
+        let p = model.get_pin_group(name);
         match p {
             Some(_p) => {
                 Ok(Py::new(py, PinGroup {
-                  id: String::from(id),
+                  name: String::from(name),
                   path: String::from(&self.path),
                   model_id: self.model_id,
               }).unwrap())
             },
             // Stay in sync with Python's Hash - Raise a KeyError if no pin is found.
-            None => Err(exceptions::KeyError::py_err(format!("No pin or pin alias found for {}", id)))
+            None => Err(exceptions::KeyError::py_err(format!("No pin or pin alias found for {}", name)))
         }
     }
 
@@ -172,17 +172,17 @@ impl pyo3::class::iter::PyIterProtocol for PinContainerIter {
         Ok(slf.to_object(py))
     }
 
-    /// The Iterator will be created with an index starting at 0 and the pin ids at the time of its creation.
+    /// The Iterator will be created with an index starting at 0 and the pin names at the time of its creation.
     /// For each call to 'next', we'll create a pin object with the next value in the list, or None, if no more keys are available.
     /// Note: this means that the iterator can become stale if the PinContainer is changed. This can happen if the iterator is stored from Python code
-    ///  directly. E.g.: i = dut.pins.__iter__() => iterator with the pin ids at the time of creation,
+    ///  directly. E.g.: i = dut.pins.__iter__() => iterator with the pin names at the time of creation,
     /// Todo: Fix the above using iterators. My Rust skills aren't there yet though... - Coreyeng
     fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<String>> {
         if slf.i >= slf.keys.len() {
             return Ok(None)
         }
-        let id = slf.keys[slf.i].clone();
+        let name = slf.keys[slf.i].clone();
         slf.i += 1;
-        Ok(Some(id))
+        Ok(Some(name))
     }
 }

--- a/rust/origen/pyapi/src/pins/pin_group.rs
+++ b/rust/origen/pyapi/src/pins/pin_group.rs
@@ -7,39 +7,39 @@ use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes, PySlice};
 
 #[pyclass]
 pub struct PinGroup {
-    pub id: String,
+    pub name: String,
     pub path: String,
     pub model_id: usize,
 }
 
 #[pymethods]
 impl PinGroup {
-    // Even though we're storing the id in this instance, we're going to go back to the core anyway.
+    // Even though we're storing the name in this instance, we're going to go back to the core anyway.
     #[getter]
-    fn get_id(&self) -> PyResult<String> {
+    fn get_name(&self) -> PyResult<String> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let grp = model._get_pin_group(&self.id)?;
-        Ok(grp.id.clone())
+        let grp = model._get_pin_group(&self.name)?;
+        Ok(grp.name.clone())
     }
 
     #[getter]
     fn get_data(&self) -> PyResult<u32> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        Ok(model.get_pin_group_data(&self.id))
+        Ok(model.get_pin_group_data(&self.name))
     }
 
     #[setter]
     fn set_data(&self, data: u32) -> PyResult<Py<Self>> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        model.set_pin_group_data(&self.id, data)?;
+        model.set_pin_group_data(&self.name, data)?;
         
         let gil = Python::acquire_gil();
         let py = gil.python();
         Ok(Py::new(py, Self {
-          id: self.id.clone(),
+          name: self.name.clone(),
           path: self.path.clone(),
           model_id: self.model_id,
         }).unwrap())
@@ -52,25 +52,25 @@ impl PinGroup {
     fn with_mask(&self, mask: usize) -> PyResult<Py<Self>> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        model.set_pin_group_nonsticky_mask(&self.id, mask)?;
+        model.set_pin_group_nonsticky_mask(&self.name, mask)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
         Ok(Py::new(py, Self {
-          id: self.id.clone(),
+          name: self.name.clone(),
           path: self.path.clone(),
           model_id: self.model_id,
         }).unwrap())
     }
 
     #[getter]
-    fn get_pin_ids(&self) -> PyResult<Vec<String>> {
+    fn get_pin_names(&self) -> PyResult<Vec<String>> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let grp = model._get_pin_group(&self.id)?;
+        let grp = model._get_pin_group(&self.name)?;
 
         let mut v: Vec<String> = Vec::new();
-        for n in grp.pin_ids.iter() {
+        for n in grp.pin_names.iter() {
             v.push(n.clone());
         }
         Ok(v)
@@ -80,14 +80,14 @@ impl PinGroup {
     fn get_pins(&self) -> PyResult<Vec<Py<Pin>>> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let grp = model._get_pin_group(&self.id)?;
+        let grp = model._get_pin_group(&self.name)?;
 
         let gil = Python::acquire_gil();
         let py = gil.python();
         let mut v: Vec<Py<Pin>> = Vec::new();
-        for n in grp.pin_ids.iter() {
+        for n in grp.pin_names.iter() {
             v.push(Py::new(py, Pin {
-                id: String::from(n),
+                name: String::from(n),
                 path: String::from(&self.path),
                 model_id: self.model_id,
             }).unwrap());
@@ -99,52 +99,52 @@ impl PinGroup {
     fn get_pin_actions(&self) -> PyResult<String> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        Ok(model.get_pin_group_actions(&self.id)?)
+        Ok(model.get_pin_group_actions(&self.name)?)
     }
 
     fn drive(&self, data: Option<u32>) -> PyResult<()> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.drive_pin_group(&self.id, data, Option::None)?)
+      Ok(model.drive_pin_group(&self.name, data, Option::None)?)
     }
 
     fn verify(&self, data: Option<u32>) -> PyResult<()> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.verify_pin_group(&self.id, data, Option::None)?)
+      Ok(model.verify_pin_group(&self.name, data, Option::None)?)
     }
 
     fn capture(&self) -> PyResult<()> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.capture_pin_group(&self.id, Option::None)?)
+      Ok(model.capture_pin_group(&self.name, Option::None)?)
     }
 
     fn highz(&self) -> PyResult<()> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.highz_pin_group(&self.id, Option::None)?)
+      Ok(model.highz_pin_group(&self.name, Option::None)?)
     }
 
     fn reset(&self) -> PyResult<()> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.reset_pin_group(&self.id)?)
+      Ok(model.reset_pin_group(&self.name)?)
     }
 
     #[getter]
-    fn get_physical_ids(&self) -> PyResult<Vec<String>> {
+    fn get_physical_names(&self) -> PyResult<Vec<String>> {
       let mut dut = DUT.lock().unwrap();
       let model = dut.get_mut_model(self.model_id)?;
-      let ids = model.resolve_pin_group_ids(&self.id)?;
-      Ok(ids.clone())
+      let names = model.resolve_pin_group_names(&self.name)?;
+      Ok(names.clone())
    }
 
    #[getter]
    fn get_width(&self) -> PyResult<usize> {
      let mut dut = DUT.lock().unwrap();
      let model = dut.get_mut_model(self.model_id)?;
-     let grp = model._get_pin_group(&self.id)?;
+     let grp = model._get_pin_group(&self.name)?;
      Ok(grp.len())
    }
 
@@ -152,24 +152,24 @@ impl PinGroup {
    fn get_reset_data(&self) -> PyResult<u32> {
      let mut dut = DUT.lock().unwrap();
      let model = dut.get_mut_model(self.model_id)?;
-     Ok(model.get_pin_group_reset_data(&self.id))
+     Ok(model.get_pin_group_reset_data(&self.name))
    }
 
    #[getter]
    fn get_reset_actions(&self) -> PyResult<String> {
      let mut dut = DUT.lock().unwrap();
      let model = dut.get_mut_model(self.model_id)?;
-     Ok(model.get_pin_group_reset_actions(&self.id)?)
+     Ok(model.get_pin_group_reset_actions(&self.name)?)
    }
 
-    // Debug helper: Get the id held by this instance.
+    // Debug helper: Get the name held by this instance.
     #[allow(non_snake_case)]
     #[getter]
-    fn get__id(&self) -> PyResult<String> {
-        Ok(self.id.clone())
+    fn get__name(&self) -> PyResult<String> {
+        Ok(self.name.clone())
     }
 
-    // Debug helper: Get the id held by this instance.
+    // Debug helper: Get the name held by this instance.
     #[allow(non_snake_case)]
     #[getter]
     fn get__path(&self) -> PyResult<String> {
@@ -186,7 +186,7 @@ impl PinGroup {
     fn get_little_endian(&self) -> PyResult<bool> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let grp = model._get_pin_group(&self.id)?;
+        let grp = model._get_pin_group(&self.name)?;
         Ok(grp.is_little_endian())
     }
 }
@@ -196,14 +196,14 @@ impl pyo3::class::sequence::PySequenceProtocol for PinGroup {
     fn __len__(&self) -> PyResult<usize> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        let grp = model._get_pin_group(&self.id)?;
+        let grp = model._get_pin_group(&self.name)?;
         Ok(grp.len())
     }
 
     fn __contains__(&self, item: &str) -> PyResult<bool> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
-        Ok(model.pin_group_contains(&self.id, item)?)
+        Ok(model.pin_group_contains(&self.name, item)?)
     }
 }
 
@@ -219,11 +219,11 @@ impl<'p> pyo3::class::PyMappingProtocol<'p> for PinGroup {
         if let Ok(slice) = idx.cast_as::<PySlice>() {
           // Indices requires (what I think is) a max size. Should be plenty.
           let indices = slice.indices(8192)?;
-          let collection = model.slice_pin_group(&self.id, indices.start as usize, indices.stop as usize, indices.step as usize)?;
+          let collection = model.slice_pin_group(&self.name, indices.start as usize, indices.stop as usize, indices.step as usize)?;
           Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
         } else {
           let i = idx.extract::<isize>().unwrap();
-          let collection = model.slice_pin_group(&self.id, i as usize, i as usize, 1)?;
+          let collection = model.slice_pin_group(&self.name, i as usize, i as usize, 1)?;
           Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
         }
       }
@@ -234,10 +234,10 @@ impl pyo3::class::iter::PyIterProtocol for PinGroup {
     fn __iter__(slf: PyRefMut<Self>) -> PyResult<PinGroupIter> {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(slf.model_id)?;
-        let grp = model._get_pin_group(&slf.id)?;
+        let grp = model._get_pin_group(&slf.name)?;
 
         Ok(PinGroupIter {
-            keys: grp.pin_ids.clone(),
+            keys: grp.pin_names.clone(),
             i: 0,
             model_id: slf.model_id,
         })
@@ -263,8 +263,8 @@ impl pyo3::class::iter::PyIterProtocol for PinGroupIter {
     if slf.i >= slf.keys.len() {
         return Ok(None)
     }
-    let id = slf.keys[slf.i].clone();
-    let collection = PinCollection::new(slf.model_id, vec!(id), Option::None)?;
+    let name = slf.keys[slf.i].clone();
+    let collection = PinCollection::new(slf.model_id, vec!(name), Option::None)?;
     slf.i += 1;
     Ok(Some(collection))
   }

--- a/rust/origen/pyapi/src/pins/pin_group.rs
+++ b/rust/origen/pyapi/src/pins/pin_group.rs
@@ -1,9 +1,9 @@
-use origen::DUT;
-use pyo3::prelude::*;
 use super::pin::Pin;
 use super::pin_collection::PinCollection;
+use origen::DUT;
+use pyo3::prelude::*;
 #[allow(unused_imports)]
-use pyo3::types::{PyDict, PyList, PyTuple, PyIterator, PyAny, PyBytes, PySlice};
+use pyo3::types::{PyAny, PyBytes, PyDict, PyIterator, PyList, PySlice, PyTuple};
 
 #[pyclass]
 pub struct PinGroup {
@@ -35,14 +35,18 @@ impl PinGroup {
         let mut dut = DUT.lock().unwrap();
         let model = dut.get_mut_model(self.model_id)?;
         model.set_pin_group_data(&self.name, data)?;
-        
+
         let gil = Python::acquire_gil();
         let py = gil.python();
-        Ok(Py::new(py, Self {
-          name: self.name.clone(),
-          path: self.path.clone(),
-          model_id: self.model_id,
-        }).unwrap())
+        Ok(Py::new(
+            py,
+            Self {
+                name: self.name.clone(),
+                path: self.path.clone(),
+                model_id: self.model_id,
+            },
+        )
+        .unwrap())
     }
 
     fn set(&self, data: u32) -> PyResult<Py<Self>> {
@@ -56,11 +60,15 @@ impl PinGroup {
 
         let gil = Python::acquire_gil();
         let py = gil.python();
-        Ok(Py::new(py, Self {
-          name: self.name.clone(),
-          path: self.path.clone(),
-          model_id: self.model_id,
-        }).unwrap())
+        Ok(Py::new(
+            py,
+            Self {
+                name: self.name.clone(),
+                path: self.path.clone(),
+                model_id: self.model_id,
+            },
+        )
+        .unwrap())
     }
 
     #[getter]
@@ -86,11 +94,17 @@ impl PinGroup {
         let py = gil.python();
         let mut v: Vec<Py<Pin>> = Vec::new();
         for n in grp.pin_names.iter() {
-            v.push(Py::new(py, Pin {
-                name: String::from(n),
-                path: String::from(&self.path),
-                model_id: self.model_id,
-            }).unwrap());
+            v.push(
+                Py::new(
+                    py,
+                    Pin {
+                        name: String::from(n),
+                        path: String::from(&self.path),
+                        model_id: self.model_id,
+                    },
+                )
+                .unwrap(),
+            );
         }
         Ok(v)
     }
@@ -103,64 +117,64 @@ impl PinGroup {
     }
 
     fn drive(&self, data: Option<u32>) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.drive_pin_group(&self.name, data, Option::None)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.drive_pin_group(&self.name, data, Option::None)?)
     }
 
     fn verify(&self, data: Option<u32>) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.verify_pin_group(&self.name, data, Option::None)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.verify_pin_group(&self.name, data, Option::None)?)
     }
 
     fn capture(&self) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.capture_pin_group(&self.name, Option::None)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.capture_pin_group(&self.name, Option::None)?)
     }
 
     fn highz(&self) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.highz_pin_group(&self.name, Option::None)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.highz_pin_group(&self.name, Option::None)?)
     }
 
     fn reset(&self) -> PyResult<()> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      Ok(model.reset_pin_group(&self.name)?)
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.reset_pin_group(&self.name)?)
     }
 
     #[getter]
     fn get_physical_names(&self) -> PyResult<Vec<String>> {
-      let mut dut = DUT.lock().unwrap();
-      let model = dut.get_mut_model(self.model_id)?;
-      let names = model.resolve_pin_group_names(&self.name)?;
-      Ok(names.clone())
-   }
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        let names = model.resolve_pin_group_names(&self.name)?;
+        Ok(names.clone())
+    }
 
-   #[getter]
-   fn get_width(&self) -> PyResult<usize> {
-     let mut dut = DUT.lock().unwrap();
-     let model = dut.get_mut_model(self.model_id)?;
-     let grp = model._get_pin_group(&self.name)?;
-     Ok(grp.len())
-   }
+    #[getter]
+    fn get_width(&self) -> PyResult<usize> {
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        let grp = model._get_pin_group(&self.name)?;
+        Ok(grp.len())
+    }
 
-   #[getter]
-   fn get_reset_data(&self) -> PyResult<u32> {
-     let mut dut = DUT.lock().unwrap();
-     let model = dut.get_mut_model(self.model_id)?;
-     Ok(model.get_pin_group_reset_data(&self.name))
-   }
+    #[getter]
+    fn get_reset_data(&self) -> PyResult<u32> {
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.get_pin_group_reset_data(&self.name))
+    }
 
-   #[getter]
-   fn get_reset_actions(&self) -> PyResult<String> {
-     let mut dut = DUT.lock().unwrap();
-     let model = dut.get_mut_model(self.model_id)?;
-     Ok(model.get_pin_group_reset_actions(&self.name)?)
-   }
+    #[getter]
+    fn get_reset_actions(&self) -> PyResult<String> {
+        let mut dut = DUT.lock().unwrap();
+        let model = dut.get_mut_model(self.model_id)?;
+        Ok(model.get_pin_group_reset_actions(&self.name)?)
+    }
 
     // Debug helper: Get the name held by this instance.
     #[allow(non_snake_case)]
@@ -217,16 +231,25 @@ impl<'p> pyo3::class::PyMappingProtocol<'p> for PinGroup {
         let gil = Python::acquire_gil();
         let py = gil.python();
         if let Ok(slice) = idx.cast_as::<PySlice>() {
-          // Indices requires (what I think is) a max size. Should be plenty.
-          let indices = slice.indices(8192)?;
-          let collection = model.slice_pin_group(&self.name, indices.start as usize, indices.stop as usize, indices.step as usize)?;
-          Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
+            // Indices requires (what I think is) a max size. Should be plenty.
+            let indices = slice.indices(8192)?;
+            let collection = model.slice_pin_group(
+                &self.name,
+                indices.start as usize,
+                indices.stop as usize,
+                indices.step as usize,
+            )?;
+            Ok(Py::new(py, PinCollection::from(collection))
+                .unwrap()
+                .to_object(py))
         } else {
-          let i = idx.extract::<isize>().unwrap();
-          let collection = model.slice_pin_group(&self.name, i as usize, i as usize, 1)?;
-          Ok(Py::new(py, PinCollection::from(collection)).unwrap().to_object(py))
+            let i = idx.extract::<isize>().unwrap();
+            let collection = model.slice_pin_group(&self.name, i as usize, i as usize, 1)?;
+            Ok(Py::new(py, PinCollection::from(collection))
+                .unwrap()
+                .to_object(py))
         }
-      }
+    }
 }
 
 #[pyproto]
@@ -246,26 +269,26 @@ impl pyo3::class::iter::PyIterProtocol for PinGroup {
 
 #[pyclass]
 pub struct PinGroupIter {
-  keys: Vec<String>,
-  i: usize,
-  model_id: usize,
+    keys: Vec<String>,
+    i: usize,
+    model_id: usize,
 }
 
 #[pyproto]
 impl pyo3::class::iter::PyIterProtocol for PinGroupIter {
-  fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
-    let gil = Python::acquire_gil();
-    let py = gil.python();
-    Ok(slf.to_object(py))
-  }
-
-  fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PinCollection>> {
-    if slf.i >= slf.keys.len() {
-        return Ok(None)
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        Ok(slf.to_object(py))
     }
-    let name = slf.keys[slf.i].clone();
-    let collection = PinCollection::new(slf.model_id, vec!(name), Option::None)?;
-    slf.i += 1;
-    Ok(Some(collection))
-  }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PinCollection>> {
+        if slf.i >= slf.keys.len() {
+            return Ok(None);
+        }
+        let name = slf.keys[slf.i].clone();
+        let collection = PinCollection::new(slf.model_id, vec![name], Option::None)?;
+        slf.i += 1;
+        Ok(Some(collection))
+    }
 }

--- a/rust/origen/src/core/model/pins/pin.rs
+++ b/rust/origen/src/core/model/pins/pin.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use crate::error::Error;
+use std::any::Any;
 
 /// List of supported pin actions.
 #[derive(Debug, Copy, Clone)]
@@ -101,7 +102,8 @@ pub struct Pin {
     /// Any aliases this Pin has.
     pub aliases: Vec<String>,
     pub role: PinRoles,
-    pub meta: HashMap<String, MetaAble>,
+    //pub meta: HashMap<String, MetaAble>,
+    pub meta: HashMap<String, Box<Any + std::marker::Send>>,
 
     // Taking the speed over size here: this'll allow for quick lookups and indexing from pins into the pin group, but will
     // require a bit of extra storage. Since that storage is only a reference and uint, it should be small and well worth the

--- a/rust/origen/src/core/model/pins/pin.rs
+++ b/rust/origen/src/core/model/pins/pin.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
-use std::convert::TryFrom;
 use crate::error::Error;
 use std::any::Any;
+use std::collections::HashMap;
+use std::convert::TryFrom;
 
 /// List of supported pin actions.
 #[derive(Debug, Copy, Clone)]
@@ -23,7 +23,10 @@ impl PinActions {
             "V" => Ok(PinActions::Verify),
             "C" => Ok(PinActions::Capture),
             "Z" => Ok(PinActions::HighZ),
-            _ => Err(Error::new(&format!("Action {} is not available for pins!", s))),
+            _ => Err(Error::new(&format!(
+                "Action {} is not available for pins!",
+                s
+            ))),
         }
     }
 
@@ -59,7 +62,10 @@ impl TryFrom<u8> for PinActions {
             'C' => Ok(PinActions::Capture),
             'z' => Ok(PinActions::HighZ),
             'Z' => Ok(PinActions::HighZ),
-            _ => Err(Error::new(&format!("Cannot derive PinActions enum from encoded character {}!", encoded_char))),
+            _ => Err(Error::new(&format!(
+                "Cannot derive PinActions enum from encoded character {}!",
+                encoded_char
+            ))),
         }
     }
 }
@@ -143,22 +149,32 @@ impl Pin {
             self.data = data;
             Ok(())
         } else {
-            Err(Error::new(&format!("Pin data must be either 0 or 1 - got {}", data)))
+            Err(Error::new(&format!(
+                "Pin data must be either 0 or 1 - got {}",
+                data
+            )))
         }
     }
 
     pub fn reset(&mut self) {
         match self.reset_data {
-            Some(d) => { self.data = d as u8 },
-            None => { self.data = 0; },
+            Some(d) => self.data = d as u8,
+            None => {
+                self.data = 0;
+            }
         }
         match self.reset_action {
-            Some(a) => { self.action = a },
-            None => { self.action = PinActions::HighZ },
+            Some(a) => self.action = a,
+            None => self.action = PinActions::HighZ,
         }
     }
 
-    pub fn new(name: String, path: String, reset_data: Option<u32>, reset_action: Option<PinActions>) -> Pin {
+    pub fn new(
+        name: String,
+        path: String,
+        reset_data: Option<u32>,
+        reset_action: Option<PinActions>,
+    ) -> Pin {
         let mut p = Pin {
             name: name,
             path: path,
@@ -178,6 +194,11 @@ impl Pin {
 
 impl Default for Pin {
     fn default() -> Pin {
-        Self::new(String::from("default"), String::from(""), Option::None, Option::None)
+        Self::new(
+            String::from("default"),
+            String::from(""),
+            Option::None,
+            Option::None,
+        )
     }
 }

--- a/rust/origen/src/core/model/pins/pin.rs
+++ b/rust/origen/src/core/model/pins/pin.rs
@@ -85,7 +85,7 @@ pub enum PinRoles {
 pub struct Pin {
     // Since pins will be added from the add_pin function of Pins,
     // just reuse that String instance instead of creating a new one.
-    pub id: String,
+    pub name: String,
     pub path: String,
     pub data: u8,
 
@@ -156,9 +156,9 @@ impl Pin {
         }
     }
 
-    pub fn new(id: String, path: String, reset_data: Option<u32>, reset_action: Option<PinActions>) -> Pin {
+    pub fn new(name: String, path: String, reset_data: Option<u32>, reset_action: Option<PinActions>) -> Pin {
         let mut p = Pin {
-            id: id,
+            name: name,
             path: path,
             data: 0,
             action: PinActions::HighZ,

--- a/rust/origen/src/core/model/pins/pin_collection.rs
+++ b/rust/origen/src/core/model/pins/pin_collection.rs
@@ -1,5 +1,7 @@
 use crate::error::Error;
 use super::super::pins::{Endianness};
+use super::super::Model;
+use super::pin::{PinActions};
 
 /// Model for a collection (or group) of pins
 #[derive(Debug, Clone)]
@@ -55,5 +57,60 @@ impl PinCollection {
 
   pub fn is_big_endian(&self) -> bool {
     return !self.is_little_endian();
+  }
+}
+
+impl Model {
+  pub fn drive_pin_collection(&mut self, pin_collection: &mut PinCollection, data: Option<u32>) -> Result<(), Error> {
+    self.set_pin_collection_actions(pin_collection, PinActions::Drive, data)
+  }
+
+  pub fn verify_pin_collection(&mut self, pin_collection: &mut PinCollection, data: Option<u32>) -> Result<(), Error> {
+    self.set_pin_collection_actions(pin_collection, PinActions::Verify, data)
+  }
+
+  pub fn capture_pin_collection(&mut self, pin_collection: &mut PinCollection) -> Result<(), Error> {
+    self.set_pin_collection_actions(pin_collection, PinActions::Capture, Option::None)
+  }
+
+  pub fn highz_pin_collection(&mut self, pin_collection: &mut PinCollection) -> Result<(), Error> {
+    self.set_pin_collection_actions(pin_collection, PinActions::HighZ, Option::None)
+  }
+
+  pub fn set_pin_collection_actions(&mut self, collection: &mut PinCollection, action: PinActions, data: Option<u32>) -> Result<(), Error> {
+    let ids = &collection.ids;
+    let mask = collection.mask;
+    collection.mask = Option::None;
+    self.set_pin_actions(ids, action, data, mask)
+  }
+
+  pub fn get_pin_collection_data(&mut self, collection: &PinCollection) -> Result<u32, Error> {
+    let ids = &collection.ids;
+    Ok(self.get_pin_data(&ids))
+  }
+
+  pub fn get_pin_collection_reset_data(&mut self, collection: &PinCollection) -> u32 {
+    let ids = &collection.ids;
+    self.get_pin_reset_data(&ids)
+  }
+
+  pub fn get_pin_collection_reset_actions(&mut self, collection: &PinCollection) -> Result<String, Error> {
+    let ids = &collection.ids;
+    self.get_pin_reset_actions(&ids)
+  }
+
+  pub fn reset_pin_collection(&mut self,collection: &PinCollection) -> Result<(), Error> {
+    let ids = &collection.ids;
+    self.reset_pin_ids(&ids)
+  }
+
+  pub fn set_pin_collection_data(&mut self, collection: &PinCollection, data: u32) -> Result<(), Error> {
+    let ids = &collection.ids;
+    self.set_pin_data(&ids, data, collection.mask)
+  }
+
+  pub fn set_pin_collection_nonsticky_mask(&mut self, pin_collection: &mut PinCollection, mask: usize) -> Result<(), Error> {
+    pin_collection.mask = Some(mask);
+    Ok(())
   }
 }

--- a/rust/origen/src/core/model/pins/pin_collection.rs
+++ b/rust/origen/src/core/model/pins/pin_collection.rs
@@ -6,7 +6,7 @@ use super::pin::{PinActions};
 /// Model for a collection (or group) of pins
 #[derive(Debug, Clone)]
 pub struct PinCollection {
-  pub ids: Vec<String>,
+  pub pin_names: Vec<String>,
   pub endianness: Endianness,
   pub path: String,
   pub mask: Option<usize>,
@@ -14,17 +14,17 @@ pub struct PinCollection {
 }
 
 impl PinCollection {
-  pub fn new(model_id: usize, path: &str, pin_ids: &Vec<String>, endianness: Option<Endianness>) -> PinCollection {
+  pub fn new(model_id: usize, path: &str, pin_names: &Vec<String>, endianness: Option<Endianness>) -> PinCollection {
     PinCollection {
       path: path.to_string(),
-      ids: match endianness {
+      pin_names: match endianness {
         Some(e) => {
           match e {
-            Endianness::LittleEndian => pin_ids.iter().map( |p| String::from(p)).collect(),
-            Endianness::BigEndian => pin_ids.iter().rev().map( |p| String::from(p)).collect(),
+            Endianness::LittleEndian => pin_names.iter().map( |p| String::from(p)).collect(),
+            Endianness::BigEndian => pin_names.iter().rev().map( |p| String::from(p)).collect(),
           }
         },
-        None => pin_ids.iter().map( |p| String::from(p)).collect()
+        None => pin_names.iter().map( |p| String::from(p)).collect()
       },
       endianness: endianness.unwrap_or(Endianness::LittleEndian),
       mask: Option::None,
@@ -33,19 +33,19 @@ impl PinCollection {
   }
 
   pub fn len(&self) -> usize {
-    self.ids.len()
+    self.pin_names.len()
   }
 
-  pub fn slice_ids(&self, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
-    let mut sliced_ids: Vec<String> = vec!();
+  pub fn slice_names(&self, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
+    let mut sliced_names: Vec<String> = vec!();
     for i in (start_idx..=stop_idx).step_by(step_size) {
-        if i >= self.ids.len() {
-          return Err(Error::new(&format!("Index {} exceeds available pins in collection! (length: {})", i, self.ids.len())));
+        if i >= self.pin_names.len() {
+          return Err(Error::new(&format!("Index {} exceeds available pins in collection! (length: {})", i, self.pin_names.len())));
         }
-        let p = self.ids[i].clone();
-        sliced_ids.push(p);
+        let p = self.pin_names[i].clone();
+        sliced_names.push(p);
     }
-    Ok(PinCollection::new(self.model_id, &self.path, &sliced_ids, Option::Some(self.endianness)))
+    Ok(PinCollection::new(self.model_id, &self.path, &sliced_names, Option::Some(self.endianness)))
   }
 
   pub fn is_little_endian(&self) -> bool {
@@ -78,35 +78,35 @@ impl Model {
   }
 
   pub fn set_pin_collection_actions(&mut self, collection: &mut PinCollection, action: PinActions, data: Option<u32>) -> Result<(), Error> {
-    let ids = &collection.ids;
+    let pin_names = &collection.pin_names;
     let mask = collection.mask;
     collection.mask = Option::None;
-    self.set_pin_actions(ids, action, data, mask)
+    self.set_pin_actions(pin_names, action, data, mask)
   }
 
   pub fn get_pin_collection_data(&mut self, collection: &PinCollection) -> Result<u32, Error> {
-    let ids = &collection.ids;
-    Ok(self.get_pin_data(&ids))
+    let pin_names = &collection.pin_names;
+    Ok(self.get_pin_data(&pin_names))
   }
 
   pub fn get_pin_collection_reset_data(&mut self, collection: &PinCollection) -> u32 {
-    let ids = &collection.ids;
-    self.get_pin_reset_data(&ids)
+    let pin_names = &collection.pin_names;
+    self.get_pin_reset_data(&pin_names)
   }
 
   pub fn get_pin_collection_reset_actions(&mut self, collection: &PinCollection) -> Result<String, Error> {
-    let ids = &collection.ids;
-    self.get_pin_reset_actions(&ids)
+    let pin_names = &collection.pin_names;
+    self.get_pin_reset_actions(&pin_names)
   }
 
   pub fn reset_pin_collection(&mut self,collection: &PinCollection) -> Result<(), Error> {
-    let ids = &collection.ids;
-    self.reset_pin_ids(&ids)
+    let pin_names = &collection.pin_names;
+    self.reset_pin_names(&pin_names)
   }
 
   pub fn set_pin_collection_data(&mut self, collection: &PinCollection, data: u32) -> Result<(), Error> {
-    let ids = &collection.ids;
-    self.set_pin_data(&ids, data, collection.mask)
+    let pin_names = &collection.pin_names;
+    self.set_pin_data(&pin_names, data, collection.mask)
   }
 
   pub fn set_pin_collection_nonsticky_mask(&mut self, pin_collection: &mut PinCollection, mask: usize) -> Result<(), Error> {

--- a/rust/origen/src/core/model/pins/pin_collection.rs
+++ b/rust/origen/src/core/model/pins/pin_collection.rs
@@ -1,116 +1,165 @@
-use crate::error::Error;
-use super::super::pins::{Endianness};
+use super::super::pins::Endianness;
 use super::super::Model;
-use super::pin::{PinActions};
+use super::pin::PinActions;
+use crate::error::Error;
 
 /// Model for a collection (or group) of pins
 #[derive(Debug, Clone)]
 pub struct PinCollection {
-  pub pin_names: Vec<String>,
-  pub endianness: Endianness,
-  pub path: String,
-  pub mask: Option<usize>,
-  pub model_id: usize,
+    pub pin_names: Vec<String>,
+    pub endianness: Endianness,
+    pub path: String,
+    pub mask: Option<usize>,
+    pub model_id: usize,
 }
 
 impl PinCollection {
-  pub fn new(model_id: usize, path: &str, pin_names: &Vec<String>, endianness: Option<Endianness>) -> PinCollection {
-    PinCollection {
-      path: path.to_string(),
-      pin_names: match endianness {
-        Some(e) => {
-          match e {
-            Endianness::LittleEndian => pin_names.iter().map( |p| String::from(p)).collect(),
-            Endianness::BigEndian => pin_names.iter().rev().map( |p| String::from(p)).collect(),
-          }
-        },
-        None => pin_names.iter().map( |p| String::from(p)).collect()
-      },
-      endianness: endianness.unwrap_or(Endianness::LittleEndian),
-      mask: Option::None,
-      model_id: model_id,
-    }
-  }
-
-  pub fn len(&self) -> usize {
-    self.pin_names.len()
-  }
-
-  pub fn slice_names(&self, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
-    let mut sliced_names: Vec<String> = vec!();
-    for i in (start_idx..=stop_idx).step_by(step_size) {
-        if i >= self.pin_names.len() {
-          return Err(Error::new(&format!("Index {} exceeds available pins in collection! (length: {})", i, self.pin_names.len())));
+    pub fn new(
+        model_id: usize,
+        path: &str,
+        pin_names: &Vec<String>,
+        endianness: Option<Endianness>,
+    ) -> PinCollection {
+        PinCollection {
+            path: path.to_string(),
+            pin_names: match endianness {
+                Some(e) => match e {
+                    Endianness::LittleEndian => pin_names.iter().map(|p| String::from(p)).collect(),
+                    Endianness::BigEndian => {
+                        pin_names.iter().rev().map(|p| String::from(p)).collect()
+                    }
+                },
+                None => pin_names.iter().map(|p| String::from(p)).collect(),
+            },
+            endianness: endianness.unwrap_or(Endianness::LittleEndian),
+            mask: Option::None,
+            model_id: model_id,
         }
-        let p = self.pin_names[i].clone();
-        sliced_names.push(p);
     }
-    Ok(PinCollection::new(self.model_id, &self.path, &sliced_names, Option::Some(self.endianness)))
-  }
 
-  pub fn is_little_endian(&self) -> bool {
-    match self.endianness {
-      Endianness::LittleEndian => true,
-      Endianness::BigEndian => false,
+    pub fn len(&self) -> usize {
+        self.pin_names.len()
     }
-  }
 
-  pub fn is_big_endian(&self) -> bool {
-    return !self.is_little_endian();
-  }
+    pub fn slice_names(
+        &self,
+        start_idx: usize,
+        stop_idx: usize,
+        step_size: usize,
+    ) -> Result<PinCollection, Error> {
+        let mut sliced_names: Vec<String> = vec![];
+        for i in (start_idx..=stop_idx).step_by(step_size) {
+            if i >= self.pin_names.len() {
+                return Err(Error::new(&format!(
+                    "Index {} exceeds available pins in collection! (length: {})",
+                    i,
+                    self.pin_names.len()
+                )));
+            }
+            let p = self.pin_names[i].clone();
+            sliced_names.push(p);
+        }
+        Ok(PinCollection::new(
+            self.model_id,
+            &self.path,
+            &sliced_names,
+            Option::Some(self.endianness),
+        ))
+    }
+
+    pub fn is_little_endian(&self) -> bool {
+        match self.endianness {
+            Endianness::LittleEndian => true,
+            Endianness::BigEndian => false,
+        }
+    }
+
+    pub fn is_big_endian(&self) -> bool {
+        return !self.is_little_endian();
+    }
 }
 
 impl Model {
-  pub fn drive_pin_collection(&mut self, pin_collection: &mut PinCollection, data: Option<u32>) -> Result<(), Error> {
-    self.set_pin_collection_actions(pin_collection, PinActions::Drive, data)
-  }
+    pub fn drive_pin_collection(
+        &mut self,
+        pin_collection: &mut PinCollection,
+        data: Option<u32>,
+    ) -> Result<(), Error> {
+        self.set_pin_collection_actions(pin_collection, PinActions::Drive, data)
+    }
 
-  pub fn verify_pin_collection(&mut self, pin_collection: &mut PinCollection, data: Option<u32>) -> Result<(), Error> {
-    self.set_pin_collection_actions(pin_collection, PinActions::Verify, data)
-  }
+    pub fn verify_pin_collection(
+        &mut self,
+        pin_collection: &mut PinCollection,
+        data: Option<u32>,
+    ) -> Result<(), Error> {
+        self.set_pin_collection_actions(pin_collection, PinActions::Verify, data)
+    }
 
-  pub fn capture_pin_collection(&mut self, pin_collection: &mut PinCollection) -> Result<(), Error> {
-    self.set_pin_collection_actions(pin_collection, PinActions::Capture, Option::None)
-  }
+    pub fn capture_pin_collection(
+        &mut self,
+        pin_collection: &mut PinCollection,
+    ) -> Result<(), Error> {
+        self.set_pin_collection_actions(pin_collection, PinActions::Capture, Option::None)
+    }
 
-  pub fn highz_pin_collection(&mut self, pin_collection: &mut PinCollection) -> Result<(), Error> {
-    self.set_pin_collection_actions(pin_collection, PinActions::HighZ, Option::None)
-  }
+    pub fn highz_pin_collection(
+        &mut self,
+        pin_collection: &mut PinCollection,
+    ) -> Result<(), Error> {
+        self.set_pin_collection_actions(pin_collection, PinActions::HighZ, Option::None)
+    }
 
-  pub fn set_pin_collection_actions(&mut self, collection: &mut PinCollection, action: PinActions, data: Option<u32>) -> Result<(), Error> {
-    let pin_names = &collection.pin_names;
-    let mask = collection.mask;
-    collection.mask = Option::None;
-    self.set_pin_actions(pin_names, action, data, mask)
-  }
+    pub fn set_pin_collection_actions(
+        &mut self,
+        collection: &mut PinCollection,
+        action: PinActions,
+        data: Option<u32>,
+    ) -> Result<(), Error> {
+        let pin_names = &collection.pin_names;
+        let mask = collection.mask;
+        collection.mask = Option::None;
+        self.set_pin_actions(pin_names, action, data, mask)
+    }
 
-  pub fn get_pin_collection_data(&mut self, collection: &PinCollection) -> Result<u32, Error> {
-    let pin_names = &collection.pin_names;
-    Ok(self.get_pin_data(&pin_names))
-  }
+    pub fn get_pin_collection_data(&mut self, collection: &PinCollection) -> Result<u32, Error> {
+        let pin_names = &collection.pin_names;
+        Ok(self.get_pin_data(&pin_names))
+    }
 
-  pub fn get_pin_collection_reset_data(&mut self, collection: &PinCollection) -> u32 {
-    let pin_names = &collection.pin_names;
-    self.get_pin_reset_data(&pin_names)
-  }
+    pub fn get_pin_collection_reset_data(&mut self, collection: &PinCollection) -> u32 {
+        let pin_names = &collection.pin_names;
+        self.get_pin_reset_data(&pin_names)
+    }
 
-  pub fn get_pin_collection_reset_actions(&mut self, collection: &PinCollection) -> Result<String, Error> {
-    let pin_names = &collection.pin_names;
-    self.get_pin_reset_actions(&pin_names)
-  }
+    pub fn get_pin_collection_reset_actions(
+        &mut self,
+        collection: &PinCollection,
+    ) -> Result<String, Error> {
+        let pin_names = &collection.pin_names;
+        self.get_pin_reset_actions(&pin_names)
+    }
 
-  pub fn reset_pin_collection(&mut self,collection: &PinCollection) -> Result<(), Error> {
-    let pin_names = &collection.pin_names;
-    self.reset_pin_names(&pin_names)
-  }
+    pub fn reset_pin_collection(&mut self, collection: &PinCollection) -> Result<(), Error> {
+        let pin_names = &collection.pin_names;
+        self.reset_pin_names(&pin_names)
+    }
 
-  pub fn set_pin_collection_data(&mut self, collection: &PinCollection, data: u32) -> Result<(), Error> {
-    let pin_names = &collection.pin_names;
-    self.set_pin_data(&pin_names, data, collection.mask)
-  }
+    pub fn set_pin_collection_data(
+        &mut self,
+        collection: &PinCollection,
+        data: u32,
+    ) -> Result<(), Error> {
+        let pin_names = &collection.pin_names;
+        self.set_pin_data(&pin_names, data, collection.mask)
+    }
 
-  pub fn set_pin_collection_nonsticky_mask(&mut self, pin_collection: &mut PinCollection, mask: usize) -> Result<(), Error> {
-    pin_collection.mask = Some(mask);
-    Ok(())
-  }
+    pub fn set_pin_collection_nonsticky_mask(
+        &mut self,
+        pin_collection: &mut PinCollection,
+        mask: usize,
+    ) -> Result<(), Error> {
+        pin_collection.mask = Some(mask);
+        Ok(())
+    }
 }

--- a/rust/origen/src/core/model/pins/pin_group.rs
+++ b/rust/origen/src/core/model/pins/pin_group.rs
@@ -2,6 +2,11 @@
 //use crate::error::Error;
 //use super::super::super::super::DUT;
 use super::super::pins::{Endianness};
+use super::super::Model;
+use super::pin::{PinActions};
+use crate::error::Error;
+use super::pin_collection::PinCollection;
+
 //use crate::core::model::Model;
 
 
@@ -56,4 +61,93 @@ impl PinGroup {
     pub fn is_big_endian(&self) -> bool {
       return !self.is_little_endian();
     }
+}
+
+impl Model {
+  pub fn get_pin_group_data(&self, id: &str) -> u32 {
+    let pin_ids = &self.get_pin_group(id).unwrap().pin_ids;
+    self.get_pin_data(pin_ids)
+  }
+
+  pub fn get_pin_group_reset_data(&self, id: &str) -> u32 {
+    let pin_ids = &self.get_pin_group(id).unwrap().pin_ids;
+    self.get_pin_reset_data(&pin_ids)
+  }
+
+  pub fn reset_pin_group(&mut self, id: &str) -> Result<(), Error> {
+    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
+    self.reset_pin_ids(&pin_ids)
+  }
+
+  pub fn set_pin_group_data(&mut self, id: &str, data: u32) -> Result<(), Error> {
+    let grp = self.get_pin_group(id).unwrap();
+    let m = grp.mask;
+    let pin_ids = grp.pin_ids.clone();
+    self.set_pin_data(&pin_ids, data, m)
+  }
+
+  pub fn resolve_pin_group_ids(&mut self, id: &str) -> Result<Vec<String>, Error> {
+    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
+    self.resolve_pin_ids(&pin_ids)
+  }
+
+  /// Returns the pin actions as a string.
+  /// E.g.: for an 8-pin bus where the two MSBits are driving, the next two are capturing, then next wo are verifying, and the 
+  ///   two LSBits are HighZ, the return value will be "DDCCVVZZ"
+  pub fn get_pin_group_actions(&mut self, id: &str) -> Result<String, Error> {
+    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
+    self.get_pin_actions(&pin_ids)
+  }
+
+  pub fn get_pin_group_reset_actions(&mut self, id: &str) -> Result<String, Error> {
+    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
+    self.get_pin_reset_actions(&pin_ids)
+  }
+
+  pub fn set_pin_group_actions(&mut self, id: &str, action: PinActions, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
+    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
+    self.set_pin_actions(&pin_ids, action, data, mask)
+  }
+
+  pub fn drive_pin_group(&mut self, group_id: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_id, PinActions::Drive, data, mask);
+  }
+
+  pub fn verify_pin_group(&mut self, group_id: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_id, PinActions::Verify, data, mask);
+  }
+
+  pub fn capture_pin_group(&mut self, group_id: &str, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_id, PinActions::Capture, Option::None, mask);
+  }
+
+  pub fn highz_pin_group(&mut self, group_id: &str, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_id, PinActions::HighZ, Option::None, mask);
+  }
+
+  // Assume the pin group is properly defined (that is, not pin duplicates and all pins exists. If the pin group exists, these should both be met)
+  pub fn slice_pin_group(&mut self, id: &str, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
+    if let Some(p) = self.get_pin_group(id) {
+        let ids = &p.pin_ids;
+        let mut sliced_ids: Vec<String> = vec!();
+
+        for i in (start_idx..=stop_idx).step_by(step_size) {
+            if i >= ids.len() {
+                return Err(Error::new(&format!("Index {} exceeds available pins in group {} (length: {})", i, id, ids.len())));
+            }
+            let p = ids[i].clone();
+            sliced_ids.push(p);
+        }
+        Ok(PinCollection::new(self.id, &self.name, &sliced_ids, Option::None))
+        //Ok(PinCollection::new(&self.parent_path, &sliced_ids, Option::None))
+    } else {
+        Err(Error::new(&format!("Could not slice pin group {} because it doesn't exists!", id)))
+    }
+  }
+
+  pub fn set_pin_group_nonsticky_mask(&mut self, id: &str, mask: usize) -> Result<(), Error> {
+      let grp = self._get_mut_pin_group(id)?;
+      grp.mask = Some(mask);
+      Ok(())
+  }
 }

--- a/rust/origen/src/core/model/pins/pin_group.rs
+++ b/rust/origen/src/core/model/pins/pin_group.rs
@@ -1,17 +1,16 @@
 //use super::pin::{PinActions};
 //use crate::error::Error;
 //use super::super::super::super::DUT;
-use super::super::pins::{Endianness};
+use super::super::pins::Endianness;
 use super::super::Model;
-use super::pin::{PinActions};
-use crate::error::Error;
+use super::pin::PinActions;
 use super::pin_collection::PinCollection;
+use crate::error::Error;
 
 //use crate::core::model::Model;
 
-
 // We'll maintain both the pin_names which the group was built with, but we'll also maintain the list
-// of physical names. Even though we can resolve this later, most operations wil 
+// of physical names. Even though we can resolve this later, most operations wil
 #[derive(Debug, Clone)]
 pub struct PinGroup {
     pub name: String,
@@ -22,26 +21,29 @@ pub struct PinGroup {
 }
 
 impl PinGroup {
-    pub fn new(name: String, path: String, pins: Vec<String>, endianness: Option<Endianness>) -> PinGroup {
+    pub fn new(
+        name: String,
+        path: String,
+        pins: Vec<String>,
+        endianness: Option<Endianness>,
+    ) -> PinGroup {
         return PinGroup {
             name: String::from(name),
             path: String::from(path),
             pin_names: match endianness {
-              Some(e) => {
-                match e {
-                  Endianness::LittleEndian => pins,
-                  Endianness::BigEndian => {
-                    let mut _pins = pins.clone();
-                    _pins.reverse();
-                    _pins
-                  }
-                }
-              },
-              None => pins,
+                Some(e) => match e {
+                    Endianness::LittleEndian => pins,
+                    Endianness::BigEndian => {
+                        let mut _pins = pins.clone();
+                        _pins.reverse();
+                        _pins
+                    }
+                },
+                None => pins,
             },
             endianness: match endianness {
-              Some(e) => e,
-              None => Endianness::LittleEndian,
+                Some(e) => e,
+                None => Endianness::LittleEndian,
             },
             mask: Option::None,
         };
@@ -52,101 +54,140 @@ impl PinGroup {
     }
 
     pub fn is_little_endian(&self) -> bool {
-      match self.endianness {
-        Endianness::LittleEndian => true,
-        Endianness::BigEndian => false,
-      }
+        match self.endianness {
+            Endianness::LittleEndian => true,
+            Endianness::BigEndian => false,
+        }
     }
 
     pub fn is_big_endian(&self) -> bool {
-      return !self.is_little_endian();
+        return !self.is_little_endian();
     }
 }
 
 impl Model {
-  pub fn get_pin_group_data(&self, name: &str) -> u32 {
-    let pin_names = &self.get_pin_group(name).unwrap().pin_names;
-    self.get_pin_data(pin_names)
-  }
-
-  pub fn get_pin_group_reset_data(&self, name: &str) -> u32 {
-    let pin_names = &self.get_pin_group(name).unwrap().pin_names;
-    self.get_pin_reset_data(&pin_names)
-  }
-
-  pub fn reset_pin_group(&mut self, name: &str) -> Result<(), Error> {
-    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
-    self.reset_pin_names(&pin_names)
-  }
-
-  pub fn set_pin_group_data(&mut self, name: &str, data: u32) -> Result<(), Error> {
-    let grp = self.get_pin_group(name).unwrap();
-    let m = grp.mask;
-    let pin_names = grp.pin_names.clone();
-    self.set_pin_data(&pin_names, data, m)
-  }
-
-  pub fn resolve_pin_group_names(&mut self, name: &str) -> Result<Vec<String>, Error> {
-    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
-    self.resolve_pin_names(&pin_names)
-  }
-
-  /// Returns the pin actions as a string.
-  /// E.g.: for an 8-pin bus where the two MSBits are driving, the next two are capturing, then next wo are verifying, and the 
-  ///   two LSBits are HighZ, the return value will be "DDCCVVZZ"
-  pub fn get_pin_group_actions(&mut self, name: &str) -> Result<String, Error> {
-    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
-    self.get_pin_actions(&pin_names)
-  }
-
-  pub fn get_pin_group_reset_actions(&mut self, name: &str) -> Result<String, Error> {
-    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
-    self.get_pin_reset_actions(&pin_names)
-  }
-
-  pub fn set_pin_group_actions(&mut self, name: &str, action: PinActions, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
-    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
-    self.set_pin_actions(&pin_names, action, data, mask)
-  }
-
-  pub fn drive_pin_group(&mut self, group_name: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_name, PinActions::Drive, data, mask);
-  }
-
-  pub fn verify_pin_group(&mut self, group_name: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_name, PinActions::Verify, data, mask);
-  }
-
-  pub fn capture_pin_group(&mut self, group_name: &str, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_name, PinActions::Capture, Option::None, mask);
-  }
-
-  pub fn highz_pin_group(&mut self, group_name: &str, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_name, PinActions::HighZ, Option::None, mask);
-  }
-
-  // Assume the pin group is properly defined (that is, not pin duplicates and all pins exists. If the pin group exists, these should both be met)
-  pub fn slice_pin_group(&mut self, name: &str, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
-    if let Some(p) = self.get_pin_group(name) {
-        let names = &p.pin_names;
-        let mut sliced_names: Vec<String> = vec!();
-
-        for i in (start_idx..=stop_idx).step_by(step_size) {
-            if i >= names.len() {
-                return Err(Error::new(&format!("Index {} exceeds available pins in group {} (length: {})", i, name, names.len())));
-            }
-            let p = names[i].clone();
-            sliced_names.push(p);
-        }
-        Ok(PinCollection::new(self.id, &self.name, &sliced_names, Option::None))
-    } else {
-        Err(Error::new(&format!("Could not slice pin group {} because it doesn't exists!", name)))
+    pub fn get_pin_group_data(&self, name: &str) -> u32 {
+        let pin_names = &self.get_pin_group(name).unwrap().pin_names;
+        self.get_pin_data(pin_names)
     }
-  }
 
-  pub fn set_pin_group_nonsticky_mask(&mut self, name: &str, mask: usize) -> Result<(), Error> {
-      let grp = self._get_mut_pin_group(name)?;
-      grp.mask = Some(mask);
-      Ok(())
-  }
+    pub fn get_pin_group_reset_data(&self, name: &str) -> u32 {
+        let pin_names = &self.get_pin_group(name).unwrap().pin_names;
+        self.get_pin_reset_data(&pin_names)
+    }
+
+    pub fn reset_pin_group(&mut self, name: &str) -> Result<(), Error> {
+        let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+        self.reset_pin_names(&pin_names)
+    }
+
+    pub fn set_pin_group_data(&mut self, name: &str, data: u32) -> Result<(), Error> {
+        let grp = self.get_pin_group(name).unwrap();
+        let m = grp.mask;
+        let pin_names = grp.pin_names.clone();
+        self.set_pin_data(&pin_names, data, m)
+    }
+
+    pub fn resolve_pin_group_names(&mut self, name: &str) -> Result<Vec<String>, Error> {
+        let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+        self.resolve_pin_names(&pin_names)
+    }
+
+    /// Returns the pin actions as a string.
+    /// E.g.: for an 8-pin bus where the two MSBits are driving, the next two are capturing, then next wo are verifying, and the
+    ///   two LSBits are HighZ, the return value will be "DDCCVVZZ"
+    pub fn get_pin_group_actions(&mut self, name: &str) -> Result<String, Error> {
+        let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+        self.get_pin_actions(&pin_names)
+    }
+
+    pub fn get_pin_group_reset_actions(&mut self, name: &str) -> Result<String, Error> {
+        let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+        self.get_pin_reset_actions(&pin_names)
+    }
+
+    pub fn set_pin_group_actions(
+        &mut self,
+        name: &str,
+        action: PinActions,
+        data: Option<u32>,
+        mask: Option<usize>,
+    ) -> Result<(), Error> {
+        let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+        self.set_pin_actions(&pin_names, action, data, mask)
+    }
+
+    pub fn drive_pin_group(
+        &mut self,
+        group_name: &str,
+        data: Option<u32>,
+        mask: Option<usize>,
+    ) -> Result<(), Error> {
+        return self.set_pin_group_actions(group_name, PinActions::Drive, data, mask);
+    }
+
+    pub fn verify_pin_group(
+        &mut self,
+        group_name: &str,
+        data: Option<u32>,
+        mask: Option<usize>,
+    ) -> Result<(), Error> {
+        return self.set_pin_group_actions(group_name, PinActions::Verify, data, mask);
+    }
+
+    pub fn capture_pin_group(
+        &mut self,
+        group_name: &str,
+        mask: Option<usize>,
+    ) -> Result<(), Error> {
+        return self.set_pin_group_actions(group_name, PinActions::Capture, Option::None, mask);
+    }
+
+    pub fn highz_pin_group(&mut self, group_name: &str, mask: Option<usize>) -> Result<(), Error> {
+        return self.set_pin_group_actions(group_name, PinActions::HighZ, Option::None, mask);
+    }
+
+    // Assume the pin group is properly defined (that is, not pin duplicates and all pins exists. If the pin group exists, these should both be met)
+    pub fn slice_pin_group(
+        &mut self,
+        name: &str,
+        start_idx: usize,
+        stop_idx: usize,
+        step_size: usize,
+    ) -> Result<PinCollection, Error> {
+        if let Some(p) = self.get_pin_group(name) {
+            let names = &p.pin_names;
+            let mut sliced_names: Vec<String> = vec![];
+
+            for i in (start_idx..=stop_idx).step_by(step_size) {
+                if i >= names.len() {
+                    return Err(Error::new(&format!(
+                        "Index {} exceeds available pins in group {} (length: {})",
+                        i,
+                        name,
+                        names.len()
+                    )));
+                }
+                let p = names[i].clone();
+                sliced_names.push(p);
+            }
+            Ok(PinCollection::new(
+                self.id,
+                &self.name,
+                &sliced_names,
+                Option::None,
+            ))
+        } else {
+            Err(Error::new(&format!(
+                "Could not slice pin group {} because it doesn't exists!",
+                name
+            )))
+        }
+    }
+
+    pub fn set_pin_group_nonsticky_mask(&mut self, name: &str, mask: usize) -> Result<(), Error> {
+        let grp = self._get_mut_pin_group(name)?;
+        grp.mask = Some(mask);
+        Ok(())
+    }
 }

--- a/rust/origen/src/core/model/pins/pin_group.rs
+++ b/rust/origen/src/core/model/pins/pin_group.rs
@@ -10,23 +10,23 @@ use super::pin_collection::PinCollection;
 //use crate::core::model::Model;
 
 
-// We'll maintain both the pin_ids which the group was built with, but we'll also maintain the list
-// of physical IDs. Even though we can resolve this later, most operations wil 
+// We'll maintain both the pin_names which the group was built with, but we'll also maintain the list
+// of physical names. Even though we can resolve this later, most operations wil 
 #[derive(Debug, Clone)]
 pub struct PinGroup {
-    pub id: String,
+    pub name: String,
     pub path: String,
-    pub pin_ids: Vec<String>,
+    pub pin_names: Vec<String>,
     pub endianness: Endianness,
     pub mask: Option<usize>,
 }
 
 impl PinGroup {
-    pub fn new(id: String, path: String, pins: Vec<String>, endianness: Option<Endianness>) -> PinGroup {
+    pub fn new(name: String, path: String, pins: Vec<String>, endianness: Option<Endianness>) -> PinGroup {
         return PinGroup {
-            id: String::from(id),
+            name: String::from(name),
             path: String::from(path),
-            pin_ids: match endianness {
+            pin_names: match endianness {
               Some(e) => {
                 match e {
                   Endianness::LittleEndian => pins,
@@ -48,7 +48,7 @@ impl PinGroup {
     }
 
     pub fn len(&self) -> usize {
-        return self.pin_ids.len();
+        return self.pin_names.len();
     }
 
     pub fn is_little_endian(&self) -> bool {
@@ -64,89 +64,88 @@ impl PinGroup {
 }
 
 impl Model {
-  pub fn get_pin_group_data(&self, id: &str) -> u32 {
-    let pin_ids = &self.get_pin_group(id).unwrap().pin_ids;
-    self.get_pin_data(pin_ids)
+  pub fn get_pin_group_data(&self, name: &str) -> u32 {
+    let pin_names = &self.get_pin_group(name).unwrap().pin_names;
+    self.get_pin_data(pin_names)
   }
 
-  pub fn get_pin_group_reset_data(&self, id: &str) -> u32 {
-    let pin_ids = &self.get_pin_group(id).unwrap().pin_ids;
-    self.get_pin_reset_data(&pin_ids)
+  pub fn get_pin_group_reset_data(&self, name: &str) -> u32 {
+    let pin_names = &self.get_pin_group(name).unwrap().pin_names;
+    self.get_pin_reset_data(&pin_names)
   }
 
-  pub fn reset_pin_group(&mut self, id: &str) -> Result<(), Error> {
-    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
-    self.reset_pin_ids(&pin_ids)
+  pub fn reset_pin_group(&mut self, name: &str) -> Result<(), Error> {
+    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+    self.reset_pin_names(&pin_names)
   }
 
-  pub fn set_pin_group_data(&mut self, id: &str, data: u32) -> Result<(), Error> {
-    let grp = self.get_pin_group(id).unwrap();
+  pub fn set_pin_group_data(&mut self, name: &str, data: u32) -> Result<(), Error> {
+    let grp = self.get_pin_group(name).unwrap();
     let m = grp.mask;
-    let pin_ids = grp.pin_ids.clone();
-    self.set_pin_data(&pin_ids, data, m)
+    let pin_names = grp.pin_names.clone();
+    self.set_pin_data(&pin_names, data, m)
   }
 
-  pub fn resolve_pin_group_ids(&mut self, id: &str) -> Result<Vec<String>, Error> {
-    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
-    self.resolve_pin_ids(&pin_ids)
+  pub fn resolve_pin_group_names(&mut self, name: &str) -> Result<Vec<String>, Error> {
+    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+    self.resolve_pin_names(&pin_names)
   }
 
   /// Returns the pin actions as a string.
   /// E.g.: for an 8-pin bus where the two MSBits are driving, the next two are capturing, then next wo are verifying, and the 
   ///   two LSBits are HighZ, the return value will be "DDCCVVZZ"
-  pub fn get_pin_group_actions(&mut self, id: &str) -> Result<String, Error> {
-    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
-    self.get_pin_actions(&pin_ids)
+  pub fn get_pin_group_actions(&mut self, name: &str) -> Result<String, Error> {
+    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+    self.get_pin_actions(&pin_names)
   }
 
-  pub fn get_pin_group_reset_actions(&mut self, id: &str) -> Result<String, Error> {
-    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
-    self.get_pin_reset_actions(&pin_ids)
+  pub fn get_pin_group_reset_actions(&mut self, name: &str) -> Result<String, Error> {
+    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+    self.get_pin_reset_actions(&pin_names)
   }
 
-  pub fn set_pin_group_actions(&mut self, id: &str, action: PinActions, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
-    let pin_ids = self.get_pin_group(id).unwrap().pin_ids.clone();
-    self.set_pin_actions(&pin_ids, action, data, mask)
+  pub fn set_pin_group_actions(&mut self, name: &str, action: PinActions, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
+    let pin_names = self.get_pin_group(name).unwrap().pin_names.clone();
+    self.set_pin_actions(&pin_names, action, data, mask)
   }
 
-  pub fn drive_pin_group(&mut self, group_id: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_id, PinActions::Drive, data, mask);
+  pub fn drive_pin_group(&mut self, group_name: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_name, PinActions::Drive, data, mask);
   }
 
-  pub fn verify_pin_group(&mut self, group_id: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_id, PinActions::Verify, data, mask);
+  pub fn verify_pin_group(&mut self, group_name: &str, data: Option<u32>, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_name, PinActions::Verify, data, mask);
   }
 
-  pub fn capture_pin_group(&mut self, group_id: &str, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_id, PinActions::Capture, Option::None, mask);
+  pub fn capture_pin_group(&mut self, group_name: &str, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_name, PinActions::Capture, Option::None, mask);
   }
 
-  pub fn highz_pin_group(&mut self, group_id: &str, mask: Option<usize>) -> Result<(), Error> {
-    return self.set_pin_group_actions(group_id, PinActions::HighZ, Option::None, mask);
+  pub fn highz_pin_group(&mut self, group_name: &str, mask: Option<usize>) -> Result<(), Error> {
+    return self.set_pin_group_actions(group_name, PinActions::HighZ, Option::None, mask);
   }
 
   // Assume the pin group is properly defined (that is, not pin duplicates and all pins exists. If the pin group exists, these should both be met)
-  pub fn slice_pin_group(&mut self, id: &str, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
-    if let Some(p) = self.get_pin_group(id) {
-        let ids = &p.pin_ids;
-        let mut sliced_ids: Vec<String> = vec!();
+  pub fn slice_pin_group(&mut self, name: &str, start_idx: usize, stop_idx: usize, step_size: usize) -> Result<PinCollection, Error> {
+    if let Some(p) = self.get_pin_group(name) {
+        let names = &p.pin_names;
+        let mut sliced_names: Vec<String> = vec!();
 
         for i in (start_idx..=stop_idx).step_by(step_size) {
-            if i >= ids.len() {
-                return Err(Error::new(&format!("Index {} exceeds available pins in group {} (length: {})", i, id, ids.len())));
+            if i >= names.len() {
+                return Err(Error::new(&format!("Index {} exceeds available pins in group {} (length: {})", i, name, names.len())));
             }
-            let p = ids[i].clone();
-            sliced_ids.push(p);
+            let p = names[i].clone();
+            sliced_names.push(p);
         }
-        Ok(PinCollection::new(self.id, &self.name, &sliced_ids, Option::None))
-        //Ok(PinCollection::new(&self.parent_path, &sliced_ids, Option::None))
+        Ok(PinCollection::new(self.id, &self.name, &sliced_names, Option::None))
     } else {
-        Err(Error::new(&format!("Could not slice pin group {} because it doesn't exists!", id)))
+        Err(Error::new(&format!("Could not slice pin group {} because it doesn't exists!", name)))
     }
   }
 
-  pub fn set_pin_group_nonsticky_mask(&mut self, id: &str, mask: usize) -> Result<(), Error> {
-      let grp = self._get_mut_pin_group(id)?;
+  pub fn set_pin_group_nonsticky_mask(&mut self, name: &str, mask: usize) -> Result<(), Error> {
+      let grp = self._get_mut_pin_group(name)?;
       grp.mask = Some(mask);
       Ok(())
   }


### PR DESCRIPTION
Some work on reorganizing and cleaning up the pins implementation from #21. I've got both mutable and immutable accessors and did away with some unnecessary copying. Per #40, I also rebranded `id` to `name`, so the API changed slightly, but nothing too major. Basically just a find & replace from `id` to `name`.

This appears as though there's a lot of changes, but the TL;DR is:
* `id` is now `name`
* Pins implementation split out to multiple files.