### PR TITLE
Command Launcher Update

### DIFF
--- a/rust/origen/cli/src/commands/mod.rs
+++ b/rust/origen/cli/src/commands/mod.rs
@@ -20,7 +20,8 @@ pub fn launch(
     );
 
     if let Some(t) = targets {
-        let _t: Vec<String> = t.iter().map(|__t| format!("'{}'", __t)).collect();
+        // added r prefix to the string to force python to interpret as a string literal
+        let _t: Vec<String> = t.iter().map(|__t| format!("r'{}'", __t)).collect();
         cmd += &format!(", targets=[{}]", &_t.join(",")).to_string();
     }
 

--- a/rust/origen/cli/src/commands/mod.rs
+++ b/rust/origen/cli/src/commands/mod.rs
@@ -30,7 +30,8 @@ pub fn launch(
     }
 
     if files.is_some() {
-        let f: Vec<String> = files.unwrap().iter().map(|f| format!("'{}'", f)).collect();
+        // added r prefix to the string to force python to interpret as a string literal
+        let f: Vec<String> = files.unwrap().iter().map(|f| format!("r'{}'", f)).collect();
         cmd += &format!(", files=[{}]", f.join(",")).to_string();
     }
 

--- a/rust/origen/cli/src/commands/setup.rs
+++ b/rust/origen/cli/src/commands/setup.rs
@@ -2,11 +2,13 @@ extern crate time;
 
 use crate::python::{poetry_version, MIN_PYTHON_VERSION, PYTHON_CONFIG};
 use online::online;
-use origen::core::os;
+//use origen::core::os;
 use origen::core::term::*;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
+use std::ffi::OsString;
+use std::process::Command;
 
 const POETRY_INSTALLER: &str =
     "https://raw.githubusercontent.com/sdispater/poetry/1.0.0b7/get-poetry.py";
@@ -64,13 +66,15 @@ pub fn run() {
                 fs::read_to_string(&get_poetry_file).expect("Unable to read Poetry install file");
             let new_data = data.replace(
                 "/bin/env python",
-                &format!("/bin/env {}", PYTHON_CONFIG.command),
+                &format!("/bin/env {}", PYTHON_CONFIG.command.clone().into_string().unwrap()),
             );
             fs::write(&get_poetry_file, new_data).expect("Unable to write Poetry install file");
 
             // Install Poetry
-            os::cmd(&PYTHON_CONFIG.command)
-                .arg(format!("{}", get_poetry_file.display()))
+            //os::cmd(&PYTHON_CONFIG.command)
+            Command::new(&PYTHON_CONFIG.command)
+                //.arg(format!("{}", get_poetry_file.display()))
+                .arg(get_poetry_file)
                 .arg("--yes")
                 .status()
                 .expect("Something went wrong install Poetry");
@@ -78,9 +82,10 @@ pub fn run() {
             if poetry_version().unwrap().major != 1 {
                 // Have to use --preview here to get a 1.0.0 pre version, can only use versions for
                 // official releases
-                os::cmd(&PYTHON_CONFIG.poetry_command)
-                    .arg("self:update")
-                    .arg("--preview")
+                //os::cmd(&PYTHON_CONFIG.poetry_command)
+                Command::new(&PYTHON_CONFIG.poetry_command)
+                    .arg(OsString::from("self:update"))
+                    .arg(OsString::from("--preview"))
                     .status()
                     .expect("Something wend wrong updating Poetry");
             }
@@ -90,9 +95,10 @@ pub fn run() {
 
     print!("Are the app's deps. installed?  ... ");
 
-    let status = os::cmd(&PYTHON_CONFIG.poetry_command)
-        .arg("install")
-        .arg("--no-root")
+    //let status = os::cmd(&PYTHON_CONFIG.poetry_command)
+    let status = Command::new(&PYTHON_CONFIG.poetry_command)
+        .arg(OsString::from("install"))
+        .arg(OsString::from("--no-root"))
         .status();
 
     if status.is_ok() {

--- a/rust/origen/cli/src/commands/setup.rs
+++ b/rust/origen/cli/src/commands/setup.rs
@@ -6,7 +6,6 @@ use origen::core::term::*;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
-use std::ffi::OsString;
 use std::process::Command;
 
 const POETRY_INSTALLER: &str =
@@ -65,7 +64,7 @@ pub fn run() {
                 fs::read_to_string(&get_poetry_file).expect("Unable to read Poetry install file");
             let new_data = data.replace(
                 "/bin/env python",
-                &format!("/bin/env {}", PYTHON_CONFIG.command.clone().into_string().unwrap()),
+                &format!("/bin/env {}", PYTHON_CONFIG.command),
             );
             fs::write(&get_poetry_file, new_data).expect("Unable to write Poetry install file");
 
@@ -80,8 +79,8 @@ pub fn run() {
                 // Have to use --preview here to get a 1.0.0 pre version, can only use versions for
                 // official releases
                 Command::new(&PYTHON_CONFIG.poetry_command)
-                    .arg(OsString::from("self:update"))
-                    .arg(OsString::from("--preview"))
+                    .arg("self:update")
+                    .arg("--preview")
                     .status()
                     .expect("Something wend wrong updating Poetry");
             }
@@ -92,8 +91,8 @@ pub fn run() {
     print!("Are the app's deps. installed?  ... ");
 
     let status = Command::new(&PYTHON_CONFIG.poetry_command)
-        .arg(OsString::from("install"))
-        .arg(OsString::from("--no-root"))
+        .arg("install")
+        .arg("--no-root")
         .status();
 
     if status.is_ok() {

--- a/rust/origen/cli/src/commands/setup.rs
+++ b/rust/origen/cli/src/commands/setup.rs
@@ -2,7 +2,6 @@ extern crate time;
 
 use crate::python::{poetry_version, MIN_PYTHON_VERSION, PYTHON_CONFIG};
 use online::online;
-//use origen::core::os;
 use origen::core::term::*;
 use std::fs;
 use std::io;
@@ -71,9 +70,7 @@ pub fn run() {
             fs::write(&get_poetry_file, new_data).expect("Unable to write Poetry install file");
 
             // Install Poetry
-            //os::cmd(&PYTHON_CONFIG.command)
             Command::new(&PYTHON_CONFIG.command)
-                //.arg(format!("{}", get_poetry_file.display()))
                 .arg(get_poetry_file)
                 .arg("--yes")
                 .status()
@@ -82,7 +79,6 @@ pub fn run() {
             if poetry_version().unwrap().major != 1 {
                 // Have to use --preview here to get a 1.0.0 pre version, can only use versions for
                 // official releases
-                //os::cmd(&PYTHON_CONFIG.poetry_command)
                 Command::new(&PYTHON_CONFIG.poetry_command)
                     .arg(OsString::from("self:update"))
                     .arg(OsString::from("--preview"))
@@ -95,7 +91,6 @@ pub fn run() {
 
     print!("Are the app's deps. installed?  ... ");
 
-    //let status = os::cmd(&PYTHON_CONFIG.poetry_command)
     let status = Command::new(&PYTHON_CONFIG.poetry_command)
         .arg(OsString::from("install"))
         .arg(OsString::from("--no-root"))

--- a/rust/origen/cli/src/python.rs
+++ b/rust/origen/cli/src/python.rs
@@ -102,7 +102,6 @@ fn extract_version(text: &str) -> Option<Version> {
 
 /// Execute the given Python code
 pub fn run(code: &str) {
-    //let _status = os::cmd(&PYTHON_CONFIG.poetry_command)
     let _status = Command::new(&PYTHON_CONFIG.poetry_command)
         .arg("run")
         .arg(&PYTHON_CONFIG.command)

--- a/rust/origen/cli/src/python.rs
+++ b/rust/origen/cli/src/python.rs
@@ -1,7 +1,6 @@
 // Responsible for managing Python execution
 
 use std::process::Command;
-use std::ffi::OsString;
 use origen::STATUS;
 use semver::Version;
 use std::path::PathBuf;
@@ -22,7 +21,7 @@ lazy_static! {
 
 pub struct Config {
     pub available: bool,
-    pub command: OsString,
+    pub command: String,
     pub version: Version,
     pub error: String,
     pub poetry_command: PathBuf,
@@ -41,7 +40,7 @@ impl Default for Config {
                     if version >= Version::parse(MIN_PYTHON_VERSION).unwrap() {
                         return Config {
                             available: true,
-                            command: OsString::from(cmd.to_string()),
+                            command: cmd.to_string(),
                             version: version,
                             error: "".to_string(),
                             poetry_command: poetry_cmd,
@@ -57,7 +56,7 @@ impl Default for Config {
         }
         Config {
             available: false,
-            command: OsString::new(),
+            command: String::new(),
             version: Version::parse("0.0.0").unwrap(),
             error: msg,
             poetry_command: PathBuf::new(),
@@ -67,7 +66,7 @@ impl Default for Config {
 
 /// Get the Python version from the given command
 fn get_version(command: &str) -> Option<Version> {
-    match Command::new(OsString::from(command)).arg("--version").output() {
+    match Command::new(command).arg("--version").output() {
         Ok(output) => return extract_version(std::str::from_utf8(&output.stdout).unwrap()),
         Err(_e) => return None,
     }
@@ -105,7 +104,7 @@ pub fn run(code: &str) {
         .arg("run")
         .arg(&PYTHON_CONFIG.command)
         .arg("-c")
-        .arg(OsString::from(&code))
+        .arg(&code)
         .status();
 }
 

--- a/rust/origen/cli/src/python.rs
+++ b/rust/origen/cli/src/python.rs
@@ -1,6 +1,5 @@
 // Responsible for managing Python execution
 
-//use origen::core::os;
 use std::process::Command;
 use std::ffi::OsString;
 use origen::STATUS;

--- a/rust/origen/src/core/os.rs
+++ b/rust/origen/src/core/os.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+//use std::process::Command;
 
 pub fn on_windows() -> bool {
     if cfg!(windows) {

--- a/rust/origen/src/core/os.rs
+++ b/rust/origen/src/core/os.rs
@@ -1,5 +1,3 @@
-//use std::process::Command;
-
 pub fn on_windows() -> bool {
     if cfg!(windows) {
         return true;
@@ -15,17 +13,3 @@ pub fn on_linux() -> bool {
         return false;
     };
 }
-
-// Due to OS differences, the basic std::process::Command doesn't cooperate very well in a Windows environment.
-// Instead, wrap the cmd function here, which will ensures some semblance between Windows and Linux commands.
-//#[allow(unused_mut)]
-//pub fn cmd(cmd: &str) -> std::process::Command {
-//    if on_windows() {
-//        let mut c = Command::new("cmd");
-//        c.arg("/C").arg(&cmd);
-//        return c;
-//    } else {
-//        let mut c = Command::new(&cmd);
-//        return c;
-//    }
-//}

--- a/rust/origen/src/core/os.rs
+++ b/rust/origen/src/core/os.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::ffi::OsString;
 
 pub fn on_windows() -> bool {
     if cfg!(windows) {
@@ -21,8 +22,10 @@ pub fn on_linux() -> bool {
 #[allow(unused_mut)]
 pub fn cmd(cmd: &str) -> std::process::Command {
     if on_windows() {
-        let mut c = Command::new("cmd");
-        c.arg("/C").arg(&cmd);
+        //let mut c = Command::new("cmd");
+        //c.arg("/C").arg(&cmd);
+        //return c;
+        let mut c = Command::new(OsString::from(cmd));
         return c;
     } else {
         let mut c = Command::new(&cmd);

--- a/rust/origen/src/core/os.rs
+++ b/rust/origen/src/core/os.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-use std::ffi::OsString;
 
 pub fn on_windows() -> bool {
     if cfg!(windows) {
@@ -19,16 +18,14 @@ pub fn on_linux() -> bool {
 
 // Due to OS differences, the basic std::process::Command doesn't cooperate very well in a Windows environment.
 // Instead, wrap the cmd function here, which will ensures some semblance between Windows and Linux commands.
-#[allow(unused_mut)]
-pub fn cmd(cmd: &str) -> std::process::Command {
-    if on_windows() {
-        //let mut c = Command::new("cmd");
-        //c.arg("/C").arg(&cmd);
-        //return c;
-        let mut c = Command::new(OsString::from(cmd));
-        return c;
-    } else {
-        let mut c = Command::new(&cmd);
-        return c;
-    }
-}
+//#[allow(unused_mut)]
+//pub fn cmd(cmd: &str) -> std::process::Command {
+//    if on_windows() {
+//        let mut c = Command::new("cmd");
+//        c.arg("/C").arg(&cmd);
+//        return c;
+//    } else {
+//        let mut c = Command::new(&cmd);
+//        return c;
+//    }
+//}


### PR DESCRIPTION
fixes #27 

@ginty recommended using <code>PathBuf</code> it cleaned up a lot of the issues I was seeing. I don't know that all of the added <code>OsString</code> is necessary. In my testing I had better luck when using <code>OsString</code>. In any case the string has to be converted to the appropriate type for the system eventually. So, no harm (in my view).

@coreyeng can you kick the tires a bit?

I think the os.rs file becomes basically unused in this branch. I left it in for now.