### PR TITLE
Fix user ID fetch for Linux

### DIFF
--- a/rust/origen/Cargo.lock
+++ b/rust/origen/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "origen"
-version = "2.0.0-pre0"
+version = "2.0.0-pre1"
 dependencies = [
  "built",
  "chrono",

--- a/rust/origen/src/core/os.rs
+++ b/rust/origen/src/core/os.rs
@@ -7,7 +7,7 @@ pub fn on_windows() -> bool {
 }
 
 pub fn on_linux() -> bool {
-    if cfg!(linux) {
+    if cfg!(unix) {
         return true;
     } else {
         return false;

--- a/rust/origen/src/core/user.rs
+++ b/rust/origen/src/core/user.rs
@@ -56,6 +56,7 @@ impl User {
                             id = lines.pop().unwrap();
                         } else {
                             log_debug!("Failed to run 'whoami'");
+                            return None;
                         }
                     } else {
                         log_debug!("Failed to run 'whoami'");

--- a/rust/origen/src/core/user.rs
+++ b/rust/origen/src/core/user.rs
@@ -48,7 +48,7 @@ impl User {
                 }
                 // The whoami crate returned a garbage user name when compiled into a release binary,
                 // so doing it the old fashioned way. Hopefully it still works on Windows!
-                let mut id = "".to_string();
+                let id;
                 if cfg!(unix) {
                     let output = exec_and_capture("whoami", None);
                     if let Ok((status, mut lines, _stderr)) = output {

--- a/rust/origen/src/generator/processors/flatten_text.rs
+++ b/rust/origen/src/generator/processors/flatten_text.rs
@@ -2,7 +2,7 @@ use chrono::prelude::*;
 
 use crate::generator::ast::*;
 use crate::generator::processor::*;
-use crate::{app_config, producer, STATUS};
+use crate::{app_config, producer, STATUS, USER};
 
 /// Flattens nested text, textlines, text sections, etc. into 'text' types.
 /// Also evaluates text placeholder or shorthand nodes, such User, Timestamp, etc.
@@ -101,7 +101,13 @@ impl Processor for FlattenText {
             }
             Attrs::TextBoundaryLine => Ok(Return::Inline(vec![self.section_boundary()])),
             Attrs::User => {
-                self.current_line += &whoami::username();
+                if let Some(name) = USER.name() {
+                    self.current_line += &name;
+                } else if let Some(id) = USER.id() {
+                    self.current_line += &id;
+                } else {
+                    self.current_line += "Unknown";
+                }
                 Ok(Return::None)
             }
             Attrs::Timestamp => {


### PR DESCRIPTION
When releasing an initial version of the proj command it failed miserably because the function to determine the user ID didn't work.
It did work in a debug build, but not in a release build.
The root cause is inside a whoami crate that I used and which seems to use some clib internally - i.e. not easy to debug and I would like to get rid of it.

This update transitions to a less magic approach of simply running 'whoami' and capturing the output, and it now works for the production release Linux build.

@pderouen, any chance you could look at the Windows branch of this?
Is there a similar command we could run in Windows space?

Note that one thing I discovered here is that `if cfg!(linux)` does not work, it has to be either `if cfg!(unix)` or `if cfg!(target_os="linux")`.