### PR TITLE
Added result to processor output

### DIFF
--- a/rust/origen/src/generator/mod.rs
+++ b/rust/origen/src/generator/mod.rs
@@ -79,7 +79,7 @@ mod tests {
 
         // Test upcase comments processor
 
-        let new_ast = test.process(&|ast| UpcaseComments::run(ast));
+        let new_ast = test.process(&|ast| UpcaseComments::run(ast).expect("comments upcased"));
 
         let mut ast = AST::new(node!(Test, "trim_vbgap".to_string()));
         ast.push(node!(Comment, 1, "HELLO".to_string()));
@@ -105,7 +105,7 @@ mod tests {
 
         // Test cycle combiner processor
 
-        let new_ast = CycleCombiner::run(&new_ast);
+        let new_ast = CycleCombiner::run(&new_ast).unwrap();
 
         let mut ast = AST::new(node!(Test, "trim_vbgap".to_string()));
         ast.push(node!(Comment, 1, "HELLO".to_string()));

--- a/rust/origen/src/generator/processor.rs
+++ b/rust/origen/src/generator/processor.rs
@@ -3,6 +3,7 @@
 //! internals (i.e. children vector) which could be subject to change.
 
 use crate::generator::ast::*;
+pub use crate::Result;
 
 /// All procesor handler methods should return this
 pub enum Return {
@@ -28,15 +29,15 @@ pub enum Return {
 }
 
 pub trait Processor {
-    fn on_node(&mut self, _node: &Node) -> Return {
-        Return::ProcessChildren
+    fn on_node(&mut self, _node: &Node) -> Result<Return> {
+        Ok(Return::ProcessChildren)
     }
 
     /// This will be called at the end of processing every node which has children.
     /// The node which is about to be closed is provided in the arguments.
     /// Note that you should probably never return a derivative of the given node
     /// here, it should either be None or a new node(s)
-    fn on_end_of_block(&mut self, _node: &Node) -> Return {
-        Return::None
+    fn on_end_of_block(&mut self, _node: &Node) -> Result<Return> {
+        Ok(Return::None)
     }
 }

--- a/rust/origen/src/generator/processors/cycle_combiner.rs
+++ b/rust/origen/src/generator/processors/cycle_combiner.rs
@@ -9,9 +9,9 @@ pub struct CycleCombiner {
 
 impl CycleCombiner {
     #[allow(dead_code)]
-    pub fn run(node: &Node) -> Node {
+    pub fn run(node: &Node) -> Result<Node> {
         let mut p = CycleCombiner { cycle_count: 0 };
-        node.process(&mut p).unwrap()
+        Ok(node.process(&mut p)?.unwrap())
     }
 
     fn consume_cycles(&mut self) -> Node {
@@ -22,40 +22,40 @@ impl CycleCombiner {
 }
 
 impl Processor for CycleCombiner {
-    fn on_node(&mut self, node: &Node) -> Return {
+    fn on_node(&mut self, node: &Node) -> Result<Return> {
         match &node.attrs {
             Attrs::Cycle(repeat, compressable) => {
                 if *compressable {
                     self.cycle_count += repeat;
-                    Return::None
+                    Ok(Return::None)
                 } else {
                     if self.cycle_count > 0 {
                         let cyc = self.consume_cycles();
-                        Return::Inline(vec![cyc, node.clone()])
+                        Ok(Return::Inline(vec![cyc, node.clone()]))
                     } else {
-                        Return::Unmodified
+                        Ok(Return::Unmodified)
                     }
                 }
             }
             // For all other nodes except for cycles
             _ => {
                 if self.cycle_count == 0 {
-                    Return::ProcessChildren
+                    Ok(Return::ProcessChildren)
                 } else {
                     let cyc = self.consume_cycles();
-                    let new_node = node.process_children(self);
-                    Return::Inline(vec![cyc, new_node])
+                    let new_node = node.process_children(self)?;
+                    Ok(Return::Inline(vec![cyc, new_node]))
                 }
             }
         }
     }
 
     // Don't let it leave an open block with cycles pending
-    fn on_end_of_block(&mut self, _node: &Node) -> Return {
+    fn on_end_of_block(&mut self, _node: &Node) -> Result<Return> {
         if self.cycle_count > 0 {
-            Return::Replace(self.consume_cycles())
+            Ok(Return::Replace(self.consume_cycles()))
         } else {
-            Return::None
+            Ok(Return::None)
         }
     }
 }

--- a/rust/origen/src/generator/processors/to_string.rs
+++ b/rust/origen/src/generator/processors/to_string.rs
@@ -15,18 +15,18 @@ impl ToString {
             indent: 0,
             output: "".to_string(),
         };
-        node.process(&mut p);
+        node.process(&mut p).unwrap();
         p.output
     }
 }
 
 impl Processor for ToString {
-    fn on_node(&mut self, node: &Node) -> Return {
+    fn on_node(&mut self, node: &Node) -> Result<Return> {
         self.output += &" ".repeat(self.indent);
         self.output += &format!("{:?}\n", node.attrs);
         self.indent += 4;
-        node.process_children(self);
+        node.process_children(self)?;
         self.indent -= 4;
-        Return::Unmodified
+        Ok(Return::Unmodified)
     }
 }

--- a/rust/origen/src/generator/processors/upcase_comments.rs
+++ b/rust/origen/src/generator/processors/upcase_comments.rs
@@ -8,20 +8,20 @@ pub struct UpcaseComments {}
 
 impl UpcaseComments {
     #[allow(dead_code)]
-    pub fn run(node: &Node) -> Node {
+    pub fn run(node: &Node) -> Result<Node> {
         let mut p = UpcaseComments {};
-        node.process(&mut p).unwrap()
+        Ok(node.process(&mut p)?.unwrap())
     }
 }
 
 impl Processor for UpcaseComments {
-    fn on_node(&mut self, node: &Node) -> Return {
+    fn on_node(&mut self, node: &Node) -> Result<Return> {
         match &node.attrs {
             Attrs::Comment(level, msg) => {
                 let new_node = node.replace_attrs(Attrs::Comment(*level, msg.to_uppercase()));
-                Return::Replace(new_node)
+                Ok(Return::Replace(new_node))
             }
-            _ => Return::ProcessChildren,
+            _ => Ok(Return::ProcessChildren),
         }
     }
 }
@@ -41,6 +41,9 @@ mod tests {
         expect.push(node!(Cycle, 1, false));
         expect.push(node!(Comment, 1, "SOME COMMENT".to_string()));
 
-        assert_eq!(UpcaseComments::run(&ast.to_node()), expect);
+        assert_eq!(
+            UpcaseComments::run(&ast.to_node()).expect("Comments upcased"),
+            expect
+        );
     }
 }


### PR DESCRIPTION
Hi @coreyeng, another AST processor update...

I've got a STIL parser now working and have moved onto processing it.
When writing a real-life processor It quickly became clear that they will be able to generate errors and currently the only way to deal with those is to panic.

This update makes all processor's `on_node` methods return a `Result<Return>` instead of just a `Return` code.

I toyed with adding an error code to the existing `Return` enum, however that would mean that `?` couldn't be used within the `on_node` implementations to bubble errors which would be inconvenient and unexpected/unusual from a coding perspective.
I had a look to see if there was a result trait that could be added to `Return`, but I couldn't find anything like that.

The net effect of this on processors doesn't seem too bad, and basically boils down to returning something like `Ok(Return::ProcessChildren)` instead of `Return::ProcessChildren`.
