### PR TITLE
Prototyping of pin (and general) metadata

### DIFF
--- a/example/example/blocks/dut/derivatives/eagle/pins.py
+++ b/example/example/blocks/dut/derivatives/eagle/pins.py
@@ -1,0 +1,5 @@
+Pin("porta", width= 2)
+Pin("portb", width= 4)
+Pin("portc", width=2, reset_data=0b11)
+Pin("clk", reset_data=0, reset_action="D")
+Alias("clk", "swd_clk", "tclk")

--- a/python/origen/application.py
+++ b/python/origen/application.py
@@ -88,6 +88,10 @@ class Base:
                     from origen.sub_blocks import Loader
                     context = Loader(controller).api()
 
+                elif filename == "pins.py":
+                    from origen.pins import Loader
+                    context = Loader(controller).api()
+
                 else:
                     block = controller
                     context = locals()

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -49,6 +49,7 @@ class Base:
         self.__proxies__ = Proxies(self)
         self.regs_loaded = False
         self.sub_blocks_loaded = False
+        self.pins_loaded = False
 
     # This lazy-loads the block's files the first time a given resource is referenced
     def __getattr__(self, name):
@@ -72,6 +73,7 @@ class Base:
             self.__proxies__["pins"] = proxy
             for method in pins.Proxy.api():
                 self.__setattr__(method, getattr(proxy, method))
+            self._load_pins()
             return eval(f"self.{name}")
         
         elif name == "memory_maps":
@@ -142,6 +144,11 @@ class Base:
             self.sub_blocks = Proxy(self)
             self.app.load_block_files(self, "sub_blocks.py")
             self.sub_blocks_loaded = True
+    
+    def _load_pins(self):
+        if not self.pins_loaded:
+            self.app.load_block_files(self, "pins.py")
+            self.pins_loaded = True
 
 # The base class of all Origen controller objects which are also
 # the top-level (DUT)

--- a/python/origen/pins.py
+++ b/python/origen/pins.py
@@ -42,3 +42,15 @@ class Proxy:
 class Loader:
   def __init__(self, controller):
     self.controller = controller
+
+  def Pin(self, name, **kwargs):
+    self.controller.add_pin(name, **kwargs)
+
+  def Alias(self, name, *aliases):
+    self.controller.add_pin_alias(name, *aliases)
+
+  def api(self):
+      return {
+          "Pin": self.Pin,
+          "Alias": self.Alias,
+      }

--- a/rust/origen/pyapi/src/dut.rs
+++ b/rust/origen/pyapi/src/dut.rs
@@ -2,6 +2,9 @@ use crate::pins::PyInit_pins;
 use origen::DUT;
 use pyo3::prelude::*;
 use pyo3::wrap_pymodule;
+#[allow(unused_imports)]
+use pyo3::types::{PyAny, PyBytes, PyDict, PyIterator, PyList, PySlice, PyTuple};
+use origen::error::Error;
 
 /// Implements the module _origen.dut in Python which exposes all
 /// DUT-related APIs
@@ -15,7 +18,9 @@ pub fn dut(_py: Python, m: &PyModule) -> PyResult<()> {
 
 #[pyclass]
 #[derive(Debug)]
-pub struct PyDUT {}
+pub struct PyDUT {
+    metadata: Vec<PyObject>,
+}
 
 #[pymethods]
 impl PyDUT {
@@ -23,7 +28,7 @@ impl PyDUT {
     /// Instantiating a new instance of PyDUT means re-loading the target
     fn new(obj: &PyRawObject, name: &str) {
         DUT.lock().unwrap().change(name);
-        obj.init({ PyDUT {} });
+        obj.init({ PyDUT { metadata: vec!() } });
     }
 
     /// Creates a new model at the given path
@@ -43,4 +48,31 @@ impl PyDUT {
             .unwrap()
             .create_reg(address_block_id, name, offset, size)?)
     }
+
+    pub fn push_metadata(&mut self, item: &PyAny) -> usize {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        
+        self.metadata.push(item.to_object(py));
+        self.metadata.len() - 1
+    }
+
+    pub fn override_metadata_at(&mut self, idx: usize, item: &PyAny) -> PyResult<()> {
+        let gil = Python::acquire_gil();
+        let py = gil.python();
+        if self.metadata.len() > idx {
+            self.metadata[idx] = item.to_object(py);
+            Ok(())
+        } else {
+            Err(PyErr::from(Error::new(&format!("Overriding metadata at {} exceeds the size of the current metadata vector!", idx))))
+        }
+    }
+
+    pub fn get_metadata(&self, idx: usize) -> PyResult<&PyObject> {
+        Ok(&self.metadata[idx])
+    }
+}
+
+impl PyDUT {
+
 }

--- a/rust/origen/src/core/model/pins/pin.rs
+++ b/rust/origen/src/core/model/pins/pin.rs
@@ -101,7 +101,6 @@ pub struct Pin {
     /// Any aliases this Pin has.
     pub aliases: Vec<String>,
     pub role: PinRoles,
-    //pub meta: HashMap<String, MetaAble>,
     pub metadata: IndexMap<String, usize>,
 
     // Taking the speed over size here: this'll allow for quick lookups and indexing from pins into the pin group, but will


### PR DESCRIPTION
Hello. Here's a prototype for `metadata`, or interacting with and keeping track of arbitrary Python objects. I tried a couple different schemes but moving things into and out of the Python heap is tricky and ultimately I couldn't get something out of the heap, then back into it as a reference (well, at least not without going into either thread-unsafe or memory-unsafe features).

I settled on a similar scheme to what @ginty did for #40, where there's a vector of _things_ (`PyObjects`) that live in the `PyDUT` (or in the Python heap) and underlying Rust objects (`Pins`) store indices to that _vector of things_.

So far I've only added metadata for `Physical Pins`, but anything should able to use this. The [Pin struct in the PyApi](https://github.com/Origen-SDK/o2/commit/c2535ee2e4f27f9308fc593c7eb39998068a1217#diff-b474d0561ebcb8bd29300fae518d188dR31-R93) has some examples of using the aforementioned vector.

I did this over a pure Python implementation so we can use metadata in both Python or Rust. Again, this doesn't need to be solely for pin-like metadata, but can be used to store any Python references that we'll need and I think can bridge the gap between Python and Rust.

Anyway, [here's the specs](https://github.com/Origen-SDK/o2/blob/pins_wip/example/tests/pin_api_test.py#L824-L882). __Disclaimer__: I put very little effort into rolling a full `metadata API`. I'm really just going for a proof of concept, so any feedback is welcome. One thing I think we could do is make everything just have a single `metadata dict`, like we had in O1. Its a bit more difficult to get an individual item out of that on the Rust side, but would probably be more user friendly. Or we can roll or own `dict-like` container for metadata, like we've doing for pins, regs, etc. In either case, a collection of dictionaries wasn't a very interesting application of this, so I split the metadata up individually for now.