### PR TITLE
Added programmatic add_sub_block API

### DIFF
--- a/example/example/blocks/core/sub_blocks.py
+++ b/example/example/blocks/core/sub_blocks.py
@@ -1,2 +1,2 @@
-sub_block("adc0", block_path="adc.16_bit")
-sub_block("adc1", block_path="adc.8_bit")
+SubBlock("adc0", block_path="adc.16_bit")
+SubBlock("adc1", block_path="adc.8_bit")

--- a/example/example/blocks/dut/sub_blocks.py
+++ b/example/example/blocks/dut/sub_blocks.py
@@ -1,4 +1,4 @@
-sub_block("core0", block_path="core")
-sub_block("core1", block_path="core")
-sub_block("core2", block_path="core")
-sub_block("core3", block_path="core")
+SubBlock("core0", block_path="core")
+SubBlock("core1", block_path="core")
+SubBlock("core2", block_path="core")
+SubBlock("core3", block_path="core")

--- a/example/tests/sub_blocks_test.py
+++ b/example/tests/sub_blocks_test.py
@@ -1,0 +1,20 @@
+import origen
+
+def test_sub_blocks_can_be_added():
+    origen.app.instantiate_dut("dut.falcon")
+    assert origen.dut.sub_blocks.len() == 4
+    assert list(origen.dut.sub_blocks.keys()) == ['core0', 'core1', 'core2', 'core3']
+
+    # Test adding a sub_block to the top-level
+    block = origen.dut.add_sub_block("core4", block_path="core")
+    assert origen.dut.sub_blocks.len() == 5
+    assert list(origen.dut.sub_blocks.keys()) == ['core0', 'core1', 'core2', 'core3', 'core4']
+    assert block.name == "core4"
+
+    # Test adding a sub_block to an embedded block...
+    assert origen.dut.core0.adc0.sub_blocks.len() == 0
+    assert list(origen.dut.core0.adc0.sub_blocks.keys()) == []
+    block = origen.dut.core0.adc0.add_sub_block("my_block", block_path="adc.8_bit")
+    assert origen.dut.core0.adc0.sub_blocks.len() == 1
+    assert list(origen.dut.core0.adc0.sub_blocks.keys()) == ["my_block"]
+    assert block.name == "my_block"

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -2,6 +2,7 @@ import origen
 import _origen
 from origen import pins
 from origen.registers import Loader as RegLoader
+from origen.sub_blocks import Loader as SubBlockLoader
 from contextlib import contextmanager
 
 class Proxies:
@@ -130,6 +131,10 @@ class Base:
     def add_reg(self, *args, **kwargs):
         with RegLoader(self).Reg(*args, **kwargs) as reg:
             yield reg
+
+    def add_sub_block(self, *args, **kwargs):
+        self._load_sub_blocks()
+        return SubBlockLoader(self).sub_block(*args, **kwargs)
 
     def _load_regs(self):
         if not self.regs_loaded:

--- a/python/origen/sub_blocks.py
+++ b/python/origen/sub_blocks.py
@@ -54,5 +54,5 @@ class Loader:
     # Defines the methods that are accessible within blocks/<block>/sub_blocks.py
     def api(self):
         return {
-            "sub_block": self.sub_block, 
+            "SubBlock": self.sub_block, 
         }


### PR DESCRIPTION
@info-rchitect this gives the missing API to add sub_blocks programmatically for your importer.

I also changed the method in sub_blocks.py files to be `SubBlock` to align with latest regs API and to give the user the impression that they are instantiating an object

@coreyeng, we need to build out the pins Loader at some point (just a gentle reminder, no rush but @info-rchitect will be looking for it eventually). We should follow a similar API as established by regs and sub-blocks, i.e. `Pin("my_pin")`

One thing I just noticed is that in my test I had to do:

~~~python
assert list(origen.dut.sub_blocks.keys()) == ['core0', 'core1', 'core2', 'core3']
~~~

whereas in the similar regs test @info-rchitect used:

~~~python
assert origen.dut.regs.keys() == ['reg0', 'reg1', 'reg2']
~~~

The difference is that the sub_blocks `keys()` method is implemented in Python and the others are implemented in Rust.
It seems that `keys()` returns an iterator view in Python 3 - https://stackoverflow.com/questions/31837161/python-difference-between-listdict-and-dict-keys/31837256

I'm not sure if it will be possible to return a similar iterator from the Rust-implemented dict-likes or not, though we could return a list from the `sub_blocks.keys()` for consistency if we wanted to.

 Is this something you have noticed @coreyeng?


