### PR TITLE
Timing2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,13 @@ rust:
 # For the backend, only a single Python version is needed.
 # For the frontend, it'll be tested against the Python versions below, corresponding to the latest Chocolately release for 3.6, 3.7, and 3.8.
 # Additional Python versions, or even frontend lanuages, can be added here as needed.
+# Note: I'm not sure why the LIBPYTHON doesn't necessarily match the Python version. But, going with what gets installed 
+# -
 env:
-  - O2_REGRESSION=BACKEND O2_PYTHON_VERSION=3.8.1 LINUX_BIN_PATH=3.8
-  - O2_REGRESSION=FRONTEND O2_PYTHON_VERSION=3.8.1 LINUX_BIN_PATH=3.8
-  - O2_REGRESSION=FRONTEND O2_PYTHON_VERSION=3.7.6 LINUX_BIN_PATH=3.7
-  - O2_REGRESSION=FRONTEND O2_PYTHON_VERSION=3.6.8 LINUX_BIN_PATH=3.6
+  - O2_REGRESSION=BACKEND O2_PYTHON_VERSION=3.8.1 LINUX_BIN_PATH=3.8 LIBPYTHON_PATH=3.8.0
+  - O2_REGRESSION=FRONTEND O2_PYTHON_VERSION=3.8.1 LINUX_BIN_PATH=3.8 LIBPYTHON_PATH=3.8.0
+  - O2_REGRESSION=FRONTEND O2_PYTHON_VERSION=3.7.6 LINUX_BIN_PATH=3.7 LIBPYTHON_PATH=3.7.2
+  - O2_REGRESSION=FRONTEND O2_PYTHON_VERSION=3.6.8 LINUX_BIN_PATH=3.6 LIBPYTHON_PATH=3.6.8
 
 # We cannot pass files between builds without using a dummy repo or something similiar. Instead, we'll indicate Rust as the main language above and install
 # Python manually. This works out alright since the Windows environment need Python manually installed anyway.
@@ -35,18 +37,19 @@ before_install:
       if [ "${O2_REGRESSION}" == "FRONTEND" ]; then source ~/virtualenv/python$LINUX_BIN_PATH/bin/activate; fi
 
       # Not sure why, but the above activition doesn't seem to add these. Need to do this ourselves.
-      #export LD_LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
-      #export LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
-      #echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-      #echo "LIBRARY_PATH: ${LIBRARY_PATH}"
+      # Keeping some of the below for debug
+      export LD_LIBRARY_PATH=/opt/python/${LIBPYTHON_PATH}/lib
+      export LIBRARY_PATH=/opt/python/${LIBPYTHON_PATH}/lib
+      echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+      echo "LIBRARY_PATH: ${LIBRARY_PATH}"
       which python3
       which python
       python -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))'
-      ls /opt/python/3.8.0/lib -R
-      ls /home/travis/virtualenv/python3.8.0/bin/python3 -R
+      ls /opt/python/
+      #ls /home/travis/virtualenv/python3.8.0/bin/python3 -R
       #ls /home/travis/virtualenv/python3.8.0/bin/python3
       #ls /home/travis/virtualenv/python3.8.0/bin/python3/*
-      #ls $LD_LIBRARY_PATH
+      ls $LD_LIBRARY_PATH
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ before_install:
       #echo "LIBRARY_PATH: ${LIBRARY_PATH}"
       which python3
       which python
-      python -c 'from distutils import sysconfig; print sysconfig.get_config_var("LIBDIR")'
+      python -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))'
+      ls /home/travis/virtualenv/python3.8.0/bin/python3
+      ls /home/travis/virtualenv/python3.8.0/bin/python3/*
       #ls $LD_LIBRARY_PATH
     fi
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,12 @@ before_install:
       curl -sSf --retry 5 -o python-${LINUX_BIN_PATH}.tar.bz2 ${archive_url}
       sudo tar xjf python-${LINUX_BIN_PATH}.tar.bz2 --directory /
       if [ "${O2_REGRESSION}" == "FRONTEND" ]; then source ~/virtualenv/python$LINUX_BIN_PATH/bin/activate; fi
+
+      # Not sure why, but the above activition doesn't seem to add these. Need to do this ourselves.
+      export LD_LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu:$LD_LIBRARY_PATH
+      export LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu:$LD_LIBRARY_PATH
+      echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+      echo "LIBRARY_PATH: ${LIBRARY_PATH}"
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ before_install:
       #echo "LIBRARY_PATH: ${LIBRARY_PATH}"
       which python3
       which python
-      python -c 'from distutils import sysconfig; print sysconfig.get_config_var("LIBDIR")')
-      ls $LD_LIBRARY_PATH
+      python -c 'from distutils import sysconfig; print sysconfig.get_config_var("LIBDIR")'
+      #ls $LD_LIBRARY_PATH
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,11 @@ before_install:
       if [ "${O2_REGRESSION}" == "FRONTEND" ]; then source ~/virtualenv/python$LINUX_BIN_PATH/bin/activate; fi
 
       # Not sure why, but the above activition doesn't seem to add these. Need to do this ourselves.
-      export LD_LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu:$LD_LIBRARY_PATH
-      export LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu:$LD_LIBRARY_PATH
+      export LD_LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
+      export LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
       echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
       echo "LIBRARY_PATH: ${LIBRARY_PATH}"
+      ls $LD_LIBRARY_PATH
     fi
   - python --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,17 +38,16 @@ before_install:
 
       # Not sure why, but the above activition doesn't seem to add these. Need to do this ourselves.
       # Keeping some of the below for debug
+      # Note: these are blank at the start, so just setting them.
+      echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+      echo "LIBRARY_PATH: ${LIBRARY_PATH}"
       export LD_LIBRARY_PATH=/opt/python/${LIBPYTHON_PATH}/lib
       export LIBRARY_PATH=/opt/python/${LIBPYTHON_PATH}/lib
       echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
       echo "LIBRARY_PATH: ${LIBRARY_PATH}"
       which python3
-      which python
       python -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))'
       ls /opt/python/
-      #ls /home/travis/virtualenv/python3.8.0/bin/python3 -R
-      #ls /home/travis/virtualenv/python3.8.0/bin/python3
-      #ls /home/travis/virtualenv/python3.8.0/bin/python3/*
       ls $LD_LIBRARY_PATH
     fi
   - python --version
@@ -73,5 +72,5 @@ script:
       cd ../../example
       ../rust/origen/target/debug/origen -v
       ../rust/origen/target/debug/origen setup
-      $HOME/.poetry/bin/poetry run pytest
+      $HOME/.poetry/bin/poetry run pytest -vv
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,13 @@ before_install:
       if [ "${O2_REGRESSION}" == "FRONTEND" ]; then source ~/virtualenv/python$LINUX_BIN_PATH/bin/activate; fi
 
       # Not sure why, but the above activition doesn't seem to add these. Need to do this ourselves.
-      export LD_LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
-      export LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
-      echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
-      echo "LIBRARY_PATH: ${LIBRARY_PATH}"
+      #export LD_LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
+      #export LIBRARY_PATH=/usr/lib/python${LINUX_BIN_PATH}m/config-${LINUX_BIN_PATH}m-x86_64-linux-gnu
+      #echo "LD_LIBRARY_PATH: ${LD_LIBRARY_PATH}"
+      #echo "LIBRARY_PATH: ${LIBRARY_PATH}"
+      which python3
+      which python
+      python -c 'from distutils import sysconfig; print sysconfig.get_config_var("LIBDIR")')
       ls $LD_LIBRARY_PATH
     fi
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,10 @@ before_install:
       which python3
       which python
       python -c 'from distutils import sysconfig; print(sysconfig.get_config_var("LIBDIR"))'
-      ls /home/travis/virtualenv/python3.8.0/bin/python3
-      ls /home/travis/virtualenv/python3.8.0/bin/python3/*
+      ls /opt/python/3.8.0/lib -R
+      ls /home/travis/virtualenv/python3.8.0/bin/python3 -R
+      #ls /home/travis/virtualenv/python3.8.0/bin/python3
+      #ls /home/travis/virtualenv/python3.8.0/bin/python3/*
       #ls $LD_LIBRARY_PATH
     fi
   - python --version

--- a/example/example/blocks/dut/derivatives/eagle/pins.py
+++ b/example/example/blocks/dut/derivatives/eagle/pins.py
@@ -1,3 +1,4 @@
+# pylint: disable=undefined-variable
 Pin("porta", width= 2)
 Pin("portb", width= 4)
 Pin("portc", width=2, reset_data=0b11)

--- a/example/example/blocks/dut/derivatives/eagle/timing.py
+++ b/example/example/blocks/dut/derivatives/eagle/timing.py
@@ -1,0 +1,4 @@
+# pylint: disable=undefined-variable
+Timeset("simple", default_period=10)
+t = Timeset("complex")
+wtbl = t.add_wavetable("wtbl")

--- a/example/tests/shared/python_like_apis.py
+++ b/example/tests/shared/python_like_apis.py
@@ -1,0 +1,291 @@
+import pytest, abc
+
+# Test Dict-Like API
+class Fixture_DictLikeAPI(abc.ABC):
+  class Expected:
+    def __init__(self, parameters):
+      self.keys = parameters["keys"]
+      self.klass = parameters["klass"]
+      self.not_in_dut = parameters["not_in_dut"]
+
+    @property
+    def len(self):
+      return len(self.keys)
+    
+    @property
+    def in_dut(self):
+      return self.keys[0]
+
+  @abc.abstractmethod
+  def boot_dict_under_test(self):
+    pass
+
+  @abc.abstractmethod
+  def parameterize(self):
+    pass
+
+  # Pytest skips classes which have an __init__ constructor (http://doc.pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery)
+  # get around this by using a fixture on the first test to boot the object.
+  @pytest.fixture
+  def boot(self):
+    self.expected = self.Expected(self.parameterize())
+    self.dut = self.boot_dict_under_test()
+    print("Booted!")
+
+  def test_keys(self, boot):
+    assert self.dut.keys
+    assert isinstance(self.dut.keys(), list)
+    assert self.dut.keys() == self.expected.keys
+
+  def test_values(self, boot):
+    assert self.dut.values
+    assert isinstance(self.dut.values(), list)
+    assert len(self.dut.values()) == self.expected.len
+    assert isinstance(self.dut.values()[0], self.expected.klass)
+
+  def test_items(self, boot):
+    items = self.dut.items()
+    assert items
+    assert isinstance(items, list)
+    assert isinstance(items[0], tuple)
+    assert len(items) == self.expected.len
+    assert list(i[0] for i in items) == self.expected.keys
+
+  def test_contains(self, boot):
+    assert self.expected.in_dut in self.dut
+    assert self.expected.not_in_dut not in self.dut
+
+  def test_len(self, boot):
+    assert self.dut.__len__
+    assert len(self.dut) == self.expected.len
+
+  def test_getitem(self, boot):
+    assert self.dut.get
+    assert self.dut.get(self.expected.in_dut)
+    assert self.dut.get(self.expected.not_in_dut) is None
+
+  def test_index_notation(self, boot):
+    assert self.dut[self.expected.in_dut]
+    with pytest.raises(KeyError):
+      self.dut[self.expected.not_in_dut]
+
+  def test_iterating(self, boot):
+    i = 0
+    for _i, k in enumerate(self.dut):
+      assert k == self.expected.keys[_i]
+      i += 1
+    assert i == self.expected.len
+
+  def test_iterating_through_items(self, boot):
+    i = 0
+    for _i, (k, v) in enumerate(self.dut.items()):
+      assert k == self.expected.keys[_i]
+      assert isinstance(v, self.expected.klass)
+      i += 1
+    assert i == self.expected.len
+
+  def test_dict_conversion(self, boot):
+    d = dict(self.dut)
+    assert isinstance(d, dict)
+    assert list(d.keys()) == self.expected.keys
+
+  def test_list_converstion(self, boot):
+    l = list(self.dut)
+    assert isinstance(l, list)
+    assert l == self.expected.keys
+
+# Test Dict-Like API
+class Fixture_ListLikeAPI(abc.ABC):
+  class Expected:
+    def __init__(self, parent, parameters):
+      self.parent = parent
+      self.slice_klass = parameters.get("slice_klass", list)
+    
+    @property
+    def len(self):
+      return 3
+
+    def verify_i0(self, i):
+      return self.parent.verify_i0(i)
+
+    def verify_i1(self, i):
+      return self.parent.verify_i1(i)
+
+    def verify_i2(self, i):
+      return self.parent.verify_i2(i)
+
+  def parameterize(self):
+    return {}
+
+  @abc.abstractmethod
+  def boot_list_under_test(self):
+    ...
+
+  @abc.abstractmethod
+  def verify_i0(self, i):
+    ...
+
+  @abc.abstractmethod
+  def verify_i1(self, i):
+    ...
+
+  @abc.abstractmethod
+  def verify_i2(self, i):
+    ...
+
+  @pytest.fixture
+  def boot(self):
+    self.expected = self.Expected(self, self.parameterize())
+    self.lut = self.boot_list_under_test()
+  
+  def test_len(self, boot):
+    assert self.lut.__len__
+    assert len(self.lut) == self.expected.len
+  
+  def test_indexing(self, boot):
+    i0 = self.lut[0]
+    i1 = self.lut[1]
+    i2 = self.lut[2]
+    self.expected.verify_i0(i0)
+    self.expected.verify_i1(i1)
+    self.expected.verify_i2(i2)
+
+  def test_negative_indexing(self, boot):
+    i0 = self.lut[-3]
+    i1 = self.lut[-2]
+    i2 = self.lut[-1]
+    self.expected.verify_i0(i0)
+    self.expected.verify_i1(i1)
+    self.expected.verify_i2(i2)
+
+  def test_range_a(self, boot):
+    items = self.lut[:2]
+    assert isinstance(items, self.expected.slice_klass)
+    assert len(items) == 2
+    self.expected.verify_i0(items[0])
+    self.expected.verify_i1(items[1])
+
+  def test_range_b(self, boot):
+    items = self.lut[1:]
+    assert isinstance(items, self.expected.slice_klass)
+    assert len(items) == 2
+    self.expected.verify_i1(items[0])
+    self.expected.verify_i2(items[1])
+
+  def test_range_c(self, boot):
+    items = self.lut[:]
+    assert isinstance(items, self.expected.slice_klass)
+    assert len(items) == 3
+    self.expected.verify_i0(items[0])
+    self.expected.verify_i1(items[1])
+    self.expected.verify_i2(items[2])
+
+  def test_range_d(self, boot):
+    items = self.lut[::2]
+    assert isinstance(items, self.expected.slice_klass)
+    assert len(items) == 2
+    self.expected.verify_i0(items[0])
+    self.expected.verify_i2(items[1])
+
+  def test_range_e(self, boot):
+    items = self.lut[0:2]
+    assert isinstance(items, self.expected.slice_klass)
+    assert len(items) == 2
+    self.expected.verify_i0(items[0])
+    self.expected.verify_i1(items[1])
+
+  def test_negative_range_a(self, boot):
+    ritems = self.lut[-2:]
+    assert isinstance(ritems, self.expected.slice_klass)
+    assert len(ritems) == 2
+    self.expected.verify_i1(ritems[0])
+    self.expected.verify_i2(ritems[1])
+
+  def test_negative_range_b(self, boot):
+    ritems = self.lut[:-1]
+    assert isinstance(ritems, self.expected.slice_klass)
+    assert len(ritems) == 2
+    self.expected.verify_i0(ritems[0])
+    self.expected.verify_i1(ritems[1])
+
+  def test_range_reversal_a(self, boot):
+    ritems = self.lut[::-1]
+    assert isinstance(ritems, self.expected.slice_klass)
+    assert len(ritems) == 3
+    self.expected.verify_i2(ritems[0])
+    self.expected.verify_i1(ritems[1])
+    self.expected.verify_i0(ritems[2])
+
+  def test_range_reversal_b(self, boot):
+    ritems = self.lut[2:0:-1]
+    assert isinstance(ritems, self.expected.slice_klass)
+    assert len(ritems) == 2
+    self.expected.verify_i2(ritems[0])
+    self.expected.verify_i1(ritems[1])
+
+  def test_range_reversal_c(self, boot):
+    ritems = self.lut[::-2]
+    assert isinstance(ritems, self.expected.slice_klass)
+    assert len(ritems) == 2
+    self.expected.verify_i2(ritems[0])
+    self.expected.verify_i0(ritems[1])
+
+  def test_iterating(self, boot):
+    for i, x in enumerate(self.lut):
+      getattr(self.expected, f"verify_i{i}")(x)
+  
+  #def test_contains(self, boot):
+  #  assert self.expected.in_list in self.lut
+  #  assert self.expected.not_in_list not in self.lut
+  
+  def test_list(self, boot):
+    l = list(self.lut)
+    assert isinstance(l, list)
+    assert len(l) == 3
+    self.expected.verify_i0(l[0])
+    self.expected.verify_i1(l[1])
+    self.expected.verify_i2(l[2])
+  
+  # Note: the contains is a bit tricky since we're going back to the Origen DB
+  # and getting a different object each time. So, there's really now way to
+  # implicitly compare.
+  # Plan is to make implementors to provide an 'eqls' for backend objects.
+  # However, a quick test here just makes sure it doesn't crash.
+  def test_contains_kinda(self, boot):
+    assert None not in self.lut
+
+  def test_exception_on_step_0(self, boot):
+    with pytest.raises(ValueError):
+      self.lut[::0]
+  
+  def test_over_indexing(self, boot):
+    l = self.lut[0:4]
+    assert isinstance(l, self.expected.slice_klass)
+    assert len(l) == 3
+    l = self.lut[-3:-4]
+    assert isinstance(l, self.expected.slice_klass)
+    assert len(l) == 0
+
+  def test_under_indexing(self, boot):
+    l = self.lut[4:]
+    assert isinstance(l, self.expected.slice_klass)
+    assert len(l) == 0
+    l = self.lut[4:1]
+    assert isinstance(l, self.expected.slice_klass)
+    assert len(l) == 0
+    l = self.lut[4:1:-1]
+    assert isinstance(l, self.expected.slice_klass)
+    assert len(l) == 1
+  
+  def test_exception_on_index_out_of_bounds(self, boot):
+    with pytest.raises(IndexError):
+      self.lut[3]
+    with pytest.raises(IndexError):
+      self.lut[-4]
+
+  # Noticed during debug that an incorrect type would cause a panic on the Rust
+  # side. Case here is to catch that.
+  # (Side Note: Was caused by unwrapping a <PyAny>.extract instead of checking for an error)
+  def test_exception_on_slicing_with_other_types(self, boot):
+    with pytest.raises(TypeError):
+      self.lut[1,2]

--- a/example/tests/timing_test.py
+++ b/example/tests/timing_test.py
@@ -1,5 +1,6 @@
 import pytest, abc
 import origen, _origen # pylint: disable=import-error
+from shared.python_like_apis import Fixture_DictLikeAPI, Fixture_ListLikeAPI
 
 @pytest.fixture
 def clean_eagle():
@@ -112,105 +113,15 @@ def test_adding_timeset_with_equation(clean_falcon):
 #   assert t.verify_waves[0].data == 0
 #   assert t.verify_waves[0].at == 0.1
 
-# ### With Tester ####
+# This fixture assumes that a DUT is already instantiated.
+# @pytest.fixture
+# def define_basic_swd_timing(self):
+#   swdio_wave = wtbl.add_wave("SWDIO")
+#   swdio_wave.apply_to("swdio")
+#   swdio_wave.add_event("swd_io_drive1")
 
-# Test Dict-Like API
-class Fixture_DictLikeAPI(abc.ABC):
-  class Expected:
-    def __init__(self, parameters):
-      self.keys = parameters["keys"]
-      self.klass = parameters["klass"]
-      self.not_in_dut = parameters["not_in_dut"]
-
-    @property
-    def len(self):
-      return len(self.keys)
-    
-    @property
-    def in_dut(self):
-      return self.keys[0]
-
-  @abc.abstractmethod
-  def boot_dict_under_test(self):
-    pass
-
-  @abc.abstractmethod
-  def parameterize(self):
-    pass
-
-  # Pytest skips classes which have an __init__ constructor (http://doc.pytest.org/en/latest/goodpractices.html#conventions-for-python-test-discovery)
-  # get around this by using a fixture on the first test to boot the object.
-  @pytest.fixture
-  def boot(self):
-    self.expected = self.Expected(self.parameterize())
-    self.dut = self.boot_dict_under_test()
-    print("Booted!")
-
-  def test_keys(self, boot):
-    assert self.dut.keys
-    assert isinstance(self.dut.keys(), list)
-    assert self.dut.keys() == self.expected.keys
-
-  def test_values(self, boot):
-    assert self.dut.values
-    assert isinstance(self.dut.values(), list)
-    assert len(self.dut.values()) == self.expected.len
-    assert isinstance(self.dut.values()[0], self.expected.klass)
-
-  def test_items(self, boot):
-    items = self.dut.items()
-    assert items
-    assert isinstance(items, list)
-    assert isinstance(items[0], tuple)
-    assert len(items) == self.expected.len
-    assert list(i[0] for i in items) == self.expected.keys
-
-  def test_contains(self, boot):
-    assert self.expected.in_dut in self.dut
-    assert self.expected.not_in_dut not in self.dut
-
-  def test_len(self, boot):
-    assert self.dut.__len__
-    assert len(self.dut) == self.expected.len
-
-  def test_getitem(self, boot):
-    assert self.dut.get
-    assert self.dut.get(self.expected.in_dut)
-    assert self.dut.get(self.expected.not_in_dut) is None
-
-  def test_index_notation(self, boot):
-    assert self.dut[self.expected.in_dut]
-    with pytest.raises(KeyError):
-      self.dut[self.expected.not_in_dut]
-
-  def test_iterating(self, boot):
-    i = 0
-    for _i, k in enumerate(self.dut):
-      assert k == self.expected.keys[_i]
-      i += 1
-    assert i == self.expected.len
-
-  def test_iterating_through_items(self, boot):
-    i = 0
-    for _i, (k, v) in enumerate(self.dut.items()):
-      assert k == self.expected.keys[_i]
-      assert isinstance(v, self.expected.klass)
-      i += 1
-    assert i == self.expected.len
-
-  def test_dict_conversion(self, boot):
-    d = dict(self.dut)
-    assert isinstance(d, dict)
-    assert list(d.keys()) == self.expected.keys
-
-  def test_list_converstion(self, boot):
-    l = list(self.dut)
-    assert isinstance(l, list)
-    assert l == self.expected.keys
-
-# class TestDummy:
-#   def test_dummy_class(self):
-#     assert False
+# Before we go into consuming Timeset-specifics and adding addtional waves, ensure that the dict-like API is working.
+# Otherwise, we'll get a bunch of failures that have nothing to do with the actual timeset.
 
 class TestTimesetsDictLike(Fixture_DictLikeAPI):
   def parameterize(self):
@@ -221,9 +132,316 @@ class TestTimesetsDictLike(Fixture_DictLikeAPI):
     }
 
   def boot_dict_under_test(self):
-    origen.app.instantiate_dut("dut.eagle")
+    origen.app.instantiate_dut("dut.falcon")
     dut = origen.dut
     dut.add_timeset("t0")
     dut.add_timeset("t1")
     dut.add_timeset("t2")
     return dut.timesets
+
+class TestWaveTablesDictLike(Fixture_DictLikeAPI):
+  def parameterize(self):
+    return {
+      "keys": ["wtbl1", "wtbl2"],
+      "klass": _origen.dut.timesets.Wavetable,
+      "not_in_dut": "Blah"
+    }
+
+  def boot_dict_under_test(self):
+    origen.app.instantiate_dut("dut.falcon")
+    t = origen.dut.add_timeset("t")
+    t.add_wavetable("wtbl1")
+    t.add_wavetable("wtbl2")
+    return t.wavetables
+
+class TestWavesDictLike(Fixture_DictLikeAPI):
+  def parameterize(self):
+    return {
+      "keys": ["w1", "w2", "w3"],
+      "klass": _origen.dut.timesets.Wave,
+      "not_in_dut": "Blah"
+    }
+
+  def boot_dict_under_test(self):
+    origen.app.instantiate_dut("dut.falcon")
+    wt = origen.dut.add_timeset("t").add_wavetable("wt")
+    wt.add_wave("w1")
+    wt.add_wave("w2")
+    wt.add_wave("w3")
+    return wt.waves
+
+class TestEventsListLike(Fixture_ListLikeAPI):
+
+  def verify_i0(self, i):
+    assert isinstance(i, _origen.dut.timesets.Event)
+    assert i.__at__ == "period*0.25"
+
+  def verify_i1(self, i):
+    assert isinstance(i, _origen.dut.timesets.Event)
+    assert i.__at__ == "period*0.50"
+
+  def verify_i2(self, i):
+    assert isinstance(i, _origen.dut.timesets.Event)
+    assert i.__at__ == "period*0.75"
+
+  def boot_list_under_test(self):
+    origen.app.instantiate_dut("dut.eagle")
+    wt = origen.dut.add_timeset("t").add_wavetable("wt")
+    w = wt.add_wave("w1")
+    w.push_event(at="period*0.25", unit="ns", action=w.DriveHigh)
+    w.push_event(at="period*0.50", unit="ns", action=w.DriveLow)
+    w.push_event(at="period*0.75", unit="ns", action=w.HighZ)
+    return w.events
+
+# class TestEventsListLike(Fixture_ListLikeAPI):
+#   def equals(i, expected):
+#     assert i.action == expected["action"]
+#     assert i.data == expected["data"]
+#     assert i.at == expected["at"]
+
+#   def parameterize(self):
+#     return {
+#       "items": [
+#         {action: "drive", data: 1, at: "0"},
+#         {action: "drive", data: 0, at: "period*0.25"},
+#         {action: "drive", data: 1, at: "period*0.5"},
+#         {action: "drive", data: 0, at: "period*0.75"}
+#       ],
+#       "klass": _origen.dut.timesets.Event,
+#       "not_in_dut": "Blah"
+#     }
+
+  # def boot_dict_under_test(self):
+  #   origen.app.instantiate_dut("dut.eagle")
+  #   w = origen.dut.add_timeset("t").add_wavetable("wt").add_wave("w")
+  #   w.add_event("drive 1", "0")
+  #   w.add_event("drive 0", "period*0.25")
+  #   w.add_event("drive 1", "period*0.5")
+  #   w.add_event("drive 0", "period*0.75")
+  #   return w.events
+
+class TestComplexTimingScenerios:
+  
+  # Test adding a timeset with more complex features.
+  # This example should translate to the following STIL
+  #   WaveformTable w1 {
+  #     Period 'period';
+  #     Waveforms {
+  #       clk { 1 { StartClk: '0ns', U; "@/2", D; } }
+  #       clk { 0 { StopClk: '0ns', D; } }
+  #     }
+  #   }
+  @pytest.fixture
+  def define_complex_timeset(self, clean_falcon):
+    t = origen.dut.add_timeset("complex")
+    wtbl = t.add_wavetable("w1")
+    wtbl.period = "40"
+
+    # Add drive data waves
+    # This wave should tranlate into STIL as:
+    #   1 { DriveHigh: '10ns', U; }
+    w = wtbl.add_wave("DriveHigh")
+    w.indicator = "1"
+    w.apply_to("porta", "portb")
+    w.push_event(at="period*0.25", unit="ns", action=w.DriveHigh)
+
+    # This wave should tranlate into STIL as:
+    #   0 { DriveLow: '10ns', D; }
+    w = wtbl.add_wave("DriveLow")
+    w.indicator = "0"
+    w.apply_to("porta", "portb")
+    w.push_event(at="period*0.25", unit="ns", action=w.DriveLow)
+
+    # Add highZ wave
+    # This wave should tranlate into STIL as:
+    #   Z { HighZ: '10ns', Z; }
+    w = wtbl.add_wave("HighZ")
+    w.indicator = "Z"
+    w.apply_to("porta", "portb")
+    w.push_event(at="period*0.25", unit="ns", action=w.HighZ)
+
+    # Add comparison waves
+    # This wave should tranlate into STIL as:
+    #   H { CompareHigh: '4ns', H; }
+    w = wtbl.add_wave("VerifyHigh")
+    w.indicator = "H"
+    w.apply_to("porta", "portb")
+    w.push_event(at="period*0.10", unit="ns", action=w.VerifyHigh)
+
+    # This wave should tranlate into STIL as:
+    #   L { CompareLow: '4ns', L; }
+    w = wtbl.add_wave("VerifyLow")
+    w.indicator = "L"
+    w.apply_to("porta", "portb")
+    w.push_event(at="period*0.10", unit="ns", action=w.VerifyLow)
+
+    # This wave should tranlate into STIL as:
+    #   1 { StartClk: '0ns', U; "@/2", D; }
+    w = wtbl.add_wave("StartClk")
+    w.indicator = "1"
+    w.apply_to("clk")
+    w.push_event(at=0, unit="ns", action=w.DriveHigh)
+    w.push_event(at="period/2", unit="ns", action=w.DriveLow)
+
+    # This wave should tranlate into STIL as:
+    #   0 { StopClk: '0ns', D; }
+    w = wtbl.add_wave("StopClk")
+    w.indicator = "0"
+    w.apply_to("clk")
+    w.push_event(at=0, unit="ns", action=w.DriveLow)
+
+  # The fixture above is the linearized, more verbose, but more explicit way to generate timing.
+  # The fixtures below will generate equivalent timesets using 'syntatic sugar' to make writing
+  # timesets more user friendly.
+  # Note though that these fixtures don't do anything too crazy. If crazy waves are needed, the interface above will need to be used.
+  # @pytest.fixture
+  # def define_complex_timing_more_easily(self, clean_falcon):
+  #   t = origen.dut.add_timeset("complex")
+  #   wtbl = t.add_wavetable("w1")
+  #   wtbl.period = "40"
+
+  #   # Add drive data waves
+  #   # This wave should tranlate into STIL as:
+  #   #   10HLZ { Drives: '10ns', U/D/H/L/Z; }
+  #   waves = wtbl.add_waves("PortOperations", 5)
+  #   waves.indicators = ["1", "0", "H", "L", "Z"]
+  #   waves.apply_to("porta", "portb")
+  #   waves.push_event(at="period*0.25", unit="ns", action=[waves.DriveHigh, waves.DriveLow, waves.VerifyHigh, waves.VerifyLow, waves.HighZ])
+
+  # @pytest.fixture
+  # def define_complex_timing_with_context_managers(self, clean_falcon):
+  #   with origen.dut.add_timeset("complex_context_manager") as t:
+  #     with t.add_wavetable("w1") as wtbl:
+  #       wtbl.period = "40"
+  #       with wtbl.add_waves("PortOperations", 5) as (waves, e0, e1, e2, e3, e4):
+  #         waves.apply_to("porta", "portb")
+  #         waves.indicators = ["1", "0", "H", "L", "Z"]
+  #         waves.unit = "ns"
+  #         e0.to_drive_high_wave(at="period*0.25")
+  #         e1.to_drive_low_wave(at="period*0.25")
+  #         e2.to_compare_high_wave(at="period*0.25")
+  #         e3.to_compare_low_wave(at="period*0.25")
+  #         e4.to_highz_wave(at="period*0.25")
+  
+  # @pytest.fixture
+  # def define_wavetable_inheritance(self, clean_falcon):
+  #   with origen.dut.add_timeset("inherited_wavetable") as t:
+  #     with t.add_wavetable("default") as wtbl:
+  #       wtbl.period = "40"
+  #       with wtbl.add_waves("Clk") as w:
+  #         w.apply_to("clk")
+  #         w.indicators = ["0", "1"]
+  #         w.push_drive_low_event()
+  #         w.push_clocking_event()
+  #       with wtbl.add_waves("ShiftedClk", base="Clk") as grp:
+  #         grp.apply_to("other_clk")
+  #         grp.waves[1].to_clocking_event(at="")
+
+  # We're assuming timesets, wavetable, etc. have already passed their appropriate dict/list-like_api test, so assuming that
+  # interface is good there and just filling in some missing pieces.
+  def test_retrieving_timeset_data(self, define_complex_timeset):
+    wtbl = origen.dut.timesets["complex"].wavetables["w1"]
+    
+    # Try to get the resolved period.
+    assert wtbl.period == 40
+
+    # Get the period before evaluation
+    assert wtbl.__period__ == "40"
+
+    # Get the pins which have waves defined for them in the wavetable
+    clk_waves = wtbl.waves.applied_to("clk")
+    assert isinstance(clk_waves, dict)
+    assert len(clk_waves) == 2
+    assert set(clk_waves.keys()) == {"StartClk", "StopClk"}
+    assert isinstance(clk_waves["StartClk"], _origen.dut.timesets.Wave)
+    assert clk_waves["StartClk"].name == "StartClk"
+
+    # Given a single waveform, retrieve its events
+    wave = wtbl.waves["DriveHigh"]
+    assert wave.indicator == "1"
+    assert wave.applied_to == ["porta", "portb"]
+    assert len(wave.events) == 1
+    e = wave.events[0]
+    assert isinstance(e, _origen.dut.timesets.Event)
+    assert e.action == wave.DriveHigh
+    assert e.unit == "ns"
+    assert e.__at__ == "period*0.25"
+    assert e.at == 10
+
+    wave = wtbl.waves["StartClk"]
+    e = wave.events[0]
+    assert e.action == wave.DriveHigh
+    assert e.unit == "ns"
+    assert e.__at__ == "0"
+    assert e.at == 0
+    e = wave.events[1]
+    assert e.action == wave.DriveLow
+    assert e.unit == "ns"
+    assert e.__at__ == "period/2"
+    assert e.at == 20
+  
+  def test_exception_on_duplicate_wavetable(self, define_complex_timeset):
+    assert 'complex' in origen.dut.timesets
+    assert 'w1' in origen.dut.timesets['complex'].wavetables
+    with pytest.raises(OSError):
+      origen.dut.timesets['complex'].add_wavetable('w1')
+  
+  def test_exception_on_duplicate_wave(self, define_complex_timeset):
+    assert 'complex' in origen.dut.timesets
+    assert 'w1' in origen.dut.timesets['complex'].wavetables
+    assert 'DriveHigh' in origen.dut.timesets['complex'].wavetables['w1'].waves
+    with pytest.raises(OSError):
+      origen.dut.timesets['complex'].wavetables['w1'].add_wave('DriveHigh')
+  
+  def test_exception_on_event_missing_action(self, define_complex_timeset):
+    w = origen.dut.timesets['complex'].wavetables['w1'].waves['DriveHigh']
+    with pytest.raises(TypeError):
+      w.push_event(at="10")
+  
+  def test_exception_on_event_missing_at(self, define_complex_timeset):
+    w = origen.dut.timesets['complex'].wavetables['w1'].waves['DriveHigh']
+    with pytest.raises(TypeError):
+      w.push_event(action=w.DriveHigh)
+  
+  def test_exception_on_evaluating_with_missing_period(self, clean_falcon):
+    w = origen.dut.add_timeset('t').add_wavetable('wtbl').add_wave('w')
+    w.push_event(at="period/2", action=w.DriveHigh)
+    assert origen.dut.timesets['t'].wavetables['wtbl'].period is None
+    assert w.events[0].__at__ == "period/2"
+    with pytest.raises(OSError):
+      w.events[0].at
+  
+  def test_exception_on_unknown_action(self, define_complex_timeset):
+    w = origen.dut.timesets['complex'].wavetables['w1'].waves['DriveHigh']
+    with pytest.raises(OSError):
+      w.push_event(action="blah!", at="period/2")
+
+def test_loader_api(clean_eagle):
+  assert len(origen.dut.timesets) == 2
+
+  # Test adding some more waveforms. The updated Waveform Table should now look like:
+  #   WaveformTable w1 {
+  #     Period 'period';
+  #     Waveforms {
+  #       porta portb { 
+  #         1 { DriveHigh: '0ns', U; }
+  #         0 { DriveLow: '0ns', D; }
+  #         H { ExpectHigh: '0ns', G; }
+  #         L { DriveLow: '0ns', Q; }
+  #         Z { HighZ: '0ns', Z; }
+  #         C { Capture: '0ns', V; }
+  #       }
+  #       clk {
+  #         1 { StartClk: '0ns', U; "@/2", D; }
+  #         0 { StopClk: '0ns', D; }
+  #       }
+  #     }
+  #   }
+  #def test_adding_to_existing_timeset(self):
+  #  pass
+
+# ### With Tester ####
+
+# class TestDummy:
+#   def test_dummy_class(self):
+#     assert False

--- a/python/origen/application.py
+++ b/python/origen/application.py
@@ -6,7 +6,6 @@ import re
 import pdb
 from origen.controller import TopLevel
 from origen.translator import Translator
-from origen.errors import *
 
 # The base class of all application classes
 class Base:
@@ -94,6 +93,10 @@ class Base:
 
                 elif filename == "pins.py":
                     from origen.pins import Loader
+                    context = Loader(controller).api()
+                
+                elif filename == "timing.py":
+                    from origen.timesets import Loader
                     context = Loader(controller).api()
 
                 else:

--- a/python/origen/controller.py
+++ b/python/origen/controller.py
@@ -4,7 +4,6 @@ from origen import pins
 from origen import timesets
 from origen.registers import Loader as RegLoader
 from origen.sub_blocks import Loader as SubBlockLoader
-from origen.errors import *
 from contextlib import contextmanager
 
 class Proxies:
@@ -188,7 +187,7 @@ class Base:
 
     def _load_timesets(self):
         if not self.timesets_loaded:
-            self.app.load_block_files(self, "timesets.py")
+            self.app.load_block_files(self, "timing.py")
             self.timesets_loaded = True
 
 # The base class of all Origen controller objects which are also

--- a/python/origen/timesets.py
+++ b/python/origen/timesets.py
@@ -27,9 +27,9 @@ class Loader:
     self.controller = controller
   
   def Timeset(self, name, **kwargs):
-    self.controller.add_timeset(name, **kwargs)
+    return self.controller.add_timeset(name, **kwargs)
   
   def api(self):
     return {
-      "Timeset", self.Timeset,
+      "Timeset": self.Timeset,
     }

--- a/rust/origen/Cargo.lock
+++ b/rust/origen/Cargo.lock
@@ -802,6 +802,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "meta"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1051,7 @@ dependencies = [
  "eval",
  "indexmap",
  "lazy_static 1.4.0",
+ "meta",
  "num",
  "num-bigint",
  "path-clean",
@@ -1664,9 +1673,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
+checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/origen/Cargo.toml
+++ b/rust/origen/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 build = "build.rs"
 
 [workspace]
-members = ["cli"]
+members = ["cli", "meta"]
 
 [lib]
 
@@ -31,6 +31,7 @@ num-bigint = "0.2"
 # Per this SO thread: https://stackoverflow.com/questions/37296351/trait-for-numeric-functionality-in-rust
 # the num crate includes some useful traits to accept float-like and integer-like things without having to manually enumerate them all.
 num = "0.2.0"
+meta = { path = "./meta" }
 
 [build-dependencies]
 built = "0.3"

--- a/rust/origen/meta/Cargo.toml
+++ b/rust/origen/meta/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "meta"
+version = "0.1.0"
+authors = ["nxa13790"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0.14"
+quote = "1.0.2"

--- a/rust/origen/meta/src/id_getters_derive.rs
+++ b/rust/origen/meta/src/id_getters_derive.rs
@@ -1,0 +1,131 @@
+use crate::proc_macro::TokenStream;
+use quote::{quote, format_ident};
+use syn;
+
+#[derive(Default)]
+struct Config {
+    pub getter_type: String,
+    pub field: String,
+    pub field_container_name: String,
+    pub parent_field: String,
+    pub return_type: String,
+}
+
+pub fn impl_id_getters(ast: &syn::DeriveInput) -> syn::Result<TokenStream> {
+  let name = &ast.ident;
+  let mut getter_functions = quote! {};
+  for (_i, attr) in ast.attrs.iter().enumerate() {
+      // Go through the given attributes. If something doesn't parse, just ignore it. The Rust language will eithe catch for something
+      // grossly malformed, or it may be a (very) customized attribute.
+      // Likewise, ignore any atttributes that aren't ours.
+      match attr.parse_meta()? {
+        syn::Meta::List(syn::MetaList {ref path, ref nested, ..}) => {
+            if path.is_ident("id_getters_by_index") || path.is_ident("id_getters_by_mapping") {
+                let mut config = Config::default();
+                if path.is_ident("id_getters_by_index") {
+                    config.getter_type = "by_index".to_string();
+                } else {
+                    config.getter_type = "by_mapping".to_string();
+                }
+                for (_i, _attr) in nested.iter().enumerate() {
+                    match _attr {
+                        syn::NestedMeta::Meta(syn::Meta::NameValue(ref name_value_pair)) => {
+                            // Match the name/value pair to the appropriate field in the config.
+                            if name_value_pair.path.is_ident("field") {
+                                match &name_value_pair.lit {
+                                    syn::Lit::Str(l) => config.field = l.value(),
+                                    _ => return Err(syn::Error::new_spanned(name_value_pair.lit.clone(), format!("Could not process name-value pair's value as a String")))
+                                }
+                            } else if name_value_pair.path.is_ident("parent_field") {
+                                match &name_value_pair.lit {
+                                    syn::Lit::Str(l) => config.parent_field = l.value(),
+                                    _ => return Err(syn::Error::new_spanned(name_value_pair.lit.clone(), format!("Could not process name-value pair's value as a String")))
+                                }
+                            } else if name_value_pair.path.is_ident("field_container_name") {
+                                match &name_value_pair.lit {
+                                    syn::Lit::Str(l) => config.field_container_name = l.value(),
+                                    _ => return Err(syn::Error::new_spanned(name_value_pair.lit.clone(), format!("Could not process name-value pair's value as a String")))
+                                }
+                            } else if name_value_pair.path.is_ident("return_type") {
+                                match &name_value_pair.lit {
+                                    syn::Lit::Str(l) => config.return_type = l.value(),
+                                    _ => return Err(syn::Error::new_spanned(name_value_pair.lit.clone(), format!("Could not process name-value pair's value as a String")))
+                                }
+                            } else {
+                                return Err(syn::Error::new_spanned(name_value_pair.path.clone(), format!("Unexpected name-value pair '{}'", name_value_pair.path.get_ident().unwrap())))
+                            }
+                        },
+                        _ => return Err(syn::Error::new_spanned(_attr, format!("Could not process as a name-value pair!")))
+                    }
+                }
+
+                let func_name = format_ident!("get_{}", config.field);
+                let mut_func_name = format_ident!("get_mut_{}", config.field);
+                let _func_name = format_ident!("_{}", func_name);
+                let _mut_func_name = format_ident!("_{}", mut_func_name);
+                let clone_func_name = format_ident!("_get_cloned_{}", config.field);
+                
+                let get_id_func = format_ident!("get_{}_id", config.field);
+                let retn = format_ident!("{}", config.return_type);
+                let field_container_name = format_ident!("{}", config.field_container_name);
+                let parent_field = format_ident!("{}", config.parent_field);
+        
+                let (lookup_type, error_message);
+                if config.getter_type == "by_index" {
+                    lookup_type = quote! { usize };
+                    error_message = quote! { &format!("Could not find #config.field at index {}!", identifier) };
+                } else {
+                    lookup_type = quote!{ &str };
+                    error_message = quote! { &format!("Could not find #config.field named {}!", identifier) };
+                }
+        
+                getter_functions.extend(quote! {
+                    impl #name {
+                        pub fn #func_name (&self, parent_field_id: usize, identifier: #lookup_type) -> Option<& #retn > {
+                            if let Some(i) = self.#parent_field[parent_field_id].#get_id_func(identifier) {
+                                Some(&self.#field_container_name[i])
+                            } else {
+                                Option::None
+                            }
+                        }
+        
+                        pub fn #mut_func_name(&mut self, parent_field_id: usize, identifier: #lookup_type) -> Option<&mut #retn> {
+                            if let Some(i) = self.#parent_field[parent_field_id].#get_id_func(identifier) {
+                                Some(&mut self.#field_container_name[i])
+                            } else {
+                                Option::None
+                            }
+                        }
+        
+                        pub fn #_func_name (&self, parent_field_id: usize, identifier: #lookup_type) -> core::result::Result<& #retn, crate::error::Error> {
+                            if let Some(i) = self.#parent_field[parent_field_id].#get_id_func(identifier) {
+                                Ok(&self.#field_container_name[i])
+                            } else {
+                                Err(crate::error::Error::new(#error_message))
+                            }
+                        }
+        
+                        pub fn #_mut_func_name(&mut self, parent_field_id: usize, identifier: #lookup_type) -> core::result::Result<&mut #retn, crate::error::Error> {
+                            if let Some(i) = self.#parent_field[parent_field_id].#get_id_func(identifier) {
+                                Ok(&mut self.#field_container_name[i])
+                            } else {
+                                Err(crate::error::Error::new(#error_message))
+                            }
+                        }
+        
+                        pub fn #clone_func_name(&self, parent_field_id: usize, identifier: #lookup_type) -> core::result::Result<#retn, crate::error::Error> {
+                            if let Some(i) = self.#parent_field[parent_field_id].#get_id_func(identifier) {
+                                Ok(self.#field_container_name[i].clone())
+                            } else {
+                                Err(crate::error::Error::new(#error_message))
+                            }
+                        }
+                    }
+                });
+            }
+        },
+        _ => {},
+      }
+  }
+  Ok(getter_functions.into())
+}

--- a/rust/origen/meta/src/lib.rs
+++ b/rust/origen/meta/src/lib.rs
@@ -1,0 +1,15 @@
+extern crate proc_macro;
+use crate::proc_macro::TokenStream;
+use syn;
+
+mod meta;
+mod id_getters_derive;
+
+#[proc_macro_derive(IdGetters, attributes(id_getters_by_index, id_getters_by_mapping))]
+pub fn id_getters_derive(input: TokenStream) -> TokenStream {
+  let ast = syn::parse(input).unwrap();
+  match id_getters_derive::impl_id_getters(&ast) {
+    Ok(obj) => obj,
+    Err(message) => panic!(message)
+  }
+}

--- a/rust/origen/meta/src/meta/mod.rs
+++ b/rust/origen/meta/src/meta/mod.rs
@@ -1,0 +1,1 @@
+//pub mod object_id_vector;

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -1,12 +1,13 @@
 use crate::core::model::registers::{
     AccessType, AddressBlock, Bit, MemoryMap, Register, RegisterFile,
 };
-use crate::core::model::timesets::timeset::Timeset;
+use crate::core::model::timesets::timeset::{Timeset, Wavetable, Wave, Event};
 use crate::core::model::Model;
 use crate::error::Error;
 use crate::Result;
 use crate::DUT;
 use std::sync::RwLock;
+use indexmap::IndexMap;
 
 /// The DUT stores all objects associated with a particular device.
 /// Each object type is organized into vectors, where a particular object's position within the
@@ -25,6 +26,10 @@ pub struct Dut {
     registers: Vec<Register>,
     pub bits: Vec<Bit>,
     pub timesets: Vec<Timeset>,
+    pub wavetables: Vec<Wavetable>,
+    pub waves: Vec<Wave>,
+    pub wave_events: Vec<Event>,
+    pub id_mappings: Vec<IndexMap<String, usize>>,
 }
 
 impl Dut {
@@ -41,6 +46,11 @@ impl Dut {
             registers: Vec::<Register>::new(),
             bits: Vec::<Bit>::new(),
             timesets: Vec::<Timeset>::new(),
+            wavetables: Vec::<Wavetable>::new(),
+            waves: Vec::<Wave>::new(),
+            wave_events: Vec::<Event>::new(),
+
+            id_mappings: Vec::<IndexMap<String, usize>>::new(),
         }
     }
 
@@ -56,6 +66,12 @@ impl Dut {
         self.register_files.clear();
         self.registers.clear();
         self.bits.clear();
+        self.timesets.clear();
+        self.wavetables.clear();
+        self.waves.clear();
+        self.wave_events.clear();
+
+        self.id_mappings.clear();
         // Add the model for the DUT top-level (always ID 0)
         let _ = self.create_model(None, "dut");
     }

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -8,6 +8,7 @@ use crate::Result;
 use crate::DUT;
 use std::sync::RwLock;
 use indexmap::IndexMap;
+use crate::meta::{IdGetters};
 
 /// The DUT stores all objects associated with a particular device.
 /// Each object type is organized into vectors, where a particular object's position within the
@@ -16,7 +17,13 @@ use indexmap::IndexMap;
 /// bit IDs. This approach allows bits to be easily passed around by ID to enable the creation of
 /// bit collections that are small (a subset of a register's bits) or very large (all bits in
 /// a memory map).
-#[derive(Debug)]
+//#[include_id_getters]
+#[derive(Debug, IdGetters)]
+#[id_getters_by_mapping(field="timeset", parent_field="models", return_type="Timeset", field_container_name="timesets")]
+#[id_getters_by_mapping(field="wavetable", parent_field="timesets", return_type="Wavetable", field_container_name="wavetables")]
+#[id_getters_by_mapping(field="wave_group", parent_field="wavetables", return_type="WaveGroup", field_container_name="wave_groups")]
+#[id_getters_by_mapping(field="wave", parent_field="wave_groups", return_type="Wave", field_container_name="waves")]
+#[id_getters_by_index(field="event", parent_field="waves", return_type="Event", field_container_name="wave_events")]
 pub struct Dut {
     pub name: String,
     models: Vec<Model>,
@@ -413,5 +420,16 @@ impl Dut {
 
         self.bits.push(bit);
         id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let dut = super::Dut::new("placeholder");
+        //dut.get_event_test(0, 0);
+        //dut.hello_macro();
+        //assert_eq!(2 + 2, 4);
     }
 }

--- a/rust/origen/src/core/dut.rs
+++ b/rust/origen/src/core/dut.rs
@@ -1,7 +1,7 @@
 use crate::core::model::registers::{
     AccessType, AddressBlock, Bit, MemoryMap, Register, RegisterFile,
 };
-use crate::core::model::timesets::timeset::{Timeset, Wavetable, Wave, Event};
+use crate::core::model::timesets::timeset::{Timeset, Wavetable, Wave, WaveGroup, Event};
 use crate::core::model::Model;
 use crate::error::Error;
 use crate::Result;
@@ -27,6 +27,7 @@ pub struct Dut {
     pub bits: Vec<Bit>,
     pub timesets: Vec<Timeset>,
     pub wavetables: Vec<Wavetable>,
+    pub wave_groups: Vec<WaveGroup>,
     pub waves: Vec<Wave>,
     pub wave_events: Vec<Event>,
     pub id_mappings: Vec<IndexMap<String, usize>>,
@@ -47,6 +48,7 @@ impl Dut {
             bits: Vec::<Bit>::new(),
             timesets: Vec::<Timeset>::new(),
             wavetables: Vec::<Wavetable>::new(),
+            wave_groups: Vec::<WaveGroup>::new(),
             waves: Vec::<Wave>::new(),
             wave_events: Vec::<Event>::new(),
 
@@ -68,6 +70,7 @@ impl Dut {
         self.bits.clear();
         self.timesets.clear();
         self.wavetables.clear();
+        self.wave_groups.clear();
         self.waves.clear();
         self.wave_events.clear();
 

--- a/rust/origen/src/core/model/timesets.rs
+++ b/rust/origen/src/core/model/timesets.rs
@@ -54,10 +54,6 @@ impl Model {
     }
   }
 
-  pub fn len(&self) -> usize {
-    self.timesets.len()
-  }
-
   pub fn contains_timeset(&self, name: &str) -> bool {
     self.timesets.contains_key(name)
   }
@@ -95,36 +91,6 @@ impl Dut {
     Ok(&self.timesets[id])
   }
   
-  pub fn get_timeset(&self, model_id: usize, name: &str) -> Option<&Timeset> {
-    if let Some(t) = self.get_model(model_id).unwrap().get_timeset_id(name) {
-      Some(&self.timesets[t])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn get_mut_timeset(&mut self, model_id: usize, name: &str) -> Option<&mut Timeset> {
-    if let Some(t) = self.get_model(model_id).unwrap().get_timeset_id(name) {
-      Some(&mut self.timesets[t])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn _get_timeset(&self, model_id: usize, name: &str) -> Result<&Timeset, Error> {
-    match self.get_timeset(model_id, name) {
-      Some(t) => Ok(t),
-      None => backend_lookup_error!("timeset", name)
-    }
-  }
-
-  pub fn _get_mut_timeset(&mut self, model_id: usize, name: &str) -> Result<&mut Timeset, Error> {
-    match self.get_mut_timeset(model_id, name) {
-      Some(t) => Ok(t),
-      None => backend_lookup_error!("timeset", name)
-    }
-  }
-
   pub fn create_wavetable(&mut self, timeset_id: usize, name: &str) -> Result<&Wavetable, Error> {
     let id;
     {
@@ -145,22 +111,6 @@ impl Dut {
     }
     self.wavetables.push(w);
     Ok(&self.wavetables[id])
-  }
-
-  pub fn get_wavetable(&self, timeset_id: usize, name: &str) -> Option<&Wavetable> {
-    if let Some(w) = self.timesets[timeset_id].get_wavetable_id(name) {
-      Some(&self.wavetables[w])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn get_mut_wavetable(&mut self, timeset_id: usize, name: &str) -> Option<&mut Wavetable> {
-    if let Some(w) = self.timesets[timeset_id].get_wavetable_id(name) {
-      Some(&mut self.wavetables[w])
-    } else {
-      Option::None
-    }
   }
 
   pub fn create_wave_group(&mut self, wavetable_id: usize, name: &str, derived_from: Option<Vec<usize>>) -> Result<&WaveGroup, Error> {
@@ -210,7 +160,7 @@ impl Dut {
       for base in bases.iter() {
         let base_wave: Wave;
         {
-          base_wave = self._get_wave(wave_group_id, base)?;
+          base_wave = self._get_cloned_wave(wave_group_id, base)?;
         }
         {
           // Todo: Need to further define how wave inheritance should look.
@@ -232,46 +182,6 @@ impl Dut {
     Ok(&self.waves[id])
   }
 
-  pub fn get_wave_group(&self, wavetable_id: usize, name: &str) -> Option<&WaveGroup> {
-    if let Some(wgrp_id) = self.wavetables[wavetable_id].get_wave_group_id(name) {
-      Some(&self.wave_groups[wgrp_id])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn get_mut_wave_group(&mut self, wavetable_id: usize, name: &str) -> Option<&mut WaveGroup> {
-    if let Some(wgrp_id) = self.wavetables[wavetable_id].get_wave_group_id(name) {
-      Some(&mut self.wave_groups[wgrp_id])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn get_wave(&self, wave_group_id: usize, name: &str) -> Option<&Wave> {
-    if let Some(w) = self.wave_groups[wave_group_id].get_wave_id(name) {
-      Some(&self.waves[w])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn _get_wave(&self, wave_group_id: usize, name: &str) -> Result<Wave, Error> {
-    if let Some(w) = self.wave_groups[wave_group_id].get_wave_id(name) {
-      Ok(self.waves[w].clone())
-    } else {
-      lookup_error!("wave", name)
-    }
-  }
-
-  pub fn get_mut_wave(&mut self, wave_group_id: usize, name: &str) -> Option<&mut Wave> {
-    if let Some(w) = self.wave_groups[wave_group_id].get_wave_id(name) {
-      Some(&mut self.waves[w])
-    } else {
-      Option::None
-    }
-  }
-
   pub fn create_event(&mut self, wave_id: usize, at: Box<dyn std::string::ToString>, unit: Option<String>, action: &str) -> Result<&Event, Error> {
     let e_id;
     {
@@ -285,24 +195,5 @@ impl Dut {
     }
     self.wave_events.push(event);
     Ok(&self.wave_events[e_id])
-  }
-
-  /// Gets an event at index 'event_index' from a wave.
-  /// Note: the indices are from the wave, NOT from the toplevel DUT. Using dut.waves_events[event_index] will
-  ///   probably return the wrong event, which may not even be on the wave in question.
-  pub fn get_event(&self, wave_id: usize, event_index: usize) -> Option<&Event> {
-    if let Some(e_id) = self.waves[wave_id].get_event_id(event_index) {
-      Some(&self.wave_events[e_id])
-    } else {
-      Option::None
-    }
-  }
-
-  pub fn get_mut_event(&mut self, wave_id: usize, event_index: usize) -> Option<&mut Event> {
-    if let Some(e_id) = self.waves[wave_id].get_event_id(event_index) {
-      Some(&mut self.wave_events[e_id])
-    } else {
-      Option::None
-    }
   }
 }

--- a/rust/origen/src/core/model/timesets.rs
+++ b/rust/origen/src/core/model/timesets.rs
@@ -1,19 +1,19 @@
 pub mod timeset;
 
-use super::super::dut::Dut;
 use super::Model;
+use timeset::{Timeset, Wavetable, Wave, Event};
 use crate::error::Error;
-use timeset::Timeset;
+use super::super::dut::Dut;
 
 /// Returns an Origen Error with pre-formatted message comlaining that
 /// someting already exists.
 #[macro_export]
 macro_rules! duplicate_error {
     ($container:expr, $model_name:expr, $duplicate_name:expr) => {
-        Err(Error::new(&format!(
-            "The block '{}' already contains a(n) {} called '{}'",
-            $model_name, $container, $duplicate_name
-        )))
+      Err(Error::new(&format!(
+        "The block '{}' already contains a(n) {} called '{}'",
+        $model_name, $container, $duplicate_name
+      )))
     };
 }
 
@@ -23,96 +23,205 @@ macro_rules! duplicate_error {
 #[macro_export]
 macro_rules! backend_lookup_error {
     ($container:expr, $name:expr) => {
-        Err(Error::new(&format!(
-            "Something has gone wrong, no {} exists with ID '{}'",
-            $container, $name
-        )))
+      Err(Error::new(&format!(
+        "Something has gone wrong, no {} exists with ID '{}'",
+        $container, $name
+      )))
     };
 }
 
 impl Model {
-    pub fn add_timeset(
-        &mut self,
-        _model_id: usize,
-        instance_id: usize,
-        name: &str,
-        period: Option<Box<dyn std::string::ToString>>,
-        default_period: Option<f64>,
-    ) -> Result<Timeset, Error> {
-        let t = Timeset::new(name, period, default_period);
-        self.timesets.insert(String::from(name), instance_id);
-        Ok(t)
-    }
+  pub fn add_timeset(&mut self, model_id: usize, instance_id: usize, name: &str, period: Option<Box<dyn std::string::ToString>>, default_period: Option<f64>) -> Result<Timeset, Error> {
+    let t = Timeset::new(model_id, instance_id, name, period, default_period);
+    self.timesets.insert(String::from(name), instance_id);
+    Ok(t)
+  }
 
-    pub fn get_timeset_id(&self, name: &str) -> Option<usize> {
-        match self.timesets.get(name) {
-            Some(t) => Some(*t),
-            None => None,
-        }
+  pub fn get_timeset_id(&self, name: &str) -> Option<usize> {
+    match self.timesets.get(name) {
+      Some(t) => Some(*t),
+      None => None,
     }
+  }
 
-    pub fn len(&self) -> usize {
-        self.timesets.len()
-    }
+  pub fn len(&self) -> usize {
+    self.timesets.len()
+  }
 
-    pub fn contains_timeset(&self, name: &str) -> bool {
-        self.timesets.contains_key(name)
-    }
+  pub fn contains_timeset(&self, name: &str) -> bool {
+    self.timesets.contains_key(name)
+  }
 }
 
 impl Dut {
-    pub fn create_timeset(
-        &mut self,
-        model_id: usize,
-        name: &str,
-        period: Option<Box<dyn std::string::ToString>>,
-        default_period: Option<f64>,
-    ) -> Result<&Timeset, Error> {
-        let id;
-        {
-            id = self.timesets.len();
-        }
-
-        let t;
-        {
-            let model = self.get_mut_model(model_id)?;
-            if model.contains_timeset(name) {
-                return duplicate_error!("timeset", model.name, name);
-            }
-
-            t = model.add_timeset(model_id, id, name, period, default_period)?;
-        }
-        self.timesets.push(t);
-        Ok(&self.timesets[id])
+  pub fn create_timeset(
+    &mut self,
+    model_id: usize,
+    name: &str,
+    period: Option<Box<dyn std::string::ToString>>,
+    default_period: Option<f64>,
+  ) -> Result<&Timeset, Error> {
+    let id;
+    {
+      id = self.timesets.len();
     }
 
-    pub fn get_timeset(&self, model_id: usize, name: &str) -> Option<&Timeset> {
-        if let Some(t) = self.get_model(model_id).unwrap().get_timeset_id(name) {
-            Some(&self.timesets[t])
-        } else {
-            Option::None
-        }
+    let t;
+    {
+      let model= self.get_mut_model(model_id)?;
+      if model.contains_timeset(name) {
+        return duplicate_error!("timeset", model.name, name);
+      }
+  
+      t = model.add_timeset(
+        model_id,
+        id,
+        name,
+        period,
+        default_period,
+      )?;
+    }
+    self.timesets.push(t);
+    Ok(&self.timesets[id])
+  }
+  
+  pub fn get_timeset(&self, model_id: usize, name: &str) -> Option<&Timeset> {
+    if let Some(t) = self.get_model(model_id).unwrap().get_timeset_id(name) {
+      Some(&self.timesets[t])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn get_mut_timeset(&mut self, model_id: usize, name: &str) -> Option<&mut Timeset> {
+    if let Some(t) = self.get_model(model_id).unwrap().get_timeset_id(name) {
+      Some(&mut self.timesets[t])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn _get_timeset(&self, model_id: usize, name: &str) -> Result<&Timeset, Error> {
+    match self.get_timeset(model_id, name) {
+      Some(t) => Ok(t),
+      None => backend_lookup_error!("timeset", name)
+    }
+  }
+
+  pub fn _get_mut_timeset(&mut self, model_id: usize, name: &str) -> Result<&mut Timeset, Error> {
+    match self.get_mut_timeset(model_id, name) {
+      Some(t) => Ok(t),
+      None => backend_lookup_error!("timeset", name)
+    }
+  }
+
+  pub fn create_wavetable(&mut self, timeset_id: usize, name: &str) -> Result<&Wavetable, Error> {
+    let id;
+    {
+      id = self.wavetables.len();
     }
 
-    pub fn get_mut_timeset(&mut self, model_id: usize, name: &str) -> Option<&mut Timeset> {
-        if let Some(t) = self.get_model(model_id).unwrap().get_timeset_id(name) {
-            Some(&mut self.timesets[t])
-        } else {
-            Option::None
-        }
+    let w;
+    {
+      let t = &mut self.timesets[timeset_id];
+      if t.contains_wavetable(name) {
+        return duplicate_error!("wavetable", t.name, name);
+      }
+  
+      w = t.register_wavetable(
+        id,
+        name
+      )?;
+    }
+    self.wavetables.push(w);
+    Ok(&self.wavetables[id])
+  }
+
+  pub fn get_wavetable(&self, timeset_id: usize, name: &str) -> Option<&Wavetable> {
+    if let Some(w) = self.timesets[timeset_id].get_wavetable_id(name) {
+      Some(&self.wavetables[w])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn get_mut_wavetable(&mut self, timeset_id: usize, name: &str) -> Option<&mut Wavetable> {
+    if let Some(w) = self.timesets[timeset_id].get_wavetable_id(name) {
+      Some(&mut self.wavetables[w])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn create_wave(&mut self, wavetable_id: usize, name: &str) -> Result<&Wave, Error> {
+    let id;
+    {
+      id = self.waves.len();
     }
 
-    pub fn _get_timeset(&self, model_id: usize, name: &str) -> Result<&Timeset, Error> {
-        match self.get_timeset(model_id, name) {
-            Some(t) => Ok(t),
-            None => backend_lookup_error!("timeset", name),
-        }
+    let wave;
+    {
+      let t = &mut self.wavetables[wavetable_id];
+      if t.contains_wave(name) {
+        return duplicate_error!("wave", t.name, name);
+      }
+  
+      wave = t.register_wave(
+        id,
+        name
+      )?;
+    }
+    self.waves.push(wave);
+    Ok(&self.waves[id])
+  }
+
+  pub fn get_wave(&self, wavetable_id: usize, name: &str) -> Option<&Wave> {
+    if let Some(w) = self.wavetables[wavetable_id].get_wave_id(name) {
+      Some(&self.waves[w])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn get_mut_wave(&mut self, wavetable_id: usize, name: &str) -> Option<&mut Wave> {
+    if let Some(w) = self.wavetables[wavetable_id].get_wave_id(name) {
+      Some(&mut self.waves[w])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn create_event(&mut self, wave_id: usize, at: Box<dyn std::string::ToString>, unit: Option<String>, action: &str) -> Result<&Event, Error> {
+    let e_id;
+    {
+      e_id = self.wave_events.len();
     }
 
-    // pub fn _get_mut_timeset(&mut self, name: &str) -> Result<&mut Timeset, Error> {
-    //   match self.get_mut_timeset(name) {
-    //     Some(t) => Ok(t),
-    //     None => no_pin_group_error!()
-    //   }
-    // }
+    let event;
+    {
+      let w = &mut self.waves[wave_id];
+      event = w.push_event(e_id, at, unit, action)?;
+    }
+    self.wave_events.push(event);
+    Ok(&self.wave_events[e_id])
+  }
+
+  /// Gets an event at index 'event_index' from a wave.
+  /// Note: the indices are from the wave, NOT from the toplevel DUT. Using dut.waves_events[event_index] will
+  ///   probably return the wrong event, which may not even be on the wave in question.
+  pub fn get_event(&self, wave_id: usize, event_index: usize) -> Option<&Event> {
+    if let Some(e_id) = self.waves[wave_id].get_event_id(event_index) {
+      Some(&self.wave_events[e_id])
+    } else {
+      Option::None
+    }
+  }
+
+  pub fn get_mut_event(&mut self, wave_id: usize, event_index: usize) -> Option<&mut Event> {
+    if let Some(e_id) = self.waves[wave_id].get_event_id(event_index) {
+      Some(&mut self.wave_events[e_id])
+    } else {
+      Option::None
+    }
+  }
 }

--- a/rust/origen/src/core/model/timesets/timeset.rs
+++ b/rust/origen/src/core/model/timesets/timeset.rs
@@ -10,7 +10,7 @@ pub struct SimpleTimeset {
   pub default_period: Option<f64>
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Timeset {
   pub name: String,
   pub model_id: usize,
@@ -86,7 +86,7 @@ impl Default for Timeset {
 // Structuring the WaveTable for ATE generation which, when a pin is changed, will look up here what that change 'means' and
 // what to actually put in the output.
 // So, given a known Timeset and Wavetable, allow for a quick lookup of an event from a given PinGroup name.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Wavetable {
   pub name: String,
   pub model_id: usize,
@@ -168,7 +168,7 @@ impl Wavetable {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct WaveGroup {
   pub model_id: usize,
   pub timeset_id: usize,

--- a/rust/origen/src/core/model/timesets/timeset.rs
+++ b/rust/origen/src/core/model/timesets/timeset.rs
@@ -2,85 +2,331 @@ extern crate num;
 //use super::super::pins::pin::PinActions;
 use crate::error::Error;
 use eval;
+use indexmap::map::IndexMap;
+
+pub struct SimpleTimeset {
+  pub name: String,
+  pub period: Option<String>,
+  pub default_period: Option<f64>
+}
 
 #[derive(Debug)]
 pub struct Timeset {
-    pub name: String,
-    pub period_as_string: Option<String>,
-    pub default_period: Option<f64>,
+  pub name: String,
+  pub model_id: usize,
+  pub id: usize,
+  pub period_as_string: Option<String>,
+  pub default_period: Option<f64>,
+  pub wavetable_ids: IndexMap<String, usize>,
 }
 
 impl Timeset {
-    pub fn new(
-        name: &str,
-        period_as_string: Option<Box<dyn std::string::ToString>>,
-        default_period: Option<f64>,
-    ) -> Self {
-        Timeset {
-            name: String::from(name),
-            period_as_string: match period_as_string {
-                Some(p) => Some(p.to_string()),
-                None => None,
-            },
-            default_period: default_period,
-        }
+  pub fn new(model_id: usize, id: usize, name: &str, period_as_string: Option<Box<dyn std::string::ToString>>, default_period: Option<f64>) -> Self {
+    Timeset {
+      model_id: model_id,
+      id: id,
+      name: String::from(name),
+      period_as_string: match period_as_string {
+        Some(p) => Some(p.to_string()),
+        None => None
+      },
+      default_period: default_period,
+      wavetable_ids: IndexMap::new(),
     }
+  }
 
-    pub fn eval_str(&self) -> String {
-        let default = String::from("period");
-        let p = self.period_as_string.as_ref().unwrap_or(&default);
-        p.clone()
-    }
+  pub fn eval_str(&self) -> String {
+    let default = String::from("period");
+    let p = self.period_as_string.as_ref().unwrap_or(&default);
+    p.clone()
+  }
 
-    pub fn eval(&self, current_period: Option<f64>) -> Result<f64, Error> {
-        let default = String::from("period");
-        let p = self.period_as_string.as_ref().unwrap_or(&default);
-        let err = &format!(
-            "Could not evaluate Timeset {}'s expression: '{}'",
-            self.name, p
-        );
-        if current_period.is_none() && self.default_period.is_none() {
-            return Err(Error::new(&format!("No current timeset period set! Cannot evalate timeset '{}' without a current period as it does not have a default period!", self.name)));
-        }
-        match eval::Expr::new(p)
-            .value(
-                "period",
-                current_period.unwrap_or(self.default_period.unwrap()),
-            )
-            .exec()
-        {
-            Ok(val) => match val.as_f64() {
-                Some(v) => Ok(v),
-                None => Err(Error::new(err)),
-            },
-            Err(_e) => Err(Error::new(err)),
-        }
+  pub fn eval(&self, current_period: Option<f64>)-> Result<f64, Error> {
+    let default = String::from("period");
+    let p = self.period_as_string.as_ref().unwrap_or(&default);
+    let err = &format!("Could not evaluate Timeset {}'s expression: '{}'", self.name, p);
+    if current_period.is_none() && self.default_period.is_none() {
+      return Err(Error::new(&format!("No current timeset period set! Cannot evalate timeset '{}' without a current period as it does not have a default period!", self.name)));
     }
+    match eval::Expr::new(p).value("period", current_period.unwrap_or(self.default_period.unwrap())).exec() {
+      Ok(val) => {
+        match val.as_f64() {
+          Some(v) => Ok(v),
+          None => Err(Error::new(err))
+        }
+      }
+      Err(_e) => Err(Error::new(err))
+    }
+  }
+
+  pub fn register_wavetable(&mut self, id: usize, name: &str) -> Result<Wavetable, Error> {
+    let w = Wavetable::new(self.model_id, self.id, id, name)?;
+    self.wavetable_ids.insert(String::from(name), id);
+    Ok(w)
+  }
+
+  pub fn get_wavetable_id(&self, name: &str) -> Option<usize> {
+    match self.wavetable_ids.get(name) {
+      Some(t) => Some(*t),
+      None => None,
+    }
+  }
+
+  pub fn contains_wavetable(&self, name: &str) -> bool {
+    self.wavetable_ids.contains_key(name)
+  }
 }
 
 impl Default for Timeset {
-    fn default() -> Self {
-        Self::new("dummy", Option::None, Option::None)
-    }
+  fn default() -> Self {
+    Self::new(0, 0, "dummy", Option::None, Option::None)
+  }
 }
 
-// pub struct Event {
-//   action: PinActions,
-//   at: String,
-// }
+// Structuring the WaveTable for ATE generation which, when a pin is changed, will look up here what that change 'means' and
+// what to actually put in the output.
+// So, given a known Timeset and Wavetable, allow for a quick lookup of an event from a given PinGroup name.
+#[derive(Debug)]
+pub struct Wavetable {
+  pub name: String,
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub id: usize,
+  pub period: Option<String>,
+
+  // The 'waveforms', 'signals', and 'event' from the STIL specification is mashed together
+  // in an 'event_map', whose key is a PinGroup name and whose values are a list of events associated
+  // with that PinGroup.
+  // Note that events are Event-IDs, which can be looked up from the DUT.
+  pub wave_ids: IndexMap<String, usize>
+}
+
+impl Wavetable {
+  pub fn new(model_id: usize, timeset_id: usize, id: usize, name: &str) -> Result<Self, Error> {
+    Ok(Self {
+      name: String::from(name),
+      model_id: model_id,
+      timeset_id: timeset_id,
+      id: id,
+      period: Option::None,
+      wave_ids: IndexMap::new(),
+    })
+  }
+
+  pub fn get_wave_id(&self, name: &str) -> Option<usize> {
+    match self.wave_ids.get(name) {
+      Some(t) => Some(*t),
+      None => None,
+    }
+  }
+
+  pub fn contains_wave(&self, name: &str) -> bool {
+    self.wave_ids.contains_key(name)
+  }
+
+  // At some point, add some preliminary checking of the period to weed out some gross failures.
+  pub fn set_period(&mut self, period: Option<Box<dyn std::string::ToString>>) -> Result<(), Error> {
+    self.period = match period {
+      Some(p) => Some(p.to_string()),
+      None => None
+    };
+    Ok(())
+  }
+
+  pub fn register_wave(&mut self, id: usize, name: &str) -> Result<Wave, Error> {
+    let w = Wave::new(self.model_id, self.timeset_id, self.id, id, name)?;
+    self.wave_ids.insert(String::from(name), id);
+    Ok(w)
+  }
+
+  pub fn eval(&self, current_period: Option<f64>) -> Result<Option<f64>, Error> {
+    let default = String::from("period");
+    let p = self.period.as_ref().unwrap_or(&default);
+    let err = &format!("Could not evaluate Wavetable {}'s expression: '{}'", self.name, p);
+    if current_period.is_none() && self.period.is_none() {
+      return Ok(Option::None);
+    }
+    if current_period.is_none() && eval::Expr::new(self.period.as_ref().unwrap()).exec().is_err() {
+      return Err(Error::new(&format!("No current period set for wavetable {} and cannot evaluate period '{}' as a numeric!", self.name, self.period.as_ref().unwrap())));
+    }
+    match eval::Expr::new(p).exec() {
+        Ok(val) => {
+        match val.as_f64() {
+          Some(v) => Ok(Some(v)),
+          None => Err(Error::new(err))
+        }
+      }
+      Err(_e) => Err(Error::new(err))
+    }
+  }
+
+  pub fn get_waves_applied_to(&self, dut: &super::super::super::dut::Dut, pin: &str) -> Vec<String> {
+    let mut rtn: Vec<String> = vec!();
+    for (name, id) in self.wave_ids.iter() {
+      let w = &dut.waves[*id];
+      if w.pins.contains(&pin.to_string()) {
+        rtn.push(name.clone());
+      }
+    }
+    rtn
+  }
+}
+
+#[derive(Debug)]
+pub struct Wave {
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub wavetable_id: usize,
+  pub wave_id: usize,
+  pub name: String,
+  pub events: Vec<usize>,
+  pub pins: Vec<String>,
+  pub indicator: String,
+}
+
+impl Wave {
+  pub fn new(model_id: usize, timeset_id: usize, wavetable_id: usize, wave_id: usize, name: &str) -> Result<Self, Error> {
+    Ok(Wave {
+      model_id: model_id,
+      timeset_id: timeset_id,
+      wavetable_id: wavetable_id,
+      wave_id: wave_id,
+      name: String::from(name),
+      events: vec!(),
+      pins: vec!(),
+      indicator: String::from(""),
+    })
+  }
+
+  pub fn apply_to(&mut self, pins: Vec<String>) -> Result<(), Error> {
+    // At some point, add some error handling to ensure the pins exists, isn't already included, etc.
+    // For now though, just adding it.
+    self.pins.extend(pins.clone());
+    Ok(())
+  }
+
+  pub fn set_indicator(&mut self, indicator: &str) -> Result<(), Error> {
+    // At some point, add some error checking here, preferably from feedback from the current platform (allowed indicators, etc.)
+    self.indicator = String::from(indicator);
+    Ok(())
+  }
+
+  pub fn get_event_id(&self, event_index: usize) -> Option<usize> {
+    if event_index < self.events.len() {
+      Some(self.events[event_index])
+    } else {
+      None
+    }
+  }
+
+  //pub fn register_event(&mut self, id: usize) -> Result<(), Error> {
+  pub fn push_event(&mut self, e_id: usize, at: Box<dyn std::string::ToString>, unit: Option<String>, action: &str) -> Result<Event, Error> {
+    let e = Event::new(self.wavetable_id, self.wave_id, e_id, self.events.len(), at, unit, action)?;
+    self.events.push(e_id);
+    Ok(e)
+  }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum EventActions {
+  DriveHigh,
+  DriveLow,
+  VerifyHigh,
+  VerifyLow,
+  VerifyZ,
+  HighZ,
+  Capture,
+}
+
+impl EventActions {
+  pub fn from_str(s: &str) -> Result<EventActions, Error> {
+    match s {
+        "DriveHigh" => Ok(EventActions::DriveHigh),
+        "DriveLow" => Ok(EventActions::DriveLow),
+        "VerifyHigh" => Ok(EventActions::VerifyHigh),
+        "VerifyLow" => Ok(EventActions::VerifyLow),
+        "VerifyZ" => Ok(EventActions::VerifyZ),
+        "HighZ" => Ok(EventActions::HighZ),
+        "Capture" => Ok(EventActions::Capture),
+        _ => Err(Error::new(&format!(
+            "Unsupported Event Action: '{}'",
+            s
+        ))),
+      }
+  }
+
+pub fn as_str(&self) -> &'static str {
+    match self {
+        EventActions::DriveHigh => "DriveHigh",
+        EventActions::DriveLow => "DriveLow",
+        EventActions::VerifyHigh => "VerifyHigh",
+        EventActions::VerifyLow => "VerifyLow",
+        EventActions::VerifyZ => "VerifyZ",
+        EventActions::HighZ => "HighZ",
+        EventActions::Capture => "Capture",
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct Event {
+  pub wavetable_id: usize,
+  pub wave_id: usize,
+  pub event_id: usize,
+  pub event_index: usize,
+  pub action: String,
+  pub at: String,
+  pub unit: Option<String>,
+}
+
+impl Event {
+  fn new(wavetable_id: usize, wave_id: usize, e_id: usize, e_i: usize, at: Box<dyn std::string::ToString>, unit: Option<String>, action: &str) -> Result<Self, Error> {
+    let _temp = EventActions::from_str(action)?;
+    let e = Event {
+      wavetable_id: wavetable_id,
+      wave_id: wave_id,
+      event_id: e_id,
+      event_index: e_i,
+      at: at.to_string(),
+      unit: unit,
+      action: action.to_string(),
+    };
+    Ok(e)
+  }
+
+  pub fn eval(&self, dut: &super::super::super::dut::Dut, period: Option<f64>) -> Result<f64, Error> {
+    // Try to evaluate the wavetable's period.
+    let err = &format!("Could not evaluate event expression '{}'", self.at);
+    let _period;
+    {
+      _period = dut.wavetables[self.wavetable_id].eval(period)?;
+    }
+
+    // Try to evaluate the event
+    match eval::Expr::new(&self.at).value("period", _period).exec() {
+      Ok(val) => {
+        match val.as_f64() {
+          Some(v) => Ok(v),
+          None => Err(Error::new(err))
+        }
+      }
+      Err(_e) => Err(Error::new(err))
+    }
+  }
+}
 
 #[test]
 fn test() {
-    //let e = Event { action: PinActions::Drive, at: vec!() };
-    // let t = Timeset::new("t1", Some(Box::new("1.0")), Option::None);
-    // assert_eq!(t.eval(None).unwrap(), 1.0 as f64);
+  //let e = Event { action: PinActions::Drive, at: vec!() };
+  // let t = Timeset::new("t1", Some(Box::new("1.0")), Option::None);
+  // assert_eq!(t.eval(None).unwrap(), 1.0 as f64);
 
-    let t = Timeset::new("t1", Some(Box::new("1.0 + 1")), Option::None);
-    assert!(t.eval(None).is_err());
+  let t = Timeset::new("t1", Some(Box::new("1.0 + 1")), Option::None);
+  assert!(t.eval(None).is_err());
 
-    let t = Timeset::new("t1", Some(Box::new("period")), Some(1.0 as f64));
-    assert_eq!(t.eval(Some(1.0 as f64)).unwrap(), 1.0 as f64);
+  let t = Timeset::new("t1", Some(Box::new("period")), Some(1.0 as f64));
+  assert_eq!(t.eval(Some(1.0 as f64)).unwrap(), 1.0 as f64);
 
-    let t = Timeset::new("t1", Some(Box::new("period + 0.25")), Some(1.0 as f64));
-    assert_eq!(t.eval(Some(1.0 as f64)).unwrap(), 1.25 as f64);
+  let t = Timeset::new("t1", Some(Box::new("period + 0.25")), Some(1.0 as f64));
+  assert_eq!(t.eval(Some(1.0 as f64)).unwrap(), 1.25 as f64);
 }

--- a/rust/origen/src/core/model/timesets/timeset.rs
+++ b/rust/origen/src/core/model/timesets/timeset.rs
@@ -223,7 +223,7 @@ impl WaveGroup {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Wave {
   pub model_id: usize,
   pub timeset_id: usize,
@@ -334,7 +334,7 @@ pub fn as_str(&self) -> &'static str {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Event {
   pub wavetable_id: usize,
   pub wave_id: usize,
@@ -378,6 +378,12 @@ impl Event {
       }
       Err(_e) => Err(Error::new(err))
     }
+  }
+
+  pub fn set_action(&mut self, action: &str) -> Result<(), Error> {
+    let _temp = EventActions::from_str(action)?;
+    self.action = action.to_string();
+    Ok(())
   }
 }
 

--- a/rust/origen/src/core/model/timesets/timeset.rs
+++ b/rust/origen/src/core/model/timesets/timeset.rs
@@ -321,12 +321,12 @@ fn test() {
   // let t = Timeset::new("t1", Some(Box::new("1.0")), Option::None);
   // assert_eq!(t.eval(None).unwrap(), 1.0 as f64);
 
-  let t = Timeset::new("t1", Some(Box::new("1.0 + 1")), Option::None);
+  let t = Timeset::new(0, 0, "t1", Some(Box::new("1.0 + 1")), Option::None);
   assert!(t.eval(None).is_err());
 
-  let t = Timeset::new("t1", Some(Box::new("period")), Some(1.0 as f64));
+  let t = Timeset::new(0, 0, "t1", Some(Box::new("period")), Some(1.0 as f64));
   assert_eq!(t.eval(Some(1.0 as f64)).unwrap(), 1.0 as f64);
 
-  let t = Timeset::new("t1", Some(Box::new("period + 0.25")), Some(1.0 as f64));
+  let t = Timeset::new(0, 0, "t1", Some(Box::new("period + 0.25")), Some(1.0 as f64));
   assert_eq!(t.eval(Some(1.0 as f64)).unwrap(), 1.25 as f64);
 }

--- a/rust/origen/src/lib.rs
+++ b/rust/origen/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate serde;
+extern crate meta;
 
 pub mod core;
 pub mod error;

--- a/rust/pyapi/Cargo.lock
+++ b/rust/pyapi/Cargo.lock
@@ -286,6 +286,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 
 [[package]]
+name = "meta"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +398,7 @@ dependencies = [
  "eval",
  "indexmap",
  "lazy_static 1.4.0",
+ "meta",
  "num",
  "num-bigint",
  "path-clean",
@@ -672,9 +681,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "syn"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
+checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/pyapi/Cargo.lock
+++ b/rust/pyapi/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
 name = "pyapi"
 version = "0.0.0"
 dependencies = [
+ "indexmap",
  "num-bigint",
  "origen",
  "pyo3",

--- a/rust/pyapi/Cargo.toml
+++ b/rust/pyapi/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2018"
 [lib]
 name = "_origen"
 path = "src/lib.rs"
+#proc-macro = true
+#cdylib = true
 crate-type = ["cdylib"]
 
 ## See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -14,6 +16,9 @@ crate-type = ["cdylib"]
 [dependencies]
 origen = { path = "../origen" }
 num-bigint = "0.2"
+indexmap = "1.3.0"
+#syn = "1.0.13"
+#quote = "1.0.2"
 
 [dependencies.pyo3]
 version = "0.8.2"

--- a/rust/pyapi/src/meta/py_like_apis/dict_like_api.rs
+++ b/rust/pyapi/src/meta/py_like_apis/dict_like_api.rs
@@ -1,93 +1,134 @@
-use origen::error::Error;
+//#![feature(concat_idents)]
+
 use origen::DUT;
 use pyo3::prelude::*;
+use origen::error::Error;
+use indexmap::map::IndexMap;
+// dut: &std::sync::MutexGuard<origen::core::dut::Dut>
+
+// extern crate proc_macro;
+// extern crate syn;
+// // #[macro_use]
+// extern crate quote;
+
+// use proc_macro::TokenStream;
+
+// #[proc_macro_derive(DictLikeAPI, attributes(lookup_code))]
+// pub fn derive_dict_like_api(input: TokenStream) -> TokenStream {
+//     let n = input.to_string();
+//     let ast = syn::parse_derive_input(&n).unwrap();
+//     let gen;
+//     quote! {
+//         impl DictLikeAPI for #name {
+//             fn lookup_code() {
+                
+//             }
+//         }
+//     }
+//     gen.parse().unwrap()
+// }
+
+// struct DictLikeParams {
+//     lookup_code: syn::expr;
+// }
+
+// impl Parse for DictLikeParams {
+//     fn parse(input: ParseStream) -> Result<Self> {
+//         let lookup_code = input.parse()?;
+//         Ok(DictLikeParams{lookup_code: lookup_code})
+//     }
+// }
 
 pub trait DictLikeAPI {
-    fn model_id(&self) -> usize;
-    fn lookup_key(&self) -> &str;
-    fn new_pyitem(&self, py: Python, name: &str, model_id: usize) -> Result<PyObject, Error>;
+  fn model_id(&self) -> usize;
+  fn lookup_key(&self) -> &str;
+  fn lookup_table(&self, dut: &std::sync::MutexGuard<origen::core::dut::Dut>) -> IndexMap<String, usize>;
+  fn new_pyitem(&self, py: Python, name: &str, model_id: usize) -> Result<PyObject, Error>;
 
-    fn keys(&self) -> PyResult<Vec<String>> {
-        let dut = DUT.lock().unwrap();
-        let model = dut.get_model(self.model_id())?;
-        let names = model.lookup(self.lookup_key())?;
-        Ok(names.iter().map(|(k, _)| k.clone()).collect())
+//   #[proc_macro]
+//   fn lookup_code(input: TokenStream) -> TokenStream {
+
+//   };
+
+  fn keys(&self) -> PyResult<Vec<String>> {
+    let dut = DUT.lock().unwrap();
+    let names = self.lookup_table(&dut); //model.lookup(self.lookup_key())?;
+    Ok(names.iter().map(|(k, _)| k.clone()).collect())
+  }
+
+  fn values(&self) -> PyResult<Vec<PyObject>> {
+    let dut = DUT.lock().unwrap();
+    let items = self.lookup_table(&dut);
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let mut v: Vec<PyObject> = Vec::new();
+    for (n, _item) in items {
+        v.push(self.new_pyitem(py, &n, self.model_id())?);
     }
+    Ok(v)
+  }
 
-    fn values(&self) -> PyResult<Vec<PyObject>> {
-        let mut dut = DUT.lock().unwrap();
-        let model = dut.get_mut_model(self.model_id())?;
-        let items = model.lookup(self.lookup_key())?;
+  fn items(&self) -> PyResult<Vec<(String, PyObject)>> {
+    let dut = DUT.lock().unwrap();
+    let items = self.lookup_table(&dut);
 
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let mut v: Vec<PyObject> = Vec::new();
-        for (n, _item) in items {
-            v.push(self.new_pyitem(py, n, self.model_id())?);
-        }
-        Ok(v)
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let mut _items: Vec<(String, PyObject)> = Vec::new();
+    for (n, _item) in items.iter() {
+        _items.push((
+            n.clone(),
+            self.new_pyitem(py, &n, self.model_id())?
+        ));
     }
+    Ok(_items)
+  }
 
-    fn items(&self) -> PyResult<Vec<(String, PyObject)>> {
-        let mut dut = DUT.lock().unwrap();
-        let model = dut.get_mut_model(self.model_id())?;
-        let items = model.lookup(self.lookup_key())?;
+  fn get(&self, name: &str) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let items = self.lookup_table(&dut);
+    let item = items.get(name);
 
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let mut _items: Vec<(String, PyObject)> = Vec::new();
-        for (n, _item) in items.iter() {
-            _items.push((n.clone(), self.new_pyitem(py, &n, self.model_id())?));
-        }
-        Ok(_items)
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    match item {
+        Some(_item) => Ok(self.new_pyitem(py, name, self.model_id())?),
+        None => Ok(py.None())
+      }
+  }
+
+  // Functions for PyMappingProtocol
+  fn __getitem__(&self, name: &str) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let items = self.lookup_table(&dut);
+    let item = items.get(name);
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    match item {
+        Some(_item) => Ok(self.new_pyitem(py, name, self.model_id())?),
+        None => Err(pyo3::exceptions::KeyError::py_err(format!(
+            "No pin or pin alias found for {}",
+            name
+        ))),
     }
+  }
 
-    fn get(&self, name: &str) -> PyResult<PyObject> {
-        let mut dut = DUT.lock().unwrap();
-        let model = dut.get_mut_model(self.model_id())?;
-        let item = model.lookup(self.lookup_key())?.get(name);
+  fn __len__(&self) -> PyResult<usize> {
+    let dut = DUT.lock().unwrap();
+    let items = self.lookup_table(&dut);
+    Ok(items.len())
+  }
 
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        match item {
-            Some(_item) => Ok(self.new_pyitem(py, name, self.model_id())?),
-            None => Ok(py.None()),
-        }
-    }
-
-    // Functions for PyMappingProtocol
-    fn __getitem__(&self, name: &str) -> PyResult<PyObject> {
-        let mut dut = DUT.lock().unwrap();
-        let model = dut.get_mut_model(self.model_id())?;
-        let item = model.lookup(self.lookup_key())?.get(name);
-
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        match item {
-            Some(_item) => Ok(self.new_pyitem(py, name, self.model_id())?),
-            None => Err(pyo3::exceptions::KeyError::py_err(format!(
-                "No pin or pin alias found for {}",
-                name
-            ))),
-        }
-    }
-
-    fn __len__(&self) -> PyResult<usize> {
-        let mut dut = DUT.lock().unwrap();
-        let model = dut.get_mut_model(self.model_id())?;
-        let items = model.lookup(self.lookup_key())?;
-        Ok(items.len())
-    }
-
-    fn __iter__(&self) -> PyResult<DictLikeIter> {
-        let dut = DUT.lock().unwrap();
-        let model = dut.get_model(self.model_id())?;
-        let items = model.lookup(self.lookup_key())?;
-        Ok(DictLikeIter {
-            keys: items.iter().map(|(s, _)| s.clone()).collect(),
-            i: 0,
-        })
-    }
+  fn __iter__(&self) -> PyResult<DictLikeIter> {
+    let dut = DUT.lock().unwrap();
+    let items = self.lookup_table(&dut);
+    Ok(DictLikeIter {
+        keys: items.iter().map(|(s, _)| s.clone()).collect(),
+        i: 0,
+    })
+  }
 }
 
 #[pyclass]

--- a/rust/pyapi/src/meta/py_like_apis/list_like_api.rs
+++ b/rust/pyapi/src/meta/py_like_apis/list_like_api.rs
@@ -1,1 +1,95 @@
+use origen::DUT;
+use pyo3::prelude::*;
+use origen::error::Error;
+use pyo3::types::{PyAny, PySlice};
 
+pub trait ListLikeAPI {
+  fn item_ids(&self, dut: &std::sync::MutexGuard<origen::core::dut::Dut>) -> Vec<usize>;
+  fn new_pyitem(&self, py: Python, idx: usize) -> Result<PyObject, Error>;
+  fn __iter__(&self) -> PyResult<ListLikeIter>;
+
+  fn __getitem__(&self, idx: &PyAny) -> PyResult<PyObject> {
+    if let Ok(slice) = idx.cast_as::<PySlice>() {
+      self.___getslice__(slice)
+    } else {
+      let i = idx.extract::<isize>()?;
+      self.___getitem__(i)
+    }
+  }
+
+  fn ___getitem__(&self, idx: isize) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let item_ids = self.item_ids(&dut);
+    if idx >= (item_ids.len() as isize) {
+      return Err(pyo3::exceptions::IndexError::py_err(format!(
+        "Index {} is out range of container of size {}", idx, item_ids.len()
+      )));
+    } else if idx.abs() > (item_ids.len() as isize) {
+      return Err(pyo3::exceptions::IndexError::py_err(format!(
+        "Index {} is out range of container of size {}", idx, item_ids.len()
+      )));
+    }
+    let _idx;
+    if idx >= 0 {
+      _idx = idx as usize;
+    } else {
+      _idx = ((item_ids.len() as isize) + idx) as usize ;
+    }
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(self.new_pyitem(py, _idx)?)
+  }
+
+  fn ___getslice__(&self, slice: &PySlice) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let item_ids = self.item_ids(&dut);
+    let indices = slice.indices(item_ids.len() as i32)?;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let mut rtn: Vec<PyObject> = vec!();
+    let mut i = indices.start;
+    if indices.step > 0 {
+      while i < indices.stop {
+        rtn.push(self.new_pyitem(py, i as usize)?);
+        i += indices.step;
+      }
+    } else if indices.step < 0 {
+      while i > indices.stop {
+        rtn.push(self.new_pyitem(py, i as usize)?);
+        i += indices.step;
+      }
+    }
+    Ok(rtn.to_object(py))
+  }
+
+  fn __len__(&self) -> PyResult<usize> {
+    let dut = DUT.lock().unwrap();
+    let items = self.item_ids(&dut);
+    Ok(items.len())
+  }
+}
+
+#[pyclass]
+pub struct ListLikeIter {
+    pub parent: Box<dyn ListLikeAPI>,
+    pub i: usize,
+}
+
+#[pyproto]
+impl <'p> pyo3::class::iter::PyIterProtocol<'p> for ListLikeIter {
+  fn __iter__(slf: PyRefMut<Self>) -> PyResult<PyObject> {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(slf.to_object(py))
+  }
+
+  fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<PyObject>> {
+    if slf.i >= slf.parent.__len__().unwrap() {
+      return Ok(None);
+    }
+    slf.i += 1;
+    Ok(Some(slf.parent.___getitem__((slf.i-1) as isize).unwrap()))
+  }
+}

--- a/rust/pyapi/src/meta/py_like_apis/list_like_api.rs
+++ b/rust/pyapi/src/meta/py_like_apis/list_like_api.rs
@@ -44,7 +44,7 @@ pub trait ListLikeAPI {
   fn ___getslice__(&self, slice: &PySlice) -> PyResult<PyObject> {
     let dut = DUT.lock().unwrap();
     let item_ids = self.item_ids(&dut);
-    let indices = slice.indices(item_ids.len() as i32)?;
+    let indices = slice.indices((item_ids.len() as i32).into())?;
 
     let gil = Python::acquire_gil();
     let py = gil.python();

--- a/rust/pyapi/src/timesets.rs
+++ b/rust/pyapi/src/timesets.rs
@@ -1,80 +1,86 @@
-use super::dut::PyDUT;
 use origen::DUT;
+use super::dut::PyDUT;
 use pyo3::prelude::*;
-
-#[macro_use]
-mod timeset;
-#[macro_use]
-mod timeset_container;
-
-use pyo3::types::{PyAny, PyDict};
-use timeset::Timeset;
-use timeset_container::TimesetContainer;
 
 #[macro_export]
 macro_rules! type_error {
-    ($message:expr) => {
-        Err(pyo3::exceptions::TypeError::py_err(format!("{}", $message)))
-    };
+  ($message:expr) => {
+    Err(pyo3::exceptions::TypeError::py_err(format!(
+      "{}",
+      $message
+    )))
+  };
 }
+
+#[macro_use]
+mod timeset_container;
+#[macro_use]
+mod timeset;
+
+use timeset::{Timeset, Wavetable, Wave, EventList, Event};
+use timeset_container::{TimesetContainer, WavetableContainer, WaveContainer, EventContainer};
+use pyo3::types::{PyDict, PyAny};
 
 #[pymodule]
 pub fn timesets(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<TimesetContainer>()?;
+    m.add_class::<WavetableContainer>()?;
+    m.add_class::<WaveContainer>()?;
+    m.add_class::<EventContainer>()?;
     m.add_class::<Timeset>()?;
+    m.add_class::<Wavetable>()?;
+    m.add_class::<Wave>()?;
+    m.add_class::<EventList>()?;
+    m.add_class::<Event>()?;
     Ok(())
 }
 
 #[pymethods]
 impl PyDUT {
-    #[args(kwargs = "**")]
-    fn add_timeset(
-        &self,
-        model_id: usize,
-        name: &str,
-        period: &PyAny,
-        kwargs: Option<&PyDict>,
-    ) -> PyResult<PyObject> {
-        let mut dut = DUT.lock().unwrap();
+  #[args(kwargs = "**")]
+  fn add_timeset(&self, model_id: usize, name: &str, period: &PyAny, kwargs: Option<&PyDict>) -> PyResult<PyObject> {
+    let mut dut = DUT.lock().unwrap();
 
-        dut.create_timeset(
-            model_id,
-            name,
-            if let Ok(p) = period.extract::<String>() {
-                Some(Box::new(p))
-            } else if let Ok(p) = period.extract::<f64>() {
-                Some(Box::new(p))
-            } else if period.get_type().name() == "NoneType" {
-                Option::None
-            } else {
-                return type_error!("Could not convert 'period' argument to String or NoneType!");
-            },
-            match kwargs {
-                Some(args) => match args.get_item("default_period") {
-                    Some(arg) => Some(arg.extract::<f64>()?),
-                    None => Option::None,
-                },
-                None => Option::None,
-            },
-        )?;
+    dut.create_timeset(
+      model_id,
+      name,
+      if let Ok(p) = period.extract::<String>() {
+        Some(Box::new(p))
+      } else if let Ok(p) = period.extract::<f64>() {
+        Some(Box::new(p))
+      } else if period.get_type().name() == "NoneType" {
+        Option::None
+      } else {
+        return type_error!("Could not convert 'period' argument to String or NoneType!");
+      },
+      match kwargs {
+        Some(args) => {
+          match args.get_item("default_period") {
+            Some(arg) => Some(arg.extract::<f64>()?),
+            None => Option::None,
+          }
+        },
+        None => Option::None,
+      }
+    )?;
 
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        let model = dut.get_mut_model(model_id)?;
-        Ok(pytimeset!(py, model, model_id, name)?)
-    }
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let model = dut.get_mut_model(model_id)?;
+    Ok(pytimeset!(py, model, model_id, name)?)
+  }
 
-    fn timeset(&self, model_id: usize, name: &str) -> PyResult<PyObject> {
-        let mut dut = DUT.lock().unwrap();
-        let model = dut.get_mut_model(model_id)?;
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        Ok(pytimeset_or_pynone!(py, model, model_id, name))
-    }
+  fn timeset(&self, model_id: usize, name: &str) -> PyResult<PyObject> {
+    let mut dut = DUT.lock().unwrap();
+    let model = dut.get_mut_model(model_id)?;
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pytimeset_or_pynone!(py, model, model_id, name))
+  }
 
-    fn timesets(&self, model_id: usize) -> PyResult<Py<TimesetContainer>> {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        Ok(pytimeset_container!(py, model_id))
-    }
+  fn timesets(&self, model_id: usize) -> PyResult<Py<TimesetContainer>> {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pytimeset_container!(py, model_id))
+  }
 }

--- a/rust/pyapi/src/timesets.rs
+++ b/rust/pyapi/src/timesets.rs
@@ -17,20 +17,21 @@ mod timeset_container;
 #[macro_use]
 mod timeset;
 
-use timeset::{Timeset, Wavetable, Wave, EventList, Event};
-use timeset_container::{TimesetContainer, WavetableContainer, WaveContainer, EventContainer};
+use timeset::{Timeset, Wavetable, WaveGroup, Wave, Event};
+use timeset_container::{TimesetContainer, WavetableContainer, WaveGroupContainer, WaveContainer, EventContainer};
 use pyo3::types::{PyDict, PyAny};
 
 #[pymodule]
 pub fn timesets(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<TimesetContainer>()?;
     m.add_class::<WavetableContainer>()?;
+    m.add_class::<WaveGroupContainer>()?;
     m.add_class::<WaveContainer>()?;
     m.add_class::<EventContainer>()?;
     m.add_class::<Timeset>()?;
     m.add_class::<Wavetable>()?;
+    m.add_class::<WaveGroup>()?;
     m.add_class::<Wave>()?;
-    m.add_class::<EventList>()?;
     m.add_class::<Event>()?;
     Ok(())
 }

--- a/rust/pyapi/src/timesets/timeset.rs
+++ b/rust/pyapi/src/timesets/timeset.rs
@@ -1,122 +1,577 @@
 use origen::DUT;
 use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyAny};
+use origen::error::Error;
+use super::timeset_container::{WavetableContainer, WaveContainer, EventContainer};
 
 #[macro_export]
 macro_rules! pytimeset {
-    ($py:expr, $model:expr, $model_id:expr, $name:expr) => {
-        if $model.contains_timeset($name) {
-            Ok(Py::new(
-                $py,
-                crate::timesets::timeset::Timeset {
-                    name: String::from($name),
-                    model_id: $model_id,
-                },
-            )
-            .unwrap()
-            .to_object($py))
-        } else {
-            // Note: Errors here shouldn't happen. Any errors that arise are either
-            // bugs or from the user meta-programming their way into the backend DB.
-            Err(PyErr::from(origen::error::Error::new(&format!(
-                "No timeset {} has been added on block {}",
-                $name, $model.name
-            ))))
-        }
-    };
+  ($py:expr, $model:expr, $model_id:expr, $name:expr) => {
+    if $model.contains_timeset($name) {
+      Ok(Py::new($py, crate::timesets::timeset::Timeset {
+        name: String::from($name),
+        model_id: $model_id,
+      }).unwrap().to_object($py))
+    } else {
+      // Note: Errors here shouldn't happen. Any errors that arise are either
+      // bugs or from the user meta-programming their way into the backend DB.
+      Err(PyErr::from(origen::error::Error::new(&format!("No timeset {} has been added on block {}", $name, $model.name))))
+    }
+  };
 }
 
 // Returns a (Python) Timeset or NoneType instance.
-// Note: this does NOT return a Rust Option::None, but
+// Note: this does NOT return a Rust Option::None, but 
 #[macro_export]
 macro_rules! pytimeset_or_pynone {
-    ($py:expr, $model:expr, $model_id:expr, $name:expr) => {
-        if $model.contains_timeset($name) {
-            Py::new(
-                $py,
-                crate::timesets::timeset::Timeset {
-                    name: String::from($name),
-                    model_id: $model_id,
-                },
-            )
-            .unwrap()
-            .to_object($py)
-        } else {
-            $py.None()
-        }
-    };
+  ($py:expr, $model:expr, $model_id:expr, $name:expr) => {
+    if $model.contains_timeset($name) {
+      Py::new($py, crate::timesets::timeset::Timeset {
+        name: String::from($name),
+        model_id: $model_id,
+      }).unwrap().to_object($py)
+    } else {
+      $py.None()
+    }
+  };
+}
+
+#[macro_export]
+macro_rules! pywavetable {
+  ($py:expr, $timeset:expr, $t_id:expr, $name:expr) => {
+    if $timeset.contains_wavetable($name) {
+      Ok(Py::new($py, crate::timesets::timeset::Wavetable {
+        name: String::from($name),
+        model_id: $timeset.model_id,
+        timeset_id: $timeset.id,
+      }).unwrap().to_object($py))
+    } else {
+      // Note: Errors here shouldn't happen. Any errors that arise are either
+      // bugs or from the user meta-programming their way into the backend DB.
+      Err(PyErr::from(origen::error::Error::new(&format!("No wavetable {} has been added on block {}", $name, $timeset.name))))
+    }
+  };
+}
+
+#[macro_export]
+macro_rules! pywave {
+  ($py:expr, $wavetable:expr, $name:expr) => {
+    if $wavetable.contains_wave($name) {
+      Ok(Py::new($py, crate::timesets::timeset::Wave {
+        name: String::from($name),
+        model_id: $wavetable.model_id,
+        timeset_id: $wavetable.timeset_id,
+        wavetable_id: $wavetable.id,
+      }).unwrap().to_object($py))
+    } else {
+      // Note: Errors here shouldn't happen. Any errors that arise are either
+      // bugs or from the user meta-programming their way into the backend DB.
+      Err(PyErr::from(origen::error::Error::new(&format!("No wave {} has been added on block {}", $name, $wavetable.name))))
+    }
+  };
+}
+
+#[macro_export]
+macro_rules! pyevent {
+  ($py:expr, $wave:expr, $event_index:expr) => {
+    if $wave.events.len() > $event_index {
+      Ok(Py::new($py, crate::timesets::timeset::Event {
+        model_id: $wave.model_id,
+        timeset_id: $wave.timeset_id,
+        wavetable_id: $wave.wavetable_id,
+        wave_id: $wave.wave_id,
+        wave_name: $wave.name.clone(),
+        index: $event_index,
+      }).unwrap().to_object($py))
+    } else {
+      // Note: Errors here shouldn't happen. Any errors that arise are either
+      // bugs or from the user meta-programming their way into the backend DB.
+      Err(PyErr::from(origen::error::Error::new(&format!("No event at {} has been added on wave {}", $event_index, $wave.name))))
+    }
+  };
 }
 
 #[pyclass]
 pub struct Timeset {
-    pub name: String,
-    pub model_id: usize,
+  pub name: String,
+  pub model_id: usize,
 }
 
 #[pymethods]
 impl Timeset {
-    #[getter]
-    fn get_name(&self) -> PyResult<String> {
-        let dut = DUT.lock().unwrap();
-        let timeset = dut.get_timeset(self.model_id, &self.name);
-        Ok(timeset.unwrap().name.clone())
+
+  #[getter]
+  fn get_name(&self) -> PyResult<String> {
+    let dut = DUT.lock().unwrap();
+    let timeset = dut.get_timeset(self.model_id, &self.name);
+    Ok(timeset.unwrap().name.clone())
+  }
+
+  #[getter]
+  fn get_period(&self) -> PyResult<f64> {
+    let dut = DUT.lock().unwrap();
+    let timeset = dut._get_timeset(self.model_id, &self.name)?;
+    Ok(timeset.eval(Option::None)?)
+  }
+
+  #[getter]
+  fn get_default_period(&self) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let timeset = dut._get_timeset(self.model_id, &self.name)?;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(match timeset.default_period {
+      Some(p) => p.to_object(py),
+      None => py.None(),
+    })
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  fn get___eval_str__(&self) -> PyResult<String> {
+    let dut = DUT.lock().unwrap();
+    let timeset = dut._get_timeset(self.model_id, &self.name)?;
+    Ok(timeset.eval_str().clone())
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  fn get___period__(&self) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let timeset = dut._get_timeset(self.model_id, &self.name)?;
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(match &timeset.period_as_string {
+      Some(p) => p.clone().to_object(py),
+      None => py.None(),
+    })
+  }
+
+  #[getter]
+  fn wavetables(&self) -> PyResult<Py<WavetableContainer>> {
+    let t_id;
+    {
+      t_id = self.get_origen_id()?;
     }
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pywavetable_container!(py, self.model_id, t_id, &self.name))
+  }
 
-    #[getter]
-    fn get_period(&self) -> PyResult<f64> {
-        let dut = DUT.lock().unwrap();
-        let timeset = dut._get_timeset(self.model_id, &self.name)?;
-        Ok(timeset.eval(Option::None)?)
+  #[args(_kwargs = "**")]
+  fn add_wavetable(&self, name: &str, _kwargs: Option<&PyDict>) -> PyResult<PyObject> {
+    let mut dut = DUT.lock().unwrap();
+    let t_id;
+    {
+      t_id = dut._get_timeset(self.model_id, &self.name).unwrap().id;
     }
+    dut.create_wavetable(t_id, name)?;
 
-    #[getter]
-    fn get_default_period(&self) -> PyResult<PyObject> {
-        let dut = DUT.lock().unwrap();
-        let timeset = dut._get_timeset(self.model_id, &self.name)?;
-
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        Ok(match timeset.default_period {
-            Some(p) => p.to_object(py),
-            None => py.None(),
-        })
-    }
-
-    #[allow(non_snake_case)]
-    #[getter]
-    fn get___eval_str__(&self) -> PyResult<String> {
-        let dut = DUT.lock().unwrap();
-        let timeset = dut._get_timeset(self.model_id, &self.name)?;
-        Ok(timeset.eval_str().clone())
-    }
-
-    #[allow(non_snake_case)]
-    #[getter]
-    fn get___period__(&self) -> PyResult<PyObject> {
-        let dut = DUT.lock().unwrap();
-        let timeset = dut._get_timeset(self.model_id, &self.name)?;
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        Ok(match &timeset.period_as_string {
-            Some(p) => p.clone().to_object(py),
-            None => py.None(),
-        })
-    }
-
-    // #[getter]
-    // fn get_drive_waves(&self) -> PyResult<Py<DriveWaveContainer> {
-    //   // ...
-    // }
-    // #[getter]
-    // fn get_verify_waves(&self) -> PyResult<Py<DriveWaveContainer> {
-    //   // ...
-    // }
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let tset = dut._get_timeset(self.model_id, &self.name).unwrap();
+    Ok(pywavetable!(py, tset, t_id, name)?)
+  }
 }
 
 impl Timeset {
-    pub fn new(name: &str, model_id: usize) -> Self {
-        Self {
-            name: String::from(name),
-            model_id: model_id,
-        }
+  pub fn new(name: &str, model_id: usize) -> Self {
+    Self {
+      name: String::from(name),
+      model_id: model_id
     }
+  }
+
+  pub fn get_origen_id(&self) -> Result<usize, Error> {
+    let dut = DUT.lock().unwrap();
+    let timeset = dut._get_timeset(self.model_id, &self.name)?;
+    Ok(timeset.id)
+  }
+}
+
+#[pyclass]
+pub struct Wavetable {
+  pub timeset_id: usize,
+  pub name: String,
+  pub model_id: usize,
+}
+
+#[pymethods]
+impl Wavetable {
+
+  #[args(_kwargs = "**")]
+  fn add_wave(&self, name: &str, _kwargs: Option<&PyDict>) -> PyResult<PyObject>  {
+    let mut dut = DUT.lock().unwrap();
+    let w_id;
+    {
+      w_id = dut.get_wavetable(self.timeset_id, &self.name).unwrap().id;
+    }
+    dut.create_wave(w_id, name)?;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let wt = dut.get_wavetable(self.timeset_id, &self.name).unwrap();
+    Ok(pywave!(py, wt, name)?)
+  }
+
+  #[getter]
+  fn get_waves(&self) -> PyResult<Py<WaveContainer>> {
+    let w_id;
+    {
+      w_id = self.get_origen_id()?;
+    }
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(pywave_container!(py, self.model_id, self.timeset_id, w_id, &self.name))
+  }
+
+  #[getter]
+  fn get_name(&self) -> PyResult<String> {
+    let dut = DUT.lock().unwrap();
+    let wt = dut.get_wavetable(self.timeset_id, &self.name);
+    Ok(wt.unwrap().name.clone())
+  }
+
+  // Evaluates and returns the period.
+  // Returns None if no period was specified or an error if it could not be evaluated.
+  #[getter]
+  pub fn get_period(&self) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let wt = dut.get_wavetable(self.timeset_id, &self.name);
+    let p = wt.unwrap().eval(Option::None)?;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    match p {
+      Some(_p) => Ok(_p.to_object(py)),
+      None => Ok(py.None()),
+    }
+  }
+
+  // From the Python side, want to support receiving input as either an expression (String)
+  // or as hard coded integer/float values..
+  #[setter]
+  pub fn set_period(&self, period: &PyAny) -> PyResult<()> {
+    let mut dut = DUT.lock().unwrap();
+    let wt = dut.get_mut_wavetable(self.timeset_id, &self.name).unwrap();
+    if let Ok(p) = period.extract::<String>() {
+      wt.set_period(Some(Box::new(p)))?;
+    } else if let Ok(p) = period.extract::<f64>() {
+      wt.set_period(Some(Box::new(p)))?;
+    } else if period.get_type().name() == "NoneType" {
+      wt.set_period(Option::None)?;
+    } else {
+      return super::super::type_error!(format!("Could not interpret 'period' argument as Numeric, String, or NoneType! (class '{}')", period.get_type().name()));
+    };
+    Ok(())
+  }
+
+  // Returns the period as a string before evaluation.
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get___period__(&self) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let wt = dut.get_wavetable(self.timeset_id, &self.name);
+    let p = &wt.unwrap().period;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    match p {
+      Some(_p) => Ok(_p.to_object(py)),
+      None => Ok(py.None()),
+    }
+  }
+}
+
+impl Wavetable {
+  pub fn new(model_id: usize, timeset_id: usize, name: &str) -> Self {
+    Self {
+      timeset_id: timeset_id,
+      name: String::from(name),
+      model_id: model_id
+    }
+  }
+
+  pub fn get_origen_id(&self) -> Result<usize, Error> {
+    let dut = DUT.lock().unwrap();
+    let timeset = &dut.timesets[self.timeset_id];
+    let w_id = timeset.get_wavetable_id(&self.name).unwrap();
+    Ok(w_id)
+  }
+}
+
+#[pyclass]
+pub struct Wave {
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub wavetable_id: usize,
+  pub name: String,
+}
+
+#[pymethods]
+impl Wave {
+  #[getter]
+  fn get_events(&self) -> PyResult<Py<EventContainer>> {
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let wave_id;
+    {
+      wave_id = self.get_origen_id()?;
+    }
+    Ok(pyevent_container!(py, self.model_id, self.timeset_id, self.wavetable_id, wave_id, &self.name))
+  }
+
+  #[args(event="**")]
+  fn push_event(&self, event: Option<&PyDict>) -> PyResult<PyObject> {
+    let mut dut = DUT.lock().unwrap();
+    let (w_id, e_index);
+    {
+      w_id = dut.get_wave(self.wavetable_id, &self.name).unwrap().wave_id;
+    }
+
+    if event.is_none() {
+      return type_error!("Keywords 'at' and 'action' are required to push a new event!");
+    }
+
+    let (at, unit, action) = (
+      event.unwrap().get_item("at"), 
+      event.unwrap().get_item("unit"),
+      event.unwrap().get_item("action")
+    );
+    {
+      // Resolve the 'action' keyword first because rust is a pain in the butt.
+      // This is required and can only be a String.
+      let temp: String;
+      match action {
+        Some(_action) => {
+          if let Ok(val) = _action.extract::<String>() {
+            temp = val;
+          } else if _action.is_none() {
+            return type_error!("'action' keyword is required (found None)!")
+          } else {
+            return type_error!("Could not interpret 'action' argument as String!")
+          }
+        },
+        None => return type_error!("'action' keyword is required!")
+      }
+      let e = dut.create_event(
+        w_id,
+
+        // Resolve the 'at' keyword. This is required and can be either a String or a numeric.
+        match at {
+          Some(_at) => {
+            if let Ok(val) = _at.extract::<String>() {
+              Box::new(val)
+            } else if let Ok(val) = _at.extract::<f64>() {
+              Box::new(val)
+            } else if _at.is_none() {
+              return type_error!("'at' keyword is required (found None)!")
+            } else {
+              return type_error!("Could not interpret 'at' argument as String or Numeric!");
+            }
+          },
+          None => return type_error!("'at' keyword is required!")
+        },
+
+        // Resolve the 'unit' keyword. This is optional and can only be a string.
+        match unit {
+          Some(_unit) => {
+            if let Ok(val) = _unit.extract::<String>() {
+              Some(val)
+            } else if _unit.is_none() {
+              Option::None
+            } else {
+              return type_error!("Could not interpret 'unit' argument as String or NoneType!")
+            }
+          },
+          None => Option::None
+        },
+        &temp,
+      )?;
+      e_index = e.event_index;
+    }
+    
+    // Return the newly created event
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+
+    let w = dut.get_wave(self.wavetable_id, &self.name).unwrap();
+    Ok(pyevent!(py, w, e_index)?)
+  }
+
+  #[getter]
+  fn get_indicator(&self) -> PyResult<String> {
+    let dut = DUT.lock().unwrap();
+    let w = dut.get_wave(self.wavetable_id, &self.name).unwrap();
+    Ok(w.indicator.clone())
+  }
+
+  #[setter]
+  fn set_indicator(&self, indicator: &str) -> PyResult<()> {
+    let mut dut = DUT.lock().unwrap();
+    let w = dut.get_mut_wave(self.wavetable_id, &self.name).unwrap();
+    w.set_indicator(&indicator)?;
+    Ok(())
+  }
+
+  #[getter]
+  fn get_applied_to(&self) -> PyResult<Vec<String>> {
+    let dut = DUT.lock().unwrap();
+    let w = dut.get_wave(self.wavetable_id, &self.name).unwrap();
+    Ok(w.pins.clone())
+  }
+
+  #[args(pins="*")]
+  fn apply_to(&self, pins: Vec<String>) -> PyResult<PyObject> {
+    let mut dut = DUT.lock().unwrap();
+    let w = dut.get_mut_wave(self.wavetable_id, &self.name).unwrap();
+    w.apply_to(pins)?;
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(Py::new(py, crate::timesets::timeset::Wave {
+      name: self.name.clone(),
+      model_id: self.model_id,
+      timeset_id: self.timeset_id,
+      wavetable_id: self.wavetable_id,
+    }).unwrap().to_object(py))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_name(&self) -> PyResult<String> {
+    Ok(self.name.clone())
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_DriveHigh(&self) -> PyResult<String> {
+    Ok(String::from("DriveHigh"))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_DriveLow(&self) -> PyResult<String> {
+    Ok(String::from("DriveLow"))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_HighZ(&self) -> PyResult<String> {
+    Ok(String::from("HighZ"))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_VerifyHigh(&self) -> PyResult<String> {
+    Ok(String::from("VerifyHigh"))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_VerifyLow(&self) -> PyResult<String> {
+    Ok(String::from("VerifyLow"))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_VerifyZ(&self) -> PyResult<String> {
+    Ok(String::from("VerifyZ"))
+  }
+
+  #[allow(non_snake_case)]
+  #[getter]
+  pub fn get_Capture(&self) -> PyResult<String> {
+    Ok(String::from("Capture"))
+  }
+}
+
+impl Wave {
+  pub fn new(model_id: usize, timeset_id: usize, wavetable_id: usize, name: &str) -> Self {
+    Self {
+      model_id: model_id,
+      timeset_id: timeset_id,
+      wavetable_id: wavetable_id,
+      name: String::from(name),
+    }
+  }
+
+  pub fn get_origen_id(&self) -> Result<usize, Error> {
+    let dut = DUT.lock().unwrap();
+    let wavetable = &dut.wavetables[self.wavetable_id];
+    let w_id = wavetable.get_wave_id(&self.name).unwrap();
+    Ok(w_id)
+  }
+}
+
+#[pyclass]
+pub struct EventList {
+  pub model_id: usize,
+  pub timeset_id: String,
+  pub wavetable_id: String,
+  pub wave_name: String,
+}
+
+#[pyclass]
+pub struct Event {
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub wavetable_id: usize,
+  pub wave_id: usize,
+  pub wave_name: String,
+  pub index: usize,
+}
+
+#[pymethods]
+impl Event {
+  #[getter]
+  pub fn action(&self) -> PyResult<String> {
+    let dut = DUT.lock().unwrap();
+    let e = dut.get_event(self.wave_id, self.index).unwrap();
+    Ok(e.action.clone())
+  }
+
+  #[getter]
+  pub fn unit(&self) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let e = dut.get_event(self.wave_id, self.index).unwrap();
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    match &e.unit {
+      Some(unit) => Ok(unit.clone().to_object(py)),
+      None => Ok(py.None())
+    }
+  }
+
+  #[getter]
+  pub fn at(&self) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let e = dut.get_event(self.wave_id, self.index).unwrap();
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    Ok(e.eval(&dut, Option::None)?.to_object(py))
+  }
+
+  #[getter]
+  pub fn __at__(&self) -> PyResult<String> {
+    let dut = DUT.lock().unwrap();
+    let e = dut.get_event(self.wave_id, self.index).unwrap();
+    Ok(e.at.clone())
+  }
+}
+
+impl Event {
+  pub fn new(model_id: usize, timeset_id:usize, wavetable_id: usize, wave_id: usize, wave_name: &str, id: usize) -> Self {
+    Self {
+      model_id: model_id,
+      timeset_id: timeset_id,
+      wavetable_id: wavetable_id,
+      wave_id: wave_id,
+      wave_name: String::from(wave_name),
+      index: id,
+    }
+  }
 }

--- a/rust/pyapi/src/timesets/timeset_container.rs
+++ b/rust/pyapi/src/timesets/timeset_container.rs
@@ -1,75 +1,283 @@
-use super::super::meta::py_like_apis::dict_like_api::{DictLikeAPI, DictLikeIter};
-use origen::error::Error;
-use pyo3::class::mapping::*;
 use pyo3::prelude::*;
+use pyo3::class::mapping::*;
+use origen::error::Error;
+use super::super::meta::py_like_apis::dict_like_api::{DictLikeAPI, DictLikeIter};
+use super::super::meta::py_like_apis::list_like_api::{ListLikeAPI, ListLikeIter};
+use indexmap::map::IndexMap;
+use pyo3::types::{PyAny, PyDict};
+use super::super::timesets::*;
 
 #[macro_export]
 macro_rules! pytimeset_container {
-    ($py:expr, $model_id:expr) => {
-        Py::new(
-            $py,
-            TimesetContainer {
-                model_id: $model_id,
-            },
-        )
-        .unwrap()
-    };
+  ($py:expr, $model_id:expr) => {
+    Py::new($py, TimesetContainer {model_id: $model_id}).unwrap()
+  };
 }
 
 #[pyclass]
 pub struct TimesetContainer {
-    pub model_id: usize,
+  pub model_id: usize,
 }
 
 #[pymethods]
 impl TimesetContainer {
-    fn keys(&self) -> PyResult<Vec<String>> {
-        DictLikeAPI::keys(self)
-    }
+  fn keys(&self) -> PyResult<Vec<String>> {
+    DictLikeAPI::keys(self)
+  }
 
-    fn values(&self) -> PyResult<Vec<PyObject>> {
-        DictLikeAPI::values(self)
-    }
+  fn values(&self) -> PyResult<Vec<PyObject>> {
+    DictLikeAPI::values(self)
+  }
 
-    fn items(&self) -> PyResult<Vec<(String, PyObject)>> {
-        DictLikeAPI::items(self)
-    }
+  fn items(&self) -> PyResult<Vec<(String, PyObject)>> {
+    DictLikeAPI::items(self)
+  }
 
-    fn get(&self, name: &str) -> PyResult<PyObject> {
-        DictLikeAPI::get(self, name)
-    }
+  fn get(&self, name: &str) -> PyResult<PyObject> {
+    DictLikeAPI::get(self, name)
+  }
 }
 
 impl DictLikeAPI for TimesetContainer {
-    fn lookup_key(&self) -> &str {
-        &"timesets"
-    }
+  fn lookup_key(&self) -> &str {
+    &"timesets"
+  }
 
-    fn model_id(&self) -> usize {
-        self.model_id
-    }
+  fn lookup_table(&self, dut: &std::sync::MutexGuard<origen::core::dut::Dut>) -> IndexMap<String, usize> {
+    dut.get_model(self.model_id).unwrap().timesets.clone()
+  }
 
-    fn new_pyitem(&self, py: Python, name: &str, model_id: usize) -> Result<PyObject, Error> {
-        Ok(Py::new(py, super::timeset::Timeset::new(name, model_id))
-            .unwrap()
-            .to_object(py))
-    }
+  fn model_id(&self) -> usize {
+    self.model_id
+  }
+
+  fn new_pyitem(&self, py: Python, name: &str, model_id: usize) -> Result<PyObject, Error> {
+    Ok(Py::new(py, super::timeset::Timeset::new(name, model_id)).unwrap().to_object(py))
+  }
 }
 
 #[pyproto]
 impl PyMappingProtocol for TimesetContainer {
     fn __getitem__(&self, name: &str) -> PyResult<PyObject> {
-        DictLikeAPI::__getitem__(self, name)
+      DictLikeAPI::__getitem__(self, name)
     }
 
     fn __len__(&self) -> PyResult<usize> {
-        DictLikeAPI::__len__(self)
+      DictLikeAPI::__len__(self)
     }
 }
 
 #[pyproto]
 impl pyo3::class::iter::PyIterProtocol for TimesetContainer {
-    fn __iter__(slf: PyRefMut<Self>) -> PyResult<DictLikeIter> {
-        DictLikeAPI::__iter__(&*slf)
+  fn __iter__(slf: PyRefMut<Self>) -> PyResult<DictLikeIter> {
+    DictLikeAPI::__iter__(&*slf)
+  }
+}
+
+#[macro_export]
+macro_rules! pywavetable_container {
+  ($py:expr, $model_id:expr, $timeset_id:expr, $timeset_name:expr) => {
+    Py::new($py, WavetableContainer {model_id: $model_id, timeset_id: $timeset_id, timeset_name: String::from($timeset_name)}).unwrap()
+  };
+}
+
+/// WaveTable Container
+#[pyclass]
+pub struct WavetableContainer {
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub timeset_name: String,
+}
+
+#[pymethods]
+impl WavetableContainer {
+  fn keys(&self) -> PyResult<Vec<String>> {
+    DictLikeAPI::keys(self)
+  }
+
+  fn values(&self) -> PyResult<Vec<PyObject>> {
+    DictLikeAPI::values(self)
+  }
+
+  fn items(&self) -> PyResult<Vec<(String, PyObject)>> {
+    DictLikeAPI::items(self)
+  }
+
+  fn get(&self, name: &str) -> PyResult<PyObject> {
+    DictLikeAPI::get(self, name)
+  }
+}
+
+impl DictLikeAPI for WavetableContainer {
+  fn lookup_key(&self) -> &str {
+    &"wavetables"
+  }
+
+  fn lookup_table(&self, dut: &std::sync::MutexGuard<origen::core::dut::Dut>) -> IndexMap<String, usize> {
+    dut.timesets[self.timeset_id].wavetable_ids.clone()
+  }
+
+  fn model_id(&self) -> usize {
+    self.model_id
+  }
+
+  fn new_pyitem(&self, py: Python, name: &str, model_id: usize) -> Result<PyObject, Error> {
+    Ok(Py::new(py, super::timeset::Wavetable::new(model_id, self.timeset_id, name)).unwrap().to_object(py))
+  }
+}
+
+#[pyproto]
+impl PyMappingProtocol for WavetableContainer {
+    fn __getitem__(&self, name: &str) -> PyResult<PyObject> {
+      DictLikeAPI::__getitem__(self, name)
     }
+
+    fn __len__(&self) -> PyResult<usize> {
+      DictLikeAPI::__len__(self)
+    }
+}
+
+#[pyproto]
+impl pyo3::class::iter::PyIterProtocol for WavetableContainer {
+  fn __iter__(slf: PyRefMut<Self>) -> PyResult<DictLikeIter> {
+    DictLikeAPI::__iter__(&*slf)
+  }
+}
+
+#[macro_export]
+macro_rules! pywave_container {
+  ($py:expr, $model_id:expr, $timeset_id:expr, $wavetable_id:expr, $name:expr) => {
+    Py::new($py, WaveContainer {model_id: $model_id, timeset_id: $timeset_id, wavetable_id: $wavetable_id, name: String::from($name)}).unwrap()
+  };
+}
+
+/// Wave Container
+#[pyclass]
+pub struct WaveContainer {
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub wavetable_id: usize,
+  pub name: String,
+}
+
+#[pymethods]
+impl WaveContainer {
+  fn keys(&self) -> PyResult<Vec<String>> {
+    DictLikeAPI::keys(self)
+  }
+
+  fn values(&self) -> PyResult<Vec<PyObject>> {
+    DictLikeAPI::values(self)
+  }
+
+  fn items(&self) -> PyResult<Vec<(String, PyObject)>> {
+    DictLikeAPI::items(self)
+  }
+
+  fn get(&self, name: &str) -> PyResult<PyObject> {
+    DictLikeAPI::get(self, name)
+  }
+
+  fn applied_to(&self, pin: String) -> PyResult<PyObject> {
+    let dut = DUT.lock().unwrap();
+    let wtbl = &dut.wavetables[self.wavetable_id];
+
+    let gil = Python::acquire_gil();
+    let py = gil.python();
+    let rtn = PyDict::new(py);
+    for name in wtbl.get_waves_applied_to(&dut, &pin).iter() {
+      rtn.set_item(name.clone(), self.new_pyitem(py, &name, self.model_id)?)?;
+    }
+    Ok(rtn.to_object(py))
+  }
+}
+
+impl DictLikeAPI for WaveContainer {
+  fn lookup_key(&self) -> &str {
+    &"waves"
+  }
+
+  fn lookup_table(&self, dut: &std::sync::MutexGuard<origen::core::dut::Dut>) -> IndexMap<String, usize> {
+    dut.wavetables[self.wavetable_id].wave_ids.clone()
+  }
+
+  fn model_id(&self) -> usize {
+    self.model_id
+  }
+
+  fn new_pyitem(&self, py: Python, name: &str, model_id: usize) -> Result<PyObject, Error> {
+    Ok(Py::new(py, super::timeset::Wave::new(model_id, self.timeset_id, self.wavetable_id, name)).unwrap().to_object(py))
+  }
+}
+
+#[pyproto]
+impl PyMappingProtocol for WaveContainer {
+    fn __getitem__(&self, name: &str) -> PyResult<PyObject> {
+      DictLikeAPI::__getitem__(self, name)
+    }
+
+    fn __len__(&self) -> PyResult<usize> {
+      DictLikeAPI::__len__(self)
+    }
+}
+
+#[pyproto]
+impl pyo3::class::iter::PyIterProtocol for WaveContainer {
+  fn __iter__(slf: PyRefMut<Self>) -> PyResult<DictLikeIter> {
+    DictLikeAPI::__iter__(&*slf)
+  }
+}
+
+#[macro_export]
+macro_rules! pyevent_container {
+  ($py:expr, $model_id:expr, $timeset_id:expr, $wavetable_id:expr, $wave_id:expr, $wave_name:expr) => {
+    Py::new($py, EventContainer {model_id: $model_id, timeset_id: $timeset_id, wavetable_id: $wavetable_id, wave_id: $wave_id, wave_name: String::from($wave_name)}).unwrap()
+  };
+}
+
+/// EventList Container
+#[pyclass]
+#[derive(Clone)]
+pub struct EventContainer {
+  pub model_id: usize,
+  pub timeset_id: usize,
+  pub wavetable_id: usize,
+  pub wave_id: usize,
+  pub wave_name: String,
+}
+
+#[pymethods]
+impl EventContainer {
+}
+
+impl ListLikeAPI for EventContainer {
+  fn item_ids(&self, dut: &std::sync::MutexGuard<origen::core::dut::Dut>) -> Vec<usize> {
+    dut.waves[self.wave_id].events.clone()
+  }
+
+  fn new_pyitem(&self, py: Python, idx: usize) -> Result<PyObject, Error> {
+    Ok(Py::new(py, super::timeset::Event::new(self.model_id, self.timeset_id, self.wavetable_id, self.wave_id, &self.wave_name, idx)).unwrap().to_object(py))
+  }
+
+  fn __iter__(&self) -> PyResult<ListLikeIter> {
+    Ok(ListLikeIter {parent: Box::new((*self).clone()), i: 0})
+  }
+}
+
+#[pyproto]
+impl pyo3::class::mapping::PyMappingProtocol for EventContainer {
+  fn __getitem__(&self, idx: &PyAny) -> PyResult<PyObject> {
+    ListLikeAPI::__getitem__(self, idx)
+  }
+
+  fn __len__(&self) -> PyResult<usize> {
+    ListLikeAPI::__len__(self)
+  }
+}
+
+#[pyproto]
+impl pyo3::class::iter::PyIterProtocol for EventContainer {
+  fn __iter__(slf: PyRefMut<Self>) -> PyResult<ListLikeIter> {
+    ListLikeAPI::__iter__(&*slf)
+  }
 }


### PR DESCRIPTION
Hello,

Here're some updates to give `timesets` a bit more flexibility. The structure was based off the STIL spec and is organized more or less as a tree via `timeset -> wavetable -> wave group -> wave -> event`.

Currently, instantiating timing can be rather verbose. Adding just a couple of waves can get a bit messy.. [see the instantiation here](https://github.com/Origen-SDK/o2/blob/timing2/example/tests/timing_test.py#L242-L311). That said, this PR is more just to get the general structure down. I think that this structure can represent any timesets that we'd encounter and should be able to handle complex timings that we see in scan (and modeled off of STIL for that reason).

For this PR, I'm looking more for feedback on timing that we still can't represent. #63 was just to get something on the board and with this I'm hoping to get an interface that can represent anything we'd need. If there doesn't seem to be any missing pieces here for the representation itself, then I'll start adding some more user-friendly features to it. Context managers, some shortcut methods (`add_drive_wave, add_verify_wave, etc.`), and the like can all be added later as long as the underlying representation is sufficient. Though, crazy timings may still need to fall back to the more verbose API, but I think that'd be expected, and why its there.

The only things I think I'm missing from STIL are inheritance and bases. I did some [minor inheritance here, just a wave-to-wave inheritance,](https://github.com/Origen-SDK/o2/blob/timing2/example/tests/timing_test.py#L359-L366) to make sure that the structure I had in the backend wasn't going to hit the borrow-checker wall. It seems to hold up alright with a wave creation able to access another wave and its events, so moving up the ladder shouldn't be a problem. This'll also help with the above point in addition to rounding out STIL support.

Some other things that're along for the ride:
* [Travis seems to be fixed now so we can hopefully get CI going again](https://travis-ci.org/Origen-SDK/o2/builds/643174051).
* I added a [`list-like`](https://github.com/Origen-SDK/o2/blob/timing2/rust/pyapi/src/meta/py_like_apis/list_like_api.rs) trait and an accompanying [pytest spec](https://github.com/Origen-SDK/o2/blob/timing2/example/tests/shared/python_like_apis.py#L98-L291) to go along with the `dict-like` from before. Adding a `contains` test for backend objects requires overriding the equality operators, which I haven't tried yet, so for now I just have a [basic test to make sure it doesn't crash](https://github.com/Origen-SDK/o2/blob/timing2/example/tests/shared/python_like_apis.py#L249-L255). For non-Origen objects though, it should work alright.