### PR TITLE
Tester character mapping

### DIFF
--- a/rust/origen/src/core/model/pins.rs
+++ b/rust/origen/src/core/model/pins.rs
@@ -755,8 +755,7 @@ impl StateTracker {
     ///                          .map(|(action, data)| {
     ///                              match action { return a char }  // mapping to a tester char given data happens here
     ///                          })
-    ///                          .collect::<Vec<String>>()           // this and next turns the pin group of pin characters into a string
-    ///                          .join("")
+    ///                          .collect::<String>()                // this and next turns the pin group of pin characters into a string
     ///                   })
     ///                   .collect::<Vec<String>>()                  // collects the pin group strings into a Vec of strings
     pub fn pin_iter(&self) -> indexmap::map::Iter<String, Vec<(PinActions, u8)>> {

--- a/rust/origen/src/core/model/pins.rs
+++ b/rust/origen/src/core/model/pins.rs
@@ -755,7 +755,7 @@ impl StateTracker {
     /// let my_vector_line = state_tracker_var.pin_iter()
     ///                  .map(|(_pin, states)| {                     // (&String, &Vec<(PinActions, u8)>)
     ///                      states.iter()                           // Iter<(PinActions, u8)>
-    ///                          .map(|(action, data)| {
+    ///                          .map(|(pin_name, action, data)| {
     ///                              match action { return a char }  // mapping to a tester char given data happens here
     ///                          })
     ///                          .collect::<String>()                // this and next turns the pin group of pin characters into a string

--- a/rust/origen/src/core/model/pins.rs
+++ b/rust/origen/src/core/model/pins.rs
@@ -753,7 +753,7 @@ impl StateTracker {
     /// vector string like this:
     ///
     /// let my_vector_line = state_tracker_var.pin_iter()
-    ///                  .map(|(_pin, states)| {                     // (&String, &Vec<(PinActions, u8)>)
+    ///                  .map(|(_pin, states)| {                     // (&String, &Vec<(String, PinActions, u8)>)
     ///                      states.iter()                           // Iter<(PinActions, u8)>
     ///                          .map(|(pin_name, action, data)| {
     ///                              match action { return a char }  // mapping to a tester char given data happens here
@@ -766,7 +766,7 @@ impl StateTracker {
         self.pins.iter()
     }
 
-    /// returns the pin (or group) names included in the vector data
+    /// returns the pin (and/or group) names included in the vector data
     pub fn names(&self) -> Vec<String> {
         self.pins
             .keys()

--- a/rust/origen/src/core/model/pins.rs
+++ b/rust/origen/src/core/model/pins.rs
@@ -745,6 +745,24 @@ impl StateTracker {
             .collect::<Vec<String>>())
     }
 
+    /// Return an iterator over the pins so the Renderer can map states to characters
+    /// The Renderer should map pin states to characters and construct the final
+    /// vector string like this:
+    ///
+    /// let my_vector_line = state_tracker_var.pin_iter()
+    ///                  .map(|(_pin, states)| {                     // (&String, &Vec<(PinActions, u8)>)
+    ///                      states.iter()                           // Iter<(PinActions, u8)>
+    ///                          .map(|(action, data)| {
+    ///                              match action { return a char }  // mapping to a tester char given data happens here
+    ///                          })
+    ///                          .collect::<Vec<String>>()           // this and next turns the pin group of pin characters into a string
+    ///                          .join("")
+    ///                   })
+    ///                   .collect::<Vec<String>>()                  // collects the pin group strings into a Vec of strings
+    pub fn pin_iter(&self) -> indexmap::map::Iter<String, Vec<(PinActions, u8)>> {
+        self.pins.iter()
+    }
+
     pub fn names(&self) -> Vec<String> {
         self.pins
             .keys()

--- a/rust/origen/src/testers/v93k/mod.rs
+++ b/rust/origen/src/testers/v93k/mod.rs
@@ -47,11 +47,17 @@ impl Renderer {
         Ok(Return::Unmodified)
     }
 
-    fn char_mapper(&self, action: PinActions, data: u8) -> char {
+    fn char_mapper(&self, name: &str, action: PinActions, data: u8) -> char {
         match action {
             PinActions::Drive => match data {
                 0 => '0',
-                _ => '1',
+                _ => {
+                    if name == "clk" {
+                        'P'
+                    } else {
+                        '1'
+                    }
+                },
             },
             PinActions::Verify => match data {
                 0 => 'L',
@@ -137,11 +143,11 @@ impl Processor for Renderer {
                 let vec_line = self.states
                     .as_ref()
                     .unwrap()
-                    .pin_iter()
-                    .map(|(_name, states)| {
+                    .pin_state_iter()
+                    .map(|(_grp_name, states)| {
                         states
                             .iter()
-                            .map(|(action, data)| self.char_mapper(*action, *data))
+                            .map(|(name, action, data)| self.char_mapper(name, *action, *data))
                             .collect::<String>()
                     })
                     .collect::<Vec<String>>()

--- a/rust/origen/src/testers/v93k/mod.rs
+++ b/rust/origen/src/testers/v93k/mod.rs
@@ -47,17 +47,14 @@ impl Renderer {
         Ok(Return::Unmodified)
     }
 
-    fn char_mapper(&self, name: &str, action: PinActions, data: u8) -> char {
+    /// Returns a char representation of the given pin name, PinActions, and data
+    /// TODO: This was copied from PinActions.as_tester_char() method, it should
+    ///       be modified as appropriate for V93K
+    fn char_mapper(&self, _name: &str, action: PinActions, data: u8) -> char {
         match action {
             PinActions::Drive => match data {
                 0 => '0',
-                _ => {
-                    if name == "clk" {
-                        'P'
-                    } else {
-                        '1'
-                    }
-                },
+                _ => '1',
             },
             PinActions::Verify => match data {
                 0 => 'L',


### PR DESCRIPTION
A simple way to allow the <code>Renderer</code> to determine the <code>PinActions</code> to <code>char</code> mapping.

I initially started down the path of giving <code>StateTracker</code> a way to call back into the <code>TesterAPI</code>, that was a bit of a mind pretzel for me. I also looked into passing <code>StateTracker</code> a closure that does the mapping. This led to several (endless) thread safety compile errors. In the end I think I prefer this implementation. It's simple and it has a feel similar to a <code>yield</code> in Ruby.

Have a look and let me know what you think.