### PR TITLE
Cli tests

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,11 +35,10 @@ main() {
     if [ "$O2_REGRESSION" = "BACKEND" ]; then
         cd origen
         #cargo test --target $TARGET --release
-        cargo test --target $TARGET
-        # cli tests were skipped, change to dir to run them
-        cd cli
-        cargo test
-        cd ../../
+        # cli tests were skipped, think --workspace is needed here to also run tests in the bin dirs
+        export TRAVIS_ORIGEN_CLI="./target/$TARGET/debug/origen"
+        cargo test --target $TARGET --workspace
+        cd ../
     else
         # pass the path for the CLI tests to work
         export TRAVIS_ORIGEN_CLI="../rust/origen/target/$TARGET/debug/origen"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -36,7 +36,7 @@ main() {
         cd origen
         #cargo test --target $TARGET --release
         cargo test --target $TARGET
-        # cli tests were skipped, trying with --all
+        # cli tests were skipped above
         cd cli
         export TRAVIS_ORIGEN_CLI="../target/$TARGET/debug/origen"
         cargo test --target $TARGET

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -36,8 +36,8 @@ main() {
         cd origen
         #cargo test --target $TARGET --release
         # cli tests were skipped, think --workspace is needed here to also run tests in the bin dirs
-        export TRAVIS_ORIGEN_CLI="./target/$TARGET/debug/origen"
-        cargo test --target $TARGET --workspace
+        export TRAVIS_ORIGEN_CLI="target/$TARGET/debug/origen"
+        cargo test  --workspace --target $TARGET
         cd ../
     else
         # pass the path for the CLI tests to work

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,7 +35,8 @@ main() {
     if [ "$O2_REGRESSION" = "BACKEND" ]; then
         cd origen
         #cargo test --target $TARGET --release
-        cargo test --target $TARGET
+        # cli tests were skipped, think --workspace is needed here to also run tests in the bin dirs
+        cargo test --target $TARGET --workspace
         cd ../
     else
         # pass the path for the CLI tests to work

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -38,7 +38,8 @@ main() {
         cargo test --target $TARGET
         # cli tests were skipped above
         cd cli
-        export TRAVIS_ORIGEN_CLI="../target/$TARGET/debug/origen"
+        # don't know why this isn't set by cargo in the ci env
+        export CARGO_BIN_EXE_ORIGEN="../target/$TARGET/debug/origen"
         cargo test --target $TARGET
         cd ../../
     else

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -37,9 +37,10 @@ main() {
         #cargo test --target $TARGET --release
         cargo test --target $TARGET
         # cli tests were skipped, trying with --all
-        #export TRAVIS_ORIGEN_CLI="./target/$TARGET/debug/origen"
-        cargo test --all
-        cd ../
+        cd cli
+        export TRAVIS_ORIGEN_CLI="../target/$TARGET/debug/origen"
+        cargo test --target $TARGET
+        cd ../../
     else
         # pass the path for the CLI tests to work
         export TRAVIS_ORIGEN_CLI="../rust/origen/target/$TARGET/debug/origen"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -38,6 +38,8 @@ main() {
         cargo test --target $TARGET
         cd ../
     else
+        # pass the path for the CLI tests to work
+        export TRAVIS_ORIGEN_CLI="../rust/origen/target/$TARGET/debug/origen"
         cd ../example
         ../rust/origen/target/$TARGET/debug/origen -v
         ../rust/origen/target/$TARGET/debug/origen setup

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,9 +35,11 @@ main() {
     if [ "$O2_REGRESSION" = "BACKEND" ]; then
         cd origen
         #cargo test --target $TARGET --release
-        # cli tests were skipped, think --workspace is needed here to also run tests in the bin dirs
-        cargo test --target $TARGET --workspace
-        cd ../
+        cargo test --target $TARGET
+        # cli tests were skipped, change to dir to run them
+        cd cli
+        cargo test
+        cd ../../
     else
         # pass the path for the CLI tests to work
         export TRAVIS_ORIGEN_CLI="../rust/origen/target/$TARGET/debug/origen"

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -35,9 +35,10 @@ main() {
     if [ "$O2_REGRESSION" = "BACKEND" ]; then
         cd origen
         #cargo test --target $TARGET --release
-        # cli tests were skipped, think --workspace is needed here to also run tests in the bin dirs
-        export TRAVIS_ORIGEN_CLI="target/$TARGET/debug/origen"
-        cargo test  --workspace --target $TARGET
+        cargo test --target $TARGET
+        # cli tests were skipped, trying with --all
+        #export TRAVIS_ORIGEN_CLI="./target/$TARGET/debug/origen"
+        cargo test --all
         cd ../
     else
         # pass the path for the CLI tests to work

--- a/example/tests/cli_test.py
+++ b/example/tests/cli_test.py
@@ -3,7 +3,7 @@
 # https://docs.python.org/3/library/subprocess.html#subprocess.call
 # https://docs.python.org/3/library/subprocess.html#subprocess.run
 
-# This is just a starter example, will be cleaned up and streamlined
+# This is just a starter/proof of concept example, will be cleaned up and streamlined
 #
 # These tests may not be what you really want to test
 #
@@ -23,6 +23,9 @@
 
 import pytest
 import subprocess
+import os
+
+origen_cli = os.getenv('TRAVIS_ORIGEN_CLI') or 'origen'
 
 def test_origen_v():
   # process = subprocess.Popen(['origen', '-v']),
@@ -34,7 +37,7 @@ def test_origen_v():
   # process.stdin.write("yes\n")
   # process.stdin.close()
                 
-  process = subprocess.Popen(['origen', '-v'], stdout=subprocess.PIPE, universal_newlines=True)
+  process = subprocess.Popen([f'{origen_cli}', '-v'], stdout=subprocess.PIPE, universal_newlines=True)
 
   # wait for the process to finish and read the result
   while True:
@@ -49,7 +52,7 @@ def test_origen_v():
       break
 
 def test_bad_command():
-  process = subprocess.Popen(['origen', 'thisisnotacommand'], stderr=subprocess.PIPE, universal_newlines=True)
+  process = subprocess.Popen([f'{origen_cli}', 'thisisnotacommand'], stderr=subprocess.PIPE, universal_newlines=True)
 
   # wait for the process to finish and read the result
   while True:
@@ -63,7 +66,7 @@ def test_bad_command():
       break
 
 def test_origen_g():
-  process = subprocess.Popen(['origen', 'g', r'.\example\patterns\toggle.py', '-t', r'.\targets\dut\eagle.py'])
+  process = subprocess.Popen([f'{origen_cli}', 'g', r'.\example\patterns\toggle.py', '-t', r'.\targets\dut\eagle.py'])
   # wait for completion and get the outputs
   return_code = process.wait()
   assert return_code == 0

--- a/example/tests/cli_test.py
+++ b/example/tests/cli_test.py
@@ -12,14 +12,21 @@
 # is available before running).
 #
 # The flow appears to be working, had my doubts
-# poetry run pytest -> subprocess -> origen cli -> Python run time
+# poetry run pytest -> subprocess -> origen cli -> poetry -> Python run time
 #
 # Global commands could go here if the working dir is changed first.
-# Otherwise Rust cli tests can be used. See the following:
-# https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them
-# https://docs.rs/predicates/1.0.4/predicates/
-# https://docs.rs/assert_cmd/1.0.1/assert_cmd/
-# https://crates.io/crates/rexpect
+# Otherwise Rust cli tests can be used. See the rust/origen/cli/test directory
+#
+# an interactive command test write to stdin like this:
+#   process = subprocess.Popen(['origen', '-v']),
+#                stdin=subprocess.PIPE,
+#                stdout=subprocess.PIPE,
+#                stderr=subprocess.PIPE,
+#                universal_newlines=True,
+#                bufsize=0)
+#  process.stdin.write("yes\n")
+#  process.stdin.close()
+
 
 import pytest
 import subprocess
@@ -27,16 +34,7 @@ import os
 
 origen_cli = os.getenv('TRAVIS_ORIGEN_CLI') or 'origen'
 
-def test_origen_v():
-  # process = subprocess.Popen(['origen', '-v']),
-                # stdin=subprocess.PIPE,
-                # stdout=subprocess.PIPE,
-                # stderr=subprocess.PIPE,
-                # universal_newlines=True,
-                # bufsize=0)
-  # process.stdin.write("yes\n")
-  # process.stdin.close()
-                
+def test_origen_v():                
   process = subprocess.Popen([f'{origen_cli}', '-v'], stdout=subprocess.PIPE, universal_newlines=True)
 
   # wait for the process to finish and read the result

--- a/example/tests/cli_test.py
+++ b/example/tests/cli_test.py
@@ -1,0 +1,69 @@
+# see the following docs
+# https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+# https://docs.python.org/3/library/subprocess.html#subprocess.call
+# https://docs.python.org/3/library/subprocess.html#subprocess.run
+
+# This is just a starter example, will be cleaned up and streamlined
+#
+# These tests may not be what you really want to test
+#
+# Makes a lot of sense to run tests that require a Python workspace here
+# rather than as Rust cli tests (Rust tests would need to ensure a working app
+# is available before running).
+#
+# The flow appears to be working, had my doubts
+# poetry run pytest -> subprocess -> origen cli -> Python run time
+#
+# Global commands could go here if the working dir is changed first.
+# Otherwise Rust cli tests can be used. See the following:
+# https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them
+# https://docs.rs/predicates/1.0.4/predicates/
+# https://docs.rs/assert_cmd/1.0.1/assert_cmd/
+# https://crates.io/crates/rexpect
+
+import pytest
+import subprocess
+
+def test_origen_v():
+  # process = subprocess.Popen(['origen', '-v']),
+                # stdin=subprocess.PIPE,
+                # stdout=subprocess.PIPE,
+                # stderr=subprocess.PIPE,
+                # universal_newlines=True,
+                # bufsize=0)
+  # process.stdin.write("yes\n")
+  # process.stdin.close()
+                
+  process = subprocess.Popen(['origen', '-v'], stdout=subprocess.PIPE, universal_newlines=True)
+
+  # wait for the process to finish and read the result
+  while True:
+    return_code = process.poll()
+    if return_code is not None:
+      # Process is done
+      # Read std out
+      first_stdout_line = process.stdout.readline()
+      assert "Origen" in first_stdout_line
+      assert " 2." in first_stdout_line
+      assert return_code == 0
+      break
+
+def test_bad_command():
+  process = subprocess.Popen(['origen', 'thisisnotacommand'], stderr=subprocess.PIPE, universal_newlines=True)
+
+  # wait for the process to finish and read the result
+  while True:
+    return_code = process.poll()
+    if return_code is not None:
+      # Process is done
+      # Read std out
+      first_stderr_line = process.stderr.readline()
+      assert "error:" in first_stderr_line
+      assert return_code == 1
+      break
+
+def test_origen_g():
+  process = subprocess.Popen(['origen', 'g', r'.\example\patterns\toggle.py', '-t', r'.\targets\dut\eagle.py'])
+  # wait for completion and get the outputs
+  return_code = process.wait()
+  assert return_code == 0

--- a/example/tests/cli_test.py
+++ b/example/tests/cli_test.py
@@ -3,16 +3,9 @@
 # https://docs.python.org/3/library/subprocess.html#subprocess.call
 # https://docs.python.org/3/library/subprocess.html#subprocess.run
 
-# This is just a starter/proof of concept example, will be cleaned up and streamlined
-#
-# These tests may not be what you really want to test
-#
 # Makes a lot of sense to run tests that require a Python workspace here
 # rather than as Rust cli tests (Rust tests would need to ensure a working app
 # is available before running).
-#
-# The flow appears to be working, had my doubts
-# poetry run pytest -> subprocess -> origen cli -> poetry -> Python run time
 #
 # Global commands could go here if the working dir is changed first.
 # Otherwise Rust cli tests can be used. See the rust/origen/cli/test directory
@@ -26,6 +19,7 @@
 #                bufsize=0)
 #  process.stdin.write("yes\n")
 #  process.stdin.close()
+#  read output, etc
 
 
 import pytest
@@ -36,36 +30,20 @@ origen_cli = os.getenv('TRAVIS_ORIGEN_CLI') or 'origen'
 
 def test_origen_v():                
   process = subprocess.Popen([f'{origen_cli}', '-v'], stdout=subprocess.PIPE, universal_newlines=True)
-
-  # wait for the process to finish and read the result
-  while True:
-    return_code = process.poll()
-    if return_code is not None:
-      # Process is done
-      # Read std out
-      first_stdout_line = process.stdout.readline()
-      assert "Origen" in first_stdout_line
-      assert " 2." in first_stdout_line
-      assert return_code == 0
-      break
+  # wait for the process to finish and read the result, 0 is success
+  assert process.wait() == 0
+  # Process is done
+  # Read std out
+  first_stdout_line = process.stdout.readline()
+  assert "Origen" in first_stdout_line
+  assert " 2." in first_stdout_line
 
 def test_bad_command():
   process = subprocess.Popen([f'{origen_cli}', 'thisisnotacommand'], stderr=subprocess.PIPE, universal_newlines=True)
-
-  # wait for the process to finish and read the result
-  while True:
-    return_code = process.poll()
-    if return_code is not None:
-      # Process is done
-      # Read std out
-      first_stderr_line = process.stderr.readline()
-      assert "error:" in first_stderr_line
-      assert return_code == 1
-      break
+  assert process.wait() == 1
+  assert "error:" in process.stderr.readline()
 
 def test_origen_g():
   process = subprocess.Popen([f'{origen_cli}', 'g', r'.\example\patterns\toggle.py', '-t', r'.\targets\dut\eagle.py'], universal_newlines=True)
-  # wait for completion and get the outputs
-  return_code = process.wait()
-  assert return_code == 0
+  assert process.wait() == 0
   

--- a/example/tests/cli_test.py
+++ b/example/tests/cli_test.py
@@ -64,7 +64,8 @@ def test_bad_command():
       break
 
 def test_origen_g():
-  process = subprocess.Popen([f'{origen_cli}', 'g', r'.\example\patterns\toggle.py', '-t', r'.\targets\dut\eagle.py'])
+  process = subprocess.Popen([f'{origen_cli}', 'g', r'.\example\patterns\toggle.py', '-t', r'.\targets\dut\eagle.py'], universal_newlines=True)
   # wait for completion and get the outputs
   return_code = process.wait()
   assert return_code == 0
+  

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -15,9 +15,19 @@
 
 use std::process::Command;
 
+fn ogn_cmd() -> String {
+    // There's probably a prettier way to do this, but don't feel like fighting at the moment
+    let retval;
+    match option_env!("CARGO_BIN_EXE_ORIGEN"){
+        Some(x) => retval = x,
+        None => retval = option_env!("TRAVIS_ORIGEN_CLI").unwrap(),
+    }
+    String::from(retval)
+}
+
 #[test]
 fn origen_v_responds() -> Result<(), Box<dyn std::error::Error>> {
-    let output = Command::new(option_env!("CARGO_BIN_EXE_ORIGEN").unwrap())
+    let output = Command::new(ogn_cmd())
         .arg("-v")
         .output()?;
     
@@ -31,7 +41,7 @@ fn origen_v_responds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn origen_bad_arg() -> Result<(), Box<dyn std::error::Error>> {
-    let output = Command::new(option_env!("CARGO_BIN_EXE_ORIGEN").unwrap())
+    let output = Command::new(ogn_cmd())
         .arg("invalid_cmd_here")
         .output()?;
 

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -10,7 +10,7 @@
 // https://docs.rs/assert_cmd/1.0.1/assert_cmd/
 // https://crates.io/crates/rexpect
 //
-// helpful examples of using Command, also can do interactive tests if needed
+// helpful examples of using Command. Also possible to do interactive tests if needed
 // https://rust-lang-nursery.github.io/rust-cookbook/os/external.html
 
 use std::process::Command;
@@ -56,7 +56,7 @@ fn origen_bad_arg() -> Result<(), Box<dyn std::error::Error>> {
     // check that an error (not success) result was returned
     assert!(!output.status.success());
 
-    // get stdout from the command execution in String format for testing
+    // get stderr from the command execution in String format for testing
     let stderr = String::from_utf8(output.stderr)?;
     assert!(stderr.contains("error:"));
 

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -1,0 +1,41 @@
+
+// Global commands could go here the working dir is the target/debug dir.
+//
+// I initially tried using predicates and assert_cmd and didn't
+// find them especially helpful
+//
+// See the following:
+// https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them
+// https://docs.rs/predicates/1.0.4/predicates/
+// https://docs.rs/assert_cmd/1.0.1/assert_cmd/
+// https://crates.io/crates/rexpect
+//
+// helpful examples of using Command, also can do interactive tests if needed
+// https://rust-lang-nursery.github.io/rust-cookbook/os/external.html
+
+use std::process::Command;
+
+#[test]
+fn origen_v_responds() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(option_env!("CARGO_BIN_EXE_ORIGEN").unwrap())
+        .arg("-v")
+        .output()?;
+    
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("Origen"));
+    assert!(stdout.contains(" 2."));
+
+    Ok(())
+}
+
+#[test]
+fn origen_bad_arg() -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(option_env!("CARGO_BIN_EXE_ORIGEN").unwrap())
+        .arg("invalid_cmd_here")
+        .output()?;
+
+    assert!(output.status.success());
+
+    Ok(())
+}

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -15,18 +15,9 @@
 
 use std::process::Command;
 
-// There's probably a prettier way to do this, but don't feel like fighting at the moment
-// Cargo sets an env var to point to the executable for testing. In the CI env that
-// wasn't happening. So, I'm setting another env and checking for it if the cargo
-// env isn't set. Probably could have just used the same env var name...
+// Cargo sets an env var to point to the executable for testing.
 fn ogn_cmd() -> String {
-    option_env!("CARGO_BIN_EXE_ORIGEN").unwrap().to_string()
-    // let retval;
-    // match option_env!("CARGO_BIN_EXE_ORIGEN"){
-    //     Some(x) => retval = x,
-    //     None => retval = option_env!("TRAVIS_ORIGEN_CLI").unwrap(),
-    // }
-    // String::from(retval)
+    env!("CARGO_BIN_EXE_ORIGEN").to_string()
 }
 
 #[test]

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -45,7 +45,7 @@ fn origen_bad_arg() -> Result<(), Box<dyn std::error::Error>> {
         .arg("invalid_cmd_here")
         .output()?;
 
-    assert!(output.status.success());
+    assert!(!output.status.success());
 
     Ok(())
 }

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -1,7 +1,7 @@
 
 // Global commands could go here the working dir is the target/debug dir.
 //
-// I initially tried using predicates and assert_cmd and didn't
+// Initially tried using predicates and assert_cmd, but didn't
 // find them especially helpful. They can be added as dev dependencies.
 //
 // See the following:
@@ -20,12 +20,13 @@ use std::process::Command;
 // wasn't happening. So, I'm setting another env and checking for it if the cargo
 // env isn't set. Probably could have just used the same env var name...
 fn ogn_cmd() -> String {
-    let retval;
-    match option_env!("CARGO_BIN_EXE_ORIGEN"){
-        Some(x) => retval = x,
-        None => retval = option_env!("TRAVIS_ORIGEN_CLI").unwrap(),
-    }
-    String::from(retval)
+    option_env!("CARGO_BIN_EXE_ORIGEN").unwrap().to_string()
+    // let retval;
+    // match option_env!("CARGO_BIN_EXE_ORIGEN"){
+    //     Some(x) => retval = x,
+    //     None => retval = option_env!("TRAVIS_ORIGEN_CLI").unwrap(),
+    // }
+    // String::from(retval)
 }
 
 #[test]

--- a/rust/origen/cli/tests/cli_tests.rs
+++ b/rust/origen/cli/tests/cli_tests.rs
@@ -2,7 +2,7 @@
 // Global commands could go here the working dir is the target/debug dir.
 //
 // I initially tried using predicates and assert_cmd and didn't
-// find them especially helpful
+// find them especially helpful. They can be added as dev dependencies.
 //
 // See the following:
 // https://rust-cli.github.io/book/tutorial/testing.html#testing-cli-applications-by-running-them
@@ -15,8 +15,11 @@
 
 use std::process::Command;
 
+// There's probably a prettier way to do this, but don't feel like fighting at the moment
+// Cargo sets an env var to point to the executable for testing. In the CI env that
+// wasn't happening. So, I'm setting another env and checking for it if the cargo
+// env isn't set. Probably could have just used the same env var name...
 fn ogn_cmd() -> String {
-    // There's probably a prettier way to do this, but don't feel like fighting at the moment
     let retval;
     match option_env!("CARGO_BIN_EXE_ORIGEN"){
         Some(x) => retval = x,
@@ -27,11 +30,16 @@ fn ogn_cmd() -> String {
 
 #[test]
 fn origen_v_responds() -> Result<(), Box<dyn std::error::Error>> {
+    // .output()? will wait for completion and return an Output struct
+    // see https://doc.rust-lang.org/std/process/struct.Output.html
     let output = Command::new(ogn_cmd())
         .arg("-v")
         .output()?;
     
+    // check no error was returned
     assert!(output.status.success());
+
+    // get stdout from the command execution in String format for testing
     let stdout = String::from_utf8(output.stdout)?;
     assert!(stdout.contains("Origen"));
     assert!(stdout.contains(" 2."));
@@ -45,7 +53,12 @@ fn origen_bad_arg() -> Result<(), Box<dyn std::error::Error>> {
         .arg("invalid_cmd_here")
         .output()?;
 
+    // check that an error (not success) result was returned
     assert!(!output.status.success());
+
+    // get stdout from the command execution in String format for testing
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(stderr.contains("error:"));
 
     Ok(())
 }


### PR DESCRIPTION
Framework for performing CLI tests. You can run the rust CLI tests 1 of 2 ways:

When run from main workspace, you have to include <code>--workspace</cdoe>

This wasn't working in the Travis CI.

~~~
>> cd rust/origen
>> cargo test --workspace
~~~

You can also test individually like this:

~~~
>> cd rust/origen/cli
>> cargo test
~~~

I tried running the <code>origen g</code> test with both Rust and Python without the fixes from the <code>launcher</code> branch. It passes even though the same command fails when I run it from a command line. I think this shows the problem was with how the Windows command shell was processing the command line and args into a process call. So, likely to make a test that reproduces the failure, we'd have to launch a console and send the command string to it. I don't know that it's worth going through that trouble. Instead maybe we can just follow the known best practices (will need to add those to comments or documentation).