### PR TITLE
Added initial file argument handler

### DIFF
--- a/python/origen/boot.py
+++ b/python/origen/boot.py
@@ -2,6 +2,7 @@
 from __future__ import print_function, unicode_literals, absolute_import
 
 import sys
+import pdb
 
 if sys.platform == "win32":
     # The below is needed only for pyreadline, which is needed only for Windows support.
@@ -88,7 +89,7 @@ if sys.platform == "win32":
 
 # Called by the Origen CLI to boot the Origen Python env, not for application use
 # Any target/env overrides given to the command line will be passed in here
-def __origen__(command, target=None, environment=None, mode=None):
+def __origen__(command, target=None, environment=None, mode=None, files=None):
     import origen
     import _origen
     import origen.application
@@ -99,10 +100,18 @@ def __origen__(command, target=None, environment=None, mode=None):
     else:
         origen.set_mode(mode)
 
+    if files is not None:
+        _origen.file_handler().init(files)
+
     origen.target.load(target=target, environment=environment)
 
     if command == "generate":
         print("Generate command called!")
+
+    elif command == "compile":
+        for file in _origen.file_handler():
+            # Invoke compiler here
+            pass
 
     elif command == "interactive":
         import atexit, os, sys, colorama, termcolor, readline, rlcompleter

--- a/python/origen/boot.py
+++ b/python/origen/boot.py
@@ -2,7 +2,6 @@
 from __future__ import print_function, unicode_literals, absolute_import
 
 import sys
-import pdb
 
 if sys.platform == "win32":
     # The below is needed only for pyreadline, which is needed only for Windows support.

--- a/python/origen/target.py
+++ b/python/origen/target.py
@@ -6,6 +6,7 @@ def load(target=None, environment=None):
     app = origen.app
     if target == None:
         target = _origen.app_config()["target"]
+
     if environment == None:
         environment = _origen.app_config()["environment"]
 

--- a/rust/origen/cli/src/bin.rs
+++ b/rust/origen/cli/src/bin.rs
@@ -73,6 +73,7 @@ fn main() {
                     .takes_value(true)
                     .value_name("FILES")
                     .multiple(true)
+                    .required(true)
                 )
                 .arg(Arg::with_name("target")
                     .short("t")
@@ -106,6 +107,7 @@ fn main() {
                     .takes_value(true)
                     .value_name("FILES")
                     .multiple(true)
+                    .required(true)
                 )
                 .arg(Arg::with_name("target")
                     .short("t")
@@ -191,6 +193,7 @@ fn main() {
                     &m.value_of("target"),
                     &m.value_of("environment"),
                     &m.value_of("mode"),
+                    Some(m.values_of("files").unwrap().collect()),
                 );
             }
             Some("compile") => {
@@ -200,6 +203,7 @@ fn main() {
                     &m.value_of("target"),
                     &m.value_of("environment"),
                     &m.value_of("mode"),
+                    Some(m.values_of("files").unwrap().collect()),
                 );
             }
             Some("target") => {

--- a/rust/origen/cli/src/commands/interactive.rs
+++ b/rust/origen/cli/src/commands/interactive.rs
@@ -14,5 +14,5 @@ pub fn run(target: &Option<&str>, environment: &Option<&str>, mode: &Option<&str
             .open(&history_file);
     }
 
-    super::launch("interactive", target, environment, mode);
+    super::launch("interactive", target, environment, mode, None);
 }

--- a/rust/origen/cli/src/commands/mod.rs
+++ b/rust/origen/cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub fn launch(
     target: &Option<&str>,
     environment: &Option<&str>,
     mode: &Option<&str>,
+    files: Option<Vec<&str>>,
 ) {
     let mut cmd = format!(
         "from origen.boot import __origen__; __origen__('{}'",
@@ -31,6 +32,11 @@ pub fn launch(
     if mode.is_some() {
         let c = clean_mode(mode.unwrap());
         cmd += &format!(", mode='{}'", c).to_string();
+    }
+
+    if files.is_some() {
+        let f: Vec<String> = files.unwrap().iter().map(|f| format!("'{}'", f)).collect();
+        cmd += &format!(", files=[{}]", f.join(",")).to_string();
     }
 
     cmd += ");";

--- a/rust/origen/src/core/file_handler.rs
+++ b/rust/origen/src/core/file_handler.rs
@@ -13,7 +13,7 @@ lazy_static! {
 
 #[derive(Debug)]
 /// This struct is used as a singleton to store a permanent record of the file arguments
-/// given to the current command and the clean list of files this resolves too (lazily evaluated)
+/// given to the current command and the clean list of files this resolves to
 struct Files {
     /// The file arguments as originally supplied
     items: Vec<String>,

--- a/rust/origen/src/core/file_handler.rs
+++ b/rust/origen/src/core/file_handler.rs
@@ -1,0 +1,94 @@
+//! The file_handler is responsible for processing the file arguments supplied
+//! to Origen commands from the CLI.
+//! It provides methods for consumers to retreive one file at a time or all files
+//! at once and seamlessly opens up lists to get to the inidividual files inside.
+
+use crate::{Error, Result};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref FILES: Mutex<Files> = Mutex::new(Files::new());
+}
+
+#[derive(Debug)]
+/// This struct is used as a singleton to store a permanent record of the file arguments
+/// given to the current command and the clean list of files this resolves too (lazily evaluated)
+struct Files {
+    /// The file arguments as originally supplied
+    items: Vec<String>,
+    /// The resultant list of files from resolving any lists in the original args
+    files: Vec<PathBuf>,
+}
+
+impl Files {
+    fn new() -> Files {
+        Files {
+            items: Vec::new(),
+            files: Vec::new(),
+        }
+    }
+
+    /// Load a new set of file arguments
+    fn init(&mut self, mut files: Vec<String>) -> Result<()> {
+        self.items.clear();
+        self.items.append(&mut files);
+        self.files.clear();
+        self.resolve()?;
+        Ok(())
+    }
+
+    fn file(&mut self, index: usize) -> Option<PathBuf> {
+        if index < self.files.len() {
+            Some(self.files[index].clone())
+        } else {
+            None
+        }
+    }
+
+    // Eventually this will open up list and directory args
+    fn resolve(&mut self) -> Result<()> {
+        for item in &self.items {
+            match Path::new(item).canonicalize() {
+                Ok(x) => self.files.push(x),
+                Err(err) => return Err(Error::new(&format!("{} - {}", err.to_string(), item))),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+/// This is an iterator + external API for consuming the file list
+pub struct FileHandler {
+    i: usize,
+}
+
+impl FileHandler {
+    pub fn new() -> FileHandler {
+        FileHandler { i: 0 }
+    }
+
+    pub fn init(&mut self, files: Vec<String>) -> Result<()> {
+        let mut f = FILES.lock().unwrap();
+        f.init(files)?;
+        self.i = 0;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        let f = FILES.lock().unwrap();
+        f.files.len()
+    }
+}
+
+impl Iterator for FileHandler {
+    type Item = PathBuf;
+
+    fn next(&mut self) -> Option<PathBuf> {
+        let mut f = FILES.lock().unwrap();
+        let r = f.file(self.i);
+        self.i += 1;
+        r
+    }
+}

--- a/rust/origen/src/core/mod.rs
+++ b/rust/origen/src/core/mod.rs
@@ -1,6 +1,7 @@
 pub mod application;
 pub mod config;
 pub mod dut;
+pub mod file_handler;
 pub mod model;
 pub mod os;
 pub mod status;

--- a/rust/origen/src/error.rs
+++ b/rust/origen/src/error.rs
@@ -51,3 +51,9 @@ impl std::convert::From<Error> for PyErr {
         exceptions::OSError::py_err(err.msg)
     }
 }
+
+impl std::convert::From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Error::new(&err.to_string())
+    }
+}

--- a/rust/pyapi/src/file_handler.rs
+++ b/rust/pyapi/src/file_handler.rs
@@ -1,0 +1,53 @@
+use origen::core::file_handler::FileHandler as CoreFileHandler;
+use pyo3::class::PyMappingProtocol;
+use pyo3::prelude::*;
+
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct FileHandler {
+    inner: CoreFileHandler,
+}
+
+impl FileHandler {
+    pub fn new() -> FileHandler {
+        FileHandler {
+            inner: CoreFileHandler::new(),
+        }
+    }
+}
+
+#[pymethods]
+impl FileHandler {
+    /// Entry point for the Python process to supply Rust with the file arguments
+    /// for the current command that were collected from the CLI, should only be called
+    /// once at the start of an Origen invocation
+    fn init(&mut self, files: Vec<String>) -> PyResult<()> {
+        self.inner.init(files)?;
+        Ok(())
+    }
+
+    fn len(&self) -> PyResult<usize> {
+        Ok(self.inner.len())
+    }
+}
+
+#[pyproto]
+impl PyMappingProtocol for FileHandler {
+    fn __len__(&self) -> PyResult<usize> {
+        Ok(self.inner.len())
+    }
+}
+
+#[pyproto]
+impl pyo3::class::iter::PyIterProtocol for FileHandler {
+    fn __iter__(slf: PyRefMut<Self>) -> PyResult<FileHandler> {
+        Ok(slf.clone())
+    }
+
+    fn __next__(mut slf: PyRefMut<Self>) -> PyResult<Option<String>> {
+        match slf.inner.next() {
+            Some(x) => Ok(Some(x.display().to_string())),
+            None => Ok(None),
+        }
+    }
+}

--- a/rust/pyapi/src/lib.rs
+++ b/rust/pyapi/src/lib.rs
@@ -1,4 +1,5 @@
 mod dut;
+mod file_handler;
 mod logger;
 mod meta;
 mod pins;
@@ -22,10 +23,18 @@ fn _origen(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(app_config))?;
     m.add_wrapped(wrap_pyfunction!(clean_mode))?;
     m.add_wrapped(wrap_pyfunction!(target_file))?;
+    m.add_wrapped(wrap_pyfunction!(file_handler))?;
 
     m.add_wrapped(wrap_pymodule!(logger))?;
     m.add_wrapped(wrap_pymodule!(dut))?;
     Ok(())
+}
+
+/// Returns a file handler object (iterable) for consuming the file arguments
+/// given to the CLI
+#[pyfunction]
+fn file_handler() -> PyResult<file_handler::FileHandler> {
+    Ok(file_handler::FileHandler::new())
 }
 
 /// Returns the Origen status which informs whether an app is present, the Origen version,


### PR DESCRIPTION
Adds initial handling of the CLI command FILE argument.

@info-rchitect, here's the point for you to hook in the template compiler - https://github.com/Origen-SDK/o2/blob/compile_cmd/python/origen/boot.py#L114

Eventually the Rust side of this will be enhanced to expand directory and list file references, and maybe even handle some basic ifdef-style logic within list files. Nothing is expected to change on the Python side.

Invoke from the CLI as you would expect: `origen c path/to/template.txt`



