### PR TITLE
Simplified AST node definition

### DIFF
--- a/rust/origen/src/generator/ast.rs
+++ b/rust/origen/src/generator/ast.rs
@@ -76,75 +76,7 @@ impl Node {
     /// Returning None means that the processor has decided that the node should be removed
     /// from the next stage AST.
     pub fn process(&self, processor: &mut dyn Processor) -> Option<Node> {
-        // Call the dedicated handler for this node if it exists
-        let r = match &self.attrs {
-            Attrs::Test(name) => processor.on_test(&name, &self),
-            Attrs::Comment(level, msg) => processor.on_comment(*level, &msg, &self),
-            Attrs::PinWrite(id, data) => processor.on_pin_write(*id, *data),
-            Attrs::PinVerify(id, data) => processor.on_pin_verify(*id, *data),
-            Attrs::RegWrite(id, data, overlay_enable, overlay_str) => {
-                processor.on_reg_write(*id, data, overlay_enable, overlay_str)
-            }
-            Attrs::RegVerify(
-                id,
-                data,
-                verify_enable,
-                capture_enable,
-                overlay_enable,
-                overlay_str,
-            ) => processor.on_reg_verify(
-                *id,
-                data,
-                verify_enable,
-                capture_enable,
-                overlay_enable,
-                overlay_str,
-            ),
-            Attrs::JTAGWriteIR(size, data, overlay_enable, overlay_str) => {
-                processor.on_jtag_write_ir(*size, data, overlay_enable, overlay_str)
-            }
-            Attrs::JTAGVerifyIR(
-                size,
-                data,
-                verify_enable,
-                capture_enable,
-                overlay_enable,
-                overlay_str,
-            ) => processor.on_jtag_verify_ir(
-                *size,
-                data,
-                verify_enable,
-                capture_enable,
-                overlay_enable,
-                overlay_str,
-            ),
-            Attrs::JTAGWriteDR(size, data, overlay_enable, overlay_str) => {
-                processor.on_jtag_write_dr(*size, data, overlay_enable, overlay_str)
-            }
-            Attrs::JTAGVerifyDR(
-                size,
-                data,
-                verify_enable,
-                capture_enable,
-                overlay_enable,
-                overlay_str,
-            ) => processor.on_jtag_verify_dr(
-                *size,
-                data,
-                verify_enable,
-                capture_enable,
-                overlay_enable,
-                overlay_str,
-            ),
-            Attrs::Cycle(repeat, compressable) => processor.on_cycle(*repeat, *compressable, &self),
-            Attrs::Flow(name) => processor.on_flow(&name, &self),
-            _ => Return::_Unimplemented,
-        };
-        // If not, call the default handler all nodes handler
-        let r = match r {
-            Return::_Unimplemented => processor.on_all(&self),
-            _ => r,
-        };
+        let r = processor.on_node(&self);
         self.process_return_code(r, processor)
     }
 }
@@ -522,7 +454,6 @@ impl Node {
                 nodes.into_iter().map(|n| Box::new(n)).collect(),
             )),
             Return::InlineBoxed(nodes) => Some(Node::inline(nodes)),
-            _ => None,
         }
     }
 

--- a/rust/origen/src/generator/processor.rs
+++ b/rust/origen/src/generator/processor.rs
@@ -1,18 +1,11 @@
-//!
 //! The processor API is intentionally placed in a separate modele from the AST/Node
 //! to ensure that processor implementations use the Node API rather than coupling to its
 //! internals (i.e. children vector) which could be subject to change.
 
 use crate::generator::ast::*;
-use num_bigint::BigUint;
 
 /// All procesor handler methods should return this
 pub enum Return {
-    /// This is the value returned by the default Processor trait handlers
-    /// and is used to indicated that a given processor has not implemented a
-    /// handler for a given node type. Implementations of the Processor trait
-    /// should never return this type.
-    _Unimplemented,
     /// Deletes the node from the output AST.
     None,
     /// Clones the node (and all of its children) into the output AST. Note that
@@ -34,12 +27,8 @@ pub enum Return {
     InlineBoxed(Vec<Box<Node>>),
 }
 
-// Implements default handlers for all node types
 pub trait Processor {
-    /// This will be called for all nodes unless a dedicated handler
-    /// handler exists for the given node type. It means that by default, all
-    /// nodes will have their children processed by all processors.
-    fn on_all(&mut self, _node: &Node) -> Return {
+    fn on_node(&mut self, _node: &Node) -> Return {
         Return::ProcessChildren
     }
 
@@ -49,95 +38,5 @@ pub trait Processor {
     /// here, it should either be None or a new node(s)
     fn on_end_of_block(&mut self, _node: &Node) -> Return {
         Return::None
-    }
-
-    fn on_test(&mut self, _name: &str, _node: &Node) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_comment(&mut self, _level: u8, _msg: &str, _node: &Node) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_pin_write(&mut self, _id: usize, _data: u128) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_pin_verify(&mut self, _id: usize, _data: u128) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_reg_write(
-        &mut self,
-        _id: usize,
-        _data: &BigUint,
-        _overlay_enable: &Option<BigUint>,
-        _overlay_str: &Option<String>,
-    ) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_reg_verify(
-        &mut self,
-        _id: usize,
-        _data: &BigUint,
-        _verify_enable: &Option<BigUint>,
-        _capture_enable: &Option<BigUint>,
-        _overlay_enable: &Option<BigUint>,
-        _overlay_str: &Option<String>,
-    ) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_jtag_write_ir(
-        &mut self,
-        _size: u32,
-        _data: &BigUint,
-        _overlay_enable: &Option<BigUint>,
-        _overlay_str: &Option<String>,
-    ) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_jtag_verify_ir(
-        &mut self,
-        _size: u32,
-        _data: &BigUint,
-        _verify_enable: &Option<BigUint>,
-        _capture_enable: &Option<BigUint>,
-        _overlay_enable: &Option<BigUint>,
-        _overlay_str: &Option<String>,
-    ) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_jtag_write_dr(
-        &mut self,
-        _size: u32,
-        _data: &BigUint,
-        _overlay_enable: &Option<BigUint>,
-        _overlay_str: &Option<String>,
-    ) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_jtag_verify_dr(
-        &mut self,
-        _size: u32,
-        _data: &BigUint,
-        _verify_enable: &Option<BigUint>,
-        _capture_enable: &Option<BigUint>,
-        _overlay_enable: &Option<BigUint>,
-        _overlay_str: &Option<String>,
-    ) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_cycle(&mut self, _repeat: u32, _compressable: bool, _node: &Node) -> Return {
-        Return::_Unimplemented
-    }
-
-    fn on_flow(&mut self, _name: &str, _node: &Node) -> Return {
-        Return::_Unimplemented
     }
 }

--- a/rust/origen/src/generator/processors/to_string.rs
+++ b/rust/origen/src/generator/processors/to_string.rs
@@ -21,7 +21,7 @@ impl ToString {
 }
 
 impl Processor for ToString {
-    fn on_all(&mut self, node: &Node) -> Return {
+    fn on_node(&mut self, node: &Node) -> Return {
         self.output += &" ".repeat(self.indent);
         self.output += &format!("{:?}\n", node.attrs);
         self.indent += 4;

--- a/rust/origen/src/generator/processors/upcase_comments.rs
+++ b/rust/origen/src/generator/processors/upcase_comments.rs
@@ -15,9 +15,14 @@ impl UpcaseComments {
 }
 
 impl Processor for UpcaseComments {
-    fn on_comment(&mut self, level: u8, msg: &str, node: &Node) -> Return {
-        let new_node = node.replace_attrs(Attrs::Comment(level, msg.to_uppercase()));
-        Return::Replace(new_node)
+    fn on_node(&mut self, node: &Node) -> Return {
+        match &node.attrs {
+            Attrs::Comment(level, msg) => {
+                let new_node = node.replace_attrs(Attrs::Comment(*level, msg.to_uppercase()));
+                Return::Replace(new_node)
+            }
+            _ => Return::ProcessChildren,
+        }
     }
 }
 


### PR DESCRIPTION
I started writing a STIL parser and when creating the AST for it I quickly realized that the existing way to add new nodes was extremely tedious - the node had to be defined, then a call to its handler and then a default handler for it.

With this update the process of adding a new node is greatly simplified, only the node definition is now required.
The processors don't require any significant additional code to support this, but they have to be changed slightly - instead of implementing handler methods for each node type they care about, they should only now define one method (`on_node`) and then create a match inside that to handle the nodes that they care about.

For example, an existing processor with a handler method like this:

~~~rust
fn on_comment(&mut self, level: u8, msg: &str, node: &Node) -> Return {
    let new_node = node.replace_attrs(Attrs::Comment(level, msg.to_uppercase()));
    Return::Replace(new_node)
}
~~~

would be changed to this:

~~~rust
fn on_node(&mut self, node: &Node) -> Return {
    match &node.attrs {
            Attrs::Comment(level, msg) => {
                let new_node = node.replace_attrs(Attrs::Comment(*level, msg.to_uppercase()));
                Return::Replace(new_node)
            }
            // Instructs the processor to walk through the children of all other node types
            _ => Return::ProcessChildren,
        }
    }
}
~~~

If the processor wished to handle additional node types then it would simply add additional branches to the match statement.
        
