### PR TITLE
Added fmt and update commands

### DIFF
--- a/.origen_dev_workspace
+++ b/.origen_dev_workspace
@@ -1,0 +1,1 @@
+This file simply lets the CLI know that it is in an Origen development workspace

--- a/example/poetry.lock
+++ b/example/poetry.lock
@@ -4,7 +4,7 @@ description = "Atomic file writes."
 name = "atomicwrites"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.3.0"
+version = "1.4.0"
 
 [[package]]
 category = "dev"
@@ -61,7 +61,7 @@ marker = "python_version < \"3.8\""
 name = "importlib-metadata"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-version = "1.3.0"
+version = "1.6.0"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -109,11 +109,12 @@ description = "More routines for operating on iterables, beyond itertools"
 name = "more-itertools"
 optional = false
 python-versions = ">=3.5"
-version = "8.0.2"
+version = "8.3.0"
 
 [[package]]
 category = "main"
 description = ""
+develop = true
 name = "origen"
 optional = false
 python-versions = "^3.6"
@@ -127,6 +128,7 @@ lxml = "4.4.2"
 mako = "1.1.0"
 pyreadline = "^2.1"
 termcolor = ">= 1.1.0"
+yapf = "0.30"
 
 [package.source]
 reference = ""
@@ -189,16 +191,16 @@ category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "1.13.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+version = "1.15.0"
 
 [[package]]
 category = "main"
 description = "A modern CSS selector implementation for Beautiful Soup."
 name = "soupsieve"
 optional = false
-python-versions = "*"
-version = "1.9.5"
+python-versions = ">=3.5"
+version = "2.0.1"
 
 [[package]]
 category = "main"
@@ -209,20 +211,25 @@ python-versions = "*"
 version = "1.1.0"
 
 [[package]]
+category = "main"
+description = "A formatter for Python code."
+name = "yapf"
+optional = false
+python-versions = "*"
+version = "0.30.0"
+
+[[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
-python-versions = ">=2.7"
-version = "0.6.0"
-
-[package.dependencies]
-more-itertools = "*"
+python-versions = ">=3.6"
+version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pathlib2", "contextlib2", "unittest2"]
+testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
 content-hash = "66e8f655be817987a5d013f87b2cb8b7928413617d7be8a2b8780323831d2de5"
@@ -230,8 +237,8 @@ python-versions = "^3.6"
 
 [metadata.files]
 atomicwrites = [
-    {file = "atomicwrites-1.3.0-py2.py3-none-any.whl", hash = "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4"},
-    {file = "atomicwrites-1.3.0.tar.gz", hash = "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"},
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
@@ -250,8 +257,8 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-1.3.0-py2.py3-none-any.whl", hash = "sha256:d95141fbfa7ef2ec65cfd945e2af7e5a6ddbd7c8d9a25e66ff3be8e3daf9f60f"},
-    {file = "importlib_metadata-1.3.0.tar.gz", hash = "sha256:073a852570f92da5f744a3472af1b61e28e9f78ccf0c9117658dc32b15de7b45"},
+    {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
+    {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
 ]
 lxml = [
     {file = "lxml-4.4.2-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:7b4fc7b1ecc987ca7aaf3f4f0e71bbfbd81aaabf87002558f5bc95da3a865bcd"},
@@ -312,11 +319,16 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.0.2.tar.gz", hash = "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d"},
-    {file = "more_itertools-8.0.2-py3-none-any.whl", hash = "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"},
+    {file = "more-itertools-8.3.0.tar.gz", hash = "sha256:558bb897a2232f5e4f8e2399089e35aecb746e1f9191b6584a151647e89267be"},
+    {file = "more_itertools-8.3.0-py3-none-any.whl", hash = "sha256:7818f596b1e87be009031c7653d01acc46ed422e6656b394b0f765ce66ed4982"},
 ]
 origen = []
 pluggy = [
@@ -337,17 +349,21 @@ pytest = [
     {file = "pytest-3.10.1.tar.gz", hash = "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"},
 ]
 six = [
-    {file = "six-1.13.0-py2.py3-none-any.whl", hash = "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd"},
-    {file = "six-1.13.0.tar.gz", hash = "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"},
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 soupsieve = [
-    {file = "soupsieve-1.9.5-py2.py3-none-any.whl", hash = "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5"},
-    {file = "soupsieve-1.9.5.tar.gz", hash = "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"},
+    {file = "soupsieve-2.0.1-py3-none-any.whl", hash = "sha256:1634eea42ab371d3d346309b93df7870a88610f0725d47528be902a0d95ecc55"},
+    {file = "soupsieve-2.0.1.tar.gz", hash = "sha256:a59dc181727e95d25f781f0eb4fd1825ff45590ec8ff49eadfd7f1a537cc0232"},
 ]
 termcolor = [
     {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
+yapf = [
+    {file = "yapf-0.30.0-py2.py3-none-any.whl", hash = "sha256:3abf61ba67cf603069710d30acbc88cfe565d907e16ad81429ae90ce9651e0c9"},
+    {file = "yapf-0.30.0.tar.gz", hash = "sha256:3000abee4c28daebad55da6c85f3cd07b8062ce48e2e9943c8da1b9667d48427"},
+]
 zipp = [
-    {file = "zipp-0.6.0-py2.py3-none-any.whl", hash = "sha256:f06903e9f1f43b12d371004b4ac7b06ab39a44adc747266928ae6debfa7b3335"},
-    {file = "zipp-0.6.0.tar.gz", hash = "sha256:3718b1cbcd963c7d4c5511a8240812904164b7f381b647143a89d3b98f9bcd8e"},
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -13,6 +13,7 @@ bs4 = "0.0.1"
 beautifulsoup4 = "4.8.2"
 lxml = "4.4.2"
 mako = "1.1.0"
+yapf = "0.30"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/rust/origen/cli/src/bin.rs
+++ b/rust/origen/cli/src/bin.rs
@@ -110,6 +110,19 @@ fn main() {
     /************************************************************************************/
 
     /************************************************************************************/
+    /******************** Origen dev commands *******************************************/
+    /************************************************************************************/
+    if STATUS.is_origen_present || STATUS.is_app_present {
+        let msg = match STATUS.is_origen_present {
+            true => "Nicely format all Rust and Python files",
+            false => "Nicely format all of your application's Python files",
+        };
+        app = app
+            //************************************************************************************/
+            .subcommand(SubCommand::with_name("fmt").about(msg));
+    }
+
+    /************************************************************************************/
     /******************** In application commands ***************************************/
     /************************************************************************************/
     if STATUS.is_app_present {
@@ -258,7 +271,12 @@ fn main() {
 
            /************************************************************************************/
            .subcommand(SubCommand::with_name("setup")
-                .about("Setup your application's Python environment"),
+                .about("Setup your application's Python environment in a new workspace, this will install dependencies per the poetry.lock file"),
+           )
+
+           /************************************************************************************/
+           .subcommand(SubCommand::with_name("update")
+                .about("Update your application's Python dependencies according to the latest pyproject.toml file"),
            )
     }
 
@@ -268,6 +286,8 @@ fn main() {
 
     match matches.subcommand_name() {
         Some("setup") => commands::setup::run(),
+        Some("update") => commands::update::run(),
+        Some("fmt") => commands::fmt::run(),
         Some("proj") => commands::proj::run(matches.subcommand_matches("proj").unwrap()),
         Some("interactive") => {
             let m = matches.subcommand_matches("interactive").unwrap();

--- a/rust/origen/cli/src/commands/fmt.rs
+++ b/rust/origen/cli/src/commands/fmt.rs
@@ -1,0 +1,87 @@
+use crate::python::PYTHON_CONFIG;
+use origen::core::term::*;
+use origen::STATUS;
+use std::env;
+use std::io::stdout;
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+pub fn run() {
+    let orig_dir = env::current_dir().expect("Couldn't read the PWD");
+
+    if STATUS.is_origen_present {
+        starting("rust/origen ... ");
+        cd(&STATUS.origen_wksp_root.join("rust").join("origen"));
+
+        cargo_fmt();
+
+        starting("rust/pyapi ... ");
+        cd(&STATUS.origen_wksp_root.join("rust").join("pyapi"));
+
+        cargo_fmt();
+    }
+
+    let root = match STATUS.is_origen_present {
+        true => {
+            starting("example ... ");
+            STATUS.origen_wksp_root.join("example")
+        }
+        false => {
+            starting("formatting ... ");
+            STATUS.root.clone()
+        }
+    };
+
+    cd(&root);
+
+    py_fmt(&root);
+
+    if STATUS.is_origen_present {
+        starting("python ... ");
+        let dir = &STATUS.origen_wksp_root.join("python");
+        py_fmt(&dir);
+    }
+
+    let _ = env::set_current_dir(&orig_dir);
+}
+
+fn starting(job: &str) {
+    print!("{}", job);
+    let _ = stdout().flush();
+}
+
+// Returns true if no problems
+fn py_fmt(dir: &Path) {
+    let res = Command::new(&PYTHON_CONFIG.poetry_command)
+        .arg("run")
+        .arg("yapf")
+        .arg("--in-place")
+        .arg("--recursive")
+        .arg(&format!("{}", dir.display()))
+        .status();
+
+    if let Ok(stat) = res {
+        if stat.success() {
+            greenln("YES");
+            return;
+        }
+    }
+    redln("NO");
+}
+
+// Returns true if no problems
+fn cargo_fmt() {
+    let res = Command::new("cargo").arg("fmt").status();
+    if let Ok(stat) = res {
+        if stat.success() {
+            greenln("YES");
+            return;
+        }
+    }
+    redln("NO");
+}
+
+fn cd(dir: &Path) {
+    env::set_current_dir(&dir).expect(&format!("Couldn't cd to '{}'", dir.display()));
+}

--- a/rust/origen/cli/src/commands/mod.rs
+++ b/rust/origen/cli/src/commands/mod.rs
@@ -1,8 +1,10 @@
+pub mod fmt;
 pub mod interactive;
 pub mod mode;
 pub mod proj;
 pub mod setup;
 pub mod target;
+pub mod update;
 
 use crate::python;
 use origen::{clean_mode, LOGGER};

--- a/rust/origen/cli/src/commands/update.rs
+++ b/rust/origen/cli/src/commands/update.rs
@@ -1,0 +1,11 @@
+use crate::python::PYTHON_CONFIG;
+use std::process::Command;
+
+pub fn run() {
+    let _ = Command::new(&PYTHON_CONFIG.poetry_command)
+        .arg("update")
+        .status();
+
+    // Don't think we need to do anything here, if something goes wrong Poetry will give a better
+    // error message than we could
+}


### PR DESCRIPTION
Adds an `origen fmt` command which will code format (similar to O1 lint command) all Python files and when in an o2 development workspace it will do all Python and Rust files.

Will probably add app config options in future to allow apps to configure files/dirs to exclude, but for now it just does everything.

`origen::STATUS` can also now be interogated to determine if Origen is executing within an o2 workspace or not.

I added an additional command `origen update` which is to be used to update an app's Python dependencies, similar to running `bundle update` in O1. This is just a thin wrapper around the underlying poetry command.

This fmt tool requires a new Python package, so to run it in an existing workspace you must first run `origen update` within the example app.

I haven't run the tool on this source code yet because it will introduce a lot of diffs in the Python code.
Once this is merged I will run it on master and that will give folks an easy-ish path to merge into their branches:

* Checkout the version of master that includes this PR
* Merge that into their branch
* Run `origen fmt` on their branch
* Checkout the latest version of master that has the formatting applied
* Merge that into their branch