### PR TITLE
STIL - Allow waveform defs with no semicolon

### DIFF
--- a/rust/origen_metal/src/stil/mod.rs
+++ b/rust/origen_metal/src/stil/mod.rs
@@ -9,17 +9,101 @@ pub use nodes::STIL;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-pub fn from_file(path: &Path) -> OrigenResult<Node<STIL>> {
-    let ast = parser::parse_file(path)?;
-    let load_path = vec![Path::new(path).parent().unwrap().to_path_buf()];
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct ParseOptions {
+    pub(crate) allow_missing_final_waveform_event_semicolon: bool,
+}
 
-    let ast = processors::includer::Includer::run(&ast, load_path, HashMap::new())?;
-    Ok(ast)
+/// A configurable STIL parser.
+///
+/// The default parser accepts only standard STIL syntax. Compatibility extensions must be
+/// explicitly enabled before parsing.
+#[derive(Clone, Debug, Default)]
+pub struct Parser {
+    options: ParseOptions,
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Allow the final event in a waveform definition to omit its semicolon.
+    pub fn allow_missing_final_waveform_event_semicolon(mut self) -> Self {
+        self.options.allow_missing_final_waveform_event_semicolon = true;
+        self
+    }
+
+    pub fn from_file(&self, path: &Path) -> OrigenResult<Node<STIL>> {
+        let ast = parser::parse_file_with_options(path, self.options)?;
+        let load_path = vec![Path::new(path).parent().unwrap().to_path_buf()];
+
+        processors::includer::Includer::run_with_options(
+            &ast,
+            load_path,
+            HashMap::new(),
+            self.options,
+        )
+    }
+
+    pub fn from_file_ignore_includes(&self, path: &Path) -> OrigenResult<Node<STIL>> {
+        parser::parse_file_with_options(path, self.options)
+    }
+
+    /// Parse the given STIL file, using the given load path to resolve include statements.
+    pub fn from_file_with_options(
+        &self,
+        path: &Path,
+        load_path: &Vec<PathBuf>,
+        rename: Option<&HashMap<&str, &str>>,
+    ) -> OrigenResult<Node<STIL>> {
+        let ast = parser::parse_file_with_options(path, self.options)?;
+        let mut load_path_with_current = vec![Path::new(path).parent().unwrap().to_path_buf()];
+        for p in load_path {
+            load_path_with_current.push(p.clone());
+        }
+        let rename = match rename {
+            Some(r) => {
+                let mut rename = HashMap::new();
+                for (orig, new) in r {
+                    rename.insert(orig.to_string(), new.to_string());
+                }
+                rename
+            }
+            None => HashMap::new(),
+        };
+        processors::includer::Includer::run_with_options(
+            &ast,
+            load_path_with_current,
+            rename,
+            self.options,
+        )
+    }
+
+    pub fn from_str(&self, stil: &str, root_dir: Option<&str>) -> OrigenResult<Node<STIL>> {
+        let ast = parser::parse_str_with_options(stil, None, self.options)?;
+        let load_path = {
+            if let Some(p) = root_dir {
+                vec![Path::new(p).to_path_buf()]
+            } else {
+                vec![]
+            }
+        };
+        processors::includer::Includer::run_with_options(
+            &ast,
+            load_path,
+            HashMap::new(),
+            self.options,
+        )
+    }
+}
+
+pub fn from_file(path: &Path) -> OrigenResult<Node<STIL>> {
+    Parser::new().from_file(path)
 }
 
 pub fn from_file_ignore_includes(path: &Path) -> OrigenResult<Node<STIL>> {
-    let ast = parser::parse_file(path)?;
-    Ok(ast)
+    Parser::new().from_file_ignore_includes(path)
 }
 
 /// Parse the given STIL file, using the given load path to resolve any include statements
@@ -31,36 +115,11 @@ pub fn from_file_with_options(
     load_path: &Vec<PathBuf>,
     rename: Option<&HashMap<&str, &str>>,
 ) -> OrigenResult<Node<STIL>> {
-    let ast = parser::parse_file(path)?;
-    let mut load_path_with_current = vec![Path::new(path).parent().unwrap().to_path_buf()];
-    for p in load_path {
-        load_path_with_current.push(p.clone());
-    }
-    let rename = match rename {
-        Some(r) => {
-            let mut rename = HashMap::new();
-            for (orig, new) in r {
-                rename.insert(orig.to_string(), new.to_string());
-            }
-            rename
-        }
-        None => HashMap::new(),
-    };
-    let ast = processors::includer::Includer::run(&ast, load_path_with_current, rename)?;
-    Ok(ast)
+    Parser::new().from_file_with_options(path, load_path, rename)
 }
 
 pub fn from_str(stil: &str, root_dir: Option<&str>) -> OrigenResult<Node<STIL>> {
-    let ast = parser::parse_str(stil, None)?;
-    let load_path = {
-        if let Some(p) = root_dir {
-            vec![Path::new(p).to_path_buf()]
-        } else {
-            vec![]
-        }
-    };
-    let ast = processors::includer::Includer::run(&ast, load_path, HashMap::new())?;
-    Ok(ast)
+    Parser::new().from_str(stil, root_dir)
 }
 #[derive(Clone, Debug, PartialEq, Serialize, enum_utils::FromStr)]
 #[enumeration(case_insensitive)]

--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -697,7 +697,7 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
                 )));
                 pairs.push(p);
             }
-            Rule::event => {
+            Rule::event | Rule::event_with_no_semicolon => {
                 ids.push(ast.push_and_open(node!(STIL::Event)));
                 pairs.push(pair.into_inner());
             }

--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -1,19 +1,20 @@
 use super::nodes::STIL;
+use super::ParseOptions;
 use crate::ast::Node;
 use crate::ast::AST;
 use crate::{Error, Result};
+use flate2::read::GzDecoder;
 use pest::iterators::{Pair, Pairs};
 use pest::Parser;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::Path;
-use flate2::read::GzDecoder;
 
 #[derive(Parser)]
 #[grammar = "stil/stil.pest"]
 pub struct STILParser;
 
-pub fn parse_file(path: &Path) -> Result<Node<STIL>> {
+pub(crate) fn parse_file_with_options(path: &Path, options: ParseOptions) -> Result<Node<STIL>> {
     if path.exists() {
         let gzip = match path.extension() {
             Some(ext) => ext == "gz",
@@ -31,10 +32,7 @@ pub fn parse_file(path: &Path) -> Result<Node<STIL>> {
         let mut contents = String::new();
         reader.read_to_string(&mut contents)?;
 
-        match parse_str(
-            &contents,
-            Some(&path.display().to_string()),
-        ) {
+        match parse_str_with_options(&contents, Some(&path.display().to_string()), options) {
             Ok(n) => Ok(n),
             Err(e) => Err(Error::new(&format!(
                 "Error parsing file {}:\n{}",
@@ -50,10 +48,21 @@ pub fn parse_file(path: &Path) -> Result<Node<STIL>> {
     }
 }
 
+#[cfg(test)]
 pub fn parse_str(stil: &str, source_file: Option<&str>) -> Result<Node<STIL>> {
+    parse_str_with_options(stil, source_file, ParseOptions::default())
+}
+
+pub(crate) fn parse_str_with_options(
+    stil: &str,
+    source_file: Option<&str>,
+    options: ParseOptions,
+) -> Result<Node<STIL>> {
     match STILParser::parse(Rule::stil_source, stil) {
         Err(e) => Err(Error::new(&format!("{}", e))),
-        Ok(mut stil) => Ok(to_ast(stil.next().unwrap(), source_file)?.unwrap()),
+        Ok(mut stil) => {
+            Ok(to_ast_with_options(stil.next().unwrap(), source_file, options)?.unwrap())
+        }
     }
 }
 
@@ -77,17 +86,18 @@ fn unwrap_tag(text: &str) -> String {
     text[1..text.len() - 1].to_string()
 }
 
-fn build_expression(pair: Pair<Rule>) -> Result<Node<STIL>> {
+fn build_expression(pair: Pair<Rule>, options: ParseOptions) -> Result<Node<STIL>> {
     let mut pairs = pair.into_inner();
     let p2 = pairs.next().unwrap();
-    let mut term = to_ast(p2, None)?.unwrap();
+    let mut term = to_ast_with_options(p2, None, options)?.unwrap();
     let mut done = false;
     while !done {
         if let Some(next) = pairs.peek() {
             match next.as_rule() {
                 Rule::add => {
                     pairs.next();
-                    let next_term = to_ast(pairs.next().unwrap(), None)?.unwrap();
+                    let next_term =
+                        to_ast_with_options(pairs.next().unwrap(), None, options)?.unwrap();
                     let mut n = node!(STIL::Add);
                     n.add_child(term);
                     n.add_child(next_term);
@@ -95,7 +105,8 @@ fn build_expression(pair: Pair<Rule>) -> Result<Node<STIL>> {
                 }
                 Rule::subtract => {
                     pairs.next();
-                    let next_term = to_ast(pairs.next().unwrap(), None)?.unwrap();
+                    let next_term =
+                        to_ast_with_options(pairs.next().unwrap(), None, options)?.unwrap();
                     let mut n = node!(STIL::Subtract);
                     n.add_child(term);
                     n.add_child(next_term);
@@ -110,16 +121,17 @@ fn build_expression(pair: Pair<Rule>) -> Result<Node<STIL>> {
     Ok(term)
 }
 
-fn build_term(pair: Pair<Rule>) -> Result<Node<STIL>> {
+fn build_term(pair: Pair<Rule>, options: ParseOptions) -> Result<Node<STIL>> {
     let mut pairs = pair.into_inner();
-    let mut term = to_ast(pairs.next().unwrap(), None)?.unwrap();
+    let mut term = to_ast_with_options(pairs.next().unwrap(), None, options)?.unwrap();
     let mut done = false;
     while !done {
         if let Some(next) = pairs.peek() {
             match next.as_rule() {
                 Rule::multiply => {
                     pairs.next();
-                    let next_term = to_ast(pairs.next().unwrap(), None)?.unwrap();
+                    let next_term =
+                        to_ast_with_options(pairs.next().unwrap(), None, options)?.unwrap();
                     let mut n = node!(STIL::Multiply);
                     n.add_child(term);
                     n.add_child(next_term);
@@ -127,7 +139,8 @@ fn build_term(pair: Pair<Rule>) -> Result<Node<STIL>> {
                 }
                 Rule::divide => {
                     pairs.next();
-                    let next_term = to_ast(pairs.next().unwrap(), None)?.unwrap();
+                    let next_term =
+                        to_ast_with_options(pairs.next().unwrap(), None, options)?.unwrap();
                     let mut n = node!(STIL::Divide);
                     n.add_child(term);
                     n.add_child(next_term);
@@ -143,7 +156,16 @@ fn build_term(pair: Pair<Rule>) -> Result<Node<STIL>> {
 }
 
 // This is the main function responsible for transforming the parsed strings into an AST
-pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STIL>> {
+#[cfg(test)]
+pub fn to_ast(pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STIL>> {
+    to_ast_with_options(pair, source_file, ParseOptions::default())
+}
+
+pub(crate) fn to_ast_with_options(
+    mut pair: Pair<Rule>,
+    source_file: Option<&str>,
+    options: ParseOptions,
+) -> Result<AST<STIL>> {
     let mut ast = AST::new();
     let mut ids: Vec<usize> = vec![];
     let mut pairs: Vec<Pairs<Rule>> = vec![];
@@ -483,7 +505,7 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
             Rule::name => ast.push(node!(STIL::String, unquote(pair.as_str()))),
             Rule::signal_name => ast.push(node!(STIL::String, pair.as_str().to_string())),
             Rule::expression | Rule::expression_ => {
-                ast.push(build_expression(pair)?);
+                ast.push(build_expression(pair, options)?);
             }
             Rule::time_expr => {
                 ids.push(ast.push_and_open(node!(STIL::TimeExpr)));
@@ -697,7 +719,17 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
                 )));
                 pairs.push(p);
             }
-            Rule::event | Rule::event_with_no_semicolon => {
+            Rule::event => {
+                ids.push(ast.push_and_open(node!(STIL::Event)));
+                pairs.push(pair.into_inner());
+            }
+            Rule::event_with_no_semicolon => {
+                if !options.allow_missing_final_waveform_event_semicolon {
+                    return Err(Error::new(
+                        "A waveform event is missing its final semicolon; enable it with \
+                         stil::Parser::allow_missing_final_waveform_event_semicolon()",
+                    ));
+                }
                 ids.push(ast.push_and_open(node!(STIL::Event)));
                 pairs.push(pair.into_inner());
             }
@@ -1054,7 +1086,7 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
             Rule::iddq => ast.push(node!(STIL::IDDQ)),
             Rule::stop_statement => ast.push(node!(STIL::StopStatement)),
             Rule::term => {
-                ast.push(build_term(pair)?);
+                ast.push(build_term(pair, options)?);
             }
             Rule::factor | Rule::factor_ => {
                 ids.push(0);
@@ -1100,7 +1132,7 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
 
 #[cfg(test)]
 mod tests {
-    use super::super::from_file;
+    use super::super::{from_file, from_str, Parser as ConfigurableParser};
     use super::*;
     use std::fs;
     use std::path::Path;
@@ -1111,6 +1143,98 @@ mod tests {
             example
         ))
         .expect("cannot read file")
+    }
+
+    fn timing_block(waveform_definitions: &str) -> String {
+        format!(
+            "Timing {{\n  WaveformTable wft {{\n    Waveforms {{\n      pin {{\n{}\n      }}\n    }}\n  }}\n}}\n",
+            waveform_definitions
+        )
+    }
+
+    fn timing_source(waveform_definitions: &str) -> String {
+        format!("STIL 1.0;\n{}", timing_block(waveform_definitions))
+    }
+
+    fn event_count(node: &Node<STIL>) -> usize {
+        usize::from(matches!(node.attrs, STIL::Event))
+            + node
+                .children
+                .iter()
+                .map(|child| event_count(child))
+                .sum::<usize>()
+    }
+
+    #[test]
+    fn standard_parser_rejects_missing_final_waveform_event_semicolon() {
+        let stil = timing_source("        0 { '0ns' D }");
+
+        assert!(from_str(&stil, None).is_err());
+    }
+
+    #[test]
+    fn configured_parser_accepts_missing_final_waveform_event_semicolon() {
+        let stil = timing_source(concat!(
+            "        0 { TMARK: '0ns' D }\n",
+            "        <tag1> 1 { '0ns' U }\n",
+            "        2 { '0ns' D; '5ns' U }\n",
+            "        <tag2> 3 { '0ns' D; '5ns' U }",
+        ));
+
+        let ast = ConfigurableParser::new()
+            .allow_missing_final_waveform_event_semicolon()
+            .from_str(&stil, None)
+            .expect("legacy waveform events should parse when explicitly enabled");
+
+        assert_eq!(event_count(&ast), 6);
+    }
+
+    #[test]
+    fn standard_and_extended_events_produce_the_same_ast() {
+        let standard = timing_source("        0 { TMARK: '0ns' D; }");
+        let extended = timing_source("        0 { TMARK: '0ns' D }");
+
+        let standard_ast = from_str(&standard, None).unwrap();
+        let extended_ast = ConfigurableParser::new()
+            .allow_missing_final_waveform_event_semicolon()
+            .from_str(&extended, None)
+            .unwrap();
+
+        assert_eq!(standard_ast, extended_ast);
+    }
+
+    #[test]
+    fn extension_does_not_allow_missing_non_final_waveform_event_semicolon() {
+        let timing = timing_block("        0 { '0ns' D '5ns' U; }");
+
+        assert!(STILParser::parse(Rule::timing_block, &timing).is_err());
+    }
+
+    #[test]
+    fn standard_parser_accepts_tagged_waveform_definitions() {
+        let stil = timing_source("        <tag1> 0 { '0ns' D; }\n        <tag2> 1 { '0ns' U; }");
+
+        let ast = from_str(&stil, None).expect("tagged waveform definitions should parse");
+
+        assert_eq!(event_count(&ast), 2);
+    }
+
+    #[test]
+    fn configured_parser_options_apply_to_included_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(
+            dir.path().join("legacy.stil"),
+            timing_source("        0 { '0ns' D }"),
+        )
+        .unwrap();
+        let root = "STIL 1.0;\nInclude \"legacy.stil\";\n";
+        let root_dir = dir.path().to_str().unwrap();
+
+        assert!(from_str(root, Some(root_dir)).is_err());
+        ConfigurableParser::new()
+            .allow_missing_final_waveform_event_semicolon()
+            .from_str(root, Some(root_dir))
+            .expect("parser options should propagate to included files");
     }
 
     #[test]

--- a/rust/origen_metal/src/stil/processors/includer.rs
+++ b/rust/origen_metal/src/stil/processors/includer.rs
@@ -2,6 +2,7 @@
 
 use super::super::nodes::STIL;
 use super::super::parser;
+use super::super::ParseOptions;
 use crate::ast::Node;
 use crate::ast::{Processor, Return};
 use crate::Result;
@@ -13,6 +14,7 @@ use std::path::PathBuf;
 pub struct Includer {
     load_path: Vec<PathBuf>,
     rename: HashMap<String, String>,
+    parse_options: ParseOptions,
 }
 
 impl Includer {
@@ -22,6 +24,15 @@ impl Includer {
         load_path: Vec<PathBuf>,
         rename: HashMap<String, String>,
     ) -> Result<Node<STIL>> {
+        Self::run_with_options(node, load_path, rename, ParseOptions::default())
+    }
+
+    pub(crate) fn run_with_options(
+        node: &Node<STIL>,
+        load_path: Vec<PathBuf>,
+        rename: HashMap<String, String>,
+        parse_options: ParseOptions,
+    ) -> Result<Node<STIL>> {
         let mut full_load_path = vec![env::current_dir()?];
         for p in load_path {
             full_load_path.push(p.to_path_buf());
@@ -29,6 +40,7 @@ impl Includer {
         let mut p = Includer {
             load_path: full_load_path,
             rename: rename,
+            parse_options,
         };
         Ok(node.process(&mut p)?.unwrap())
     }
@@ -57,11 +69,12 @@ impl Processor<STIL> for Includer {
                     // path with the given one
                     path.push(&expanded);
                     if path.exists() {
-                        let ast = parser::parse_file(&path)?;
-                        return Ok(Return::Replace(Includer::run(
+                        let ast = parser::parse_file_with_options(&path, self.parse_options)?;
+                        return Ok(Return::Replace(Includer::run_with_options(
                             &ast,
                             self.load_path.clone(),
                             self.rename.clone(),
+                            self.parse_options,
                         )?));
                     }
                 }

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -221,8 +221,6 @@ sub_waveform = { label? ~ "Duration" ~ time_expr ~ "{" ~ event* ~ "}" }
 waveforms = { "Waveforms" ~ "{" ~ waveform* ~ "}" }
 waveform = { sigref_expr ~ "{" ~ inherit_waveform* ~ (tagged_wfc_definition | wfc_definition)* ~ "}" }
 inherit_waveform = { "InheritWaveform" ~ name ~ EOS }
-// Allow the final event to optionally have no semicolon at the end, for compatibility with historical AMD
-// waveform defs which don't have a semicolon for waveforms that only contain a single event
 wfc_definition = { wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ event_with_no_semicolon? ~ "}" }
 tagged_wfc_definition = { tag ~ wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ event_with_no_semicolon? ~ "}" }
 wfc_list = @{ wfc_char+ }
@@ -230,7 +228,8 @@ wfc_char = { ASCII_ALPHANUMERIC | "#" | "%" }
 inherit_waveform_wfc = { "InheritWaveform" ~ name_wfc ~ EOS }
 name_wfc = { ((name_segment ~ ".")+ ~ wfc_list) | wfc_list }
 event = { label? ~ time_expr? ~ event_list? ~ EOS }
-event_with_no_semicolon = { label? ~ time_expr? ~ event_list? }
+// Compatibility syntax. The AST builder rejects this rule unless it has been explicitly enabled.
+event_with_no_semicolon = { (label ~ time_expr? ~ event_list?) | (time_expr ~ event_list?) | event_list }
 event_list = { event_char ~ ("/" ~ event_char)* }
 event_char = {
     // Unambiguous single chars — no keyword starts with these, try first

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -221,7 +221,9 @@ sub_waveform = { label? ~ "Duration" ~ time_expr ~ "{" ~ event* ~ "}" }
 waveforms = { "Waveforms" ~ "{" ~ waveform* ~ "}" }
 waveform = { sigref_expr ~ "{" ~ inherit_waveform* ~ (tagged_wfc_definition | wfc_definition)* ~ "}" }
 inherit_waveform = { "InheritWaveform" ~ name ~ EOS }
-wfc_definition = { wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ "}" }
+// Allow the final event to optionally have no semicolon at the end, for compatibility with historical AMD
+// waveform defs which don't have a semicolon for waveforms that only contain a single event
+wfc_definition = { wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ event_with_no_semicolon? ~ "}" }
 tagged_wfc_definition = { tag ~ wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ event_with_no_semicolon? ~ "}" }
 wfc_list = @{ wfc_char+ }
 wfc_char = { ASCII_ALPHANUMERIC | "#" | "%" }

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -222,12 +222,13 @@ waveforms = { "Waveforms" ~ "{" ~ waveform* ~ "}" }
 waveform = { sigref_expr ~ "{" ~ inherit_waveform* ~ (tagged_wfc_definition | wfc_definition)* ~ "}" }
 inherit_waveform = { "InheritWaveform" ~ name ~ EOS }
 wfc_definition = { wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ "}" }
-tagged_wfc_definition = { tag ~ wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ "}" }
+tagged_wfc_definition = { tag ~ wfc_list ~ "{" ~ inherit_waveform_wfc* ~ event* ~ event_with_no_semicolon? ~ "}" }
 wfc_list = @{ wfc_char+ }
 wfc_char = { ASCII_ALPHANUMERIC | "#" | "%" }
 inherit_waveform_wfc = { "InheritWaveform" ~ name_wfc ~ EOS }
 name_wfc = { ((name_segment ~ ".")+ ~ wfc_list) | wfc_list }
 event = { label? ~ time_expr? ~ event_list? ~ EOS }
+event_with_no_semicolon = { label? ~ time_expr? ~ event_list? }
 event_list = { event_char ~ ("/" ~ event_char)* }
 event_char = {
     // Unambiguous single chars — no keyword starts with these, try first

--- a/test_apps/python_app/vendor/stil/example2.stil
+++ b/test_apps/python_app/vendor/stil/example2.stil
@@ -36,7 +36,17 @@ SignalGroups quality {
 Timing {
   WaveformTable defaults {
     Waveforms {
-      allpins { xX { TMARK: 't_anchor' Z } }
+      allpins { 
+        xX { TMARK: 't_anchor' Z } 
+        <tag1> 0  {'0ns' D; }
+        <tag1> 1  {'0ns' U }
+        L  {'0ns' L; }
+        H  {'0ns' H }
+        <tag2> p  {'0ns' U; '5ns' D; }
+        <tag3> P  {'0ns' D; '5ns' U }
+        t  {'0ns' U; '5ns' D; }
+        T  {'0ns' D; '5ns' U }
+      }
     }
   }
   WaveformTable wft1 {

--- a/test_apps/python_app/vendor/stil/example2.stil
+++ b/test_apps/python_app/vendor/stil/example2.stil
@@ -36,7 +36,7 @@ SignalGroups quality {
 Timing {
   WaveformTable defaults {
     Waveforms {
-      allpins { xX { TMARK: 't_anchor' Z; } }
+      allpins { xX { TMARK: 't_anchor' Z } }
     }
   }
   WaveformTable wft1 {

--- a/test_apps/python_app/vendor/stil/example2.stil
+++ b/test_apps/python_app/vendor/stil/example2.stil
@@ -36,17 +36,7 @@ SignalGroups quality {
 Timing {
   WaveformTable defaults {
     Waveforms {
-      allpins { 
-        xX { TMARK: 't_anchor' Z } 
-        <tag1> 0  {'0ns' D; }
-        <tag1> 1  {'0ns' U }
-        L  {'0ns' L; }
-        H  {'0ns' H }
-        <tag2> p  {'0ns' U; '5ns' D; }
-        <tag3> P  {'0ns' D; '5ns' U }
-        t  {'0ns' U; '5ns' D; }
-        T  {'0ns' D; '5ns' U }
-      }
+      allpins { xX { TMARK: 't_anchor' Z; } }
     }
   }
   WaveformTable wft1 {


### PR DESCRIPTION
AMD has historical STIL files where the final event in a waveform definition omits its `;` terminator.

This keeps standards-compliant STIL as the default and makes that legacy syntax an explicit runtime opt-in. Existing APIs and behavior remain unchanged:

```rust
let ast = origen_metal::stil::from_file(path)?;
```

AMD or another consumer can enable only the legacy final-event syntax per parser:

```rust
let ast = origen_metal::stil::Parser::new()
    .allow_missing_final_waveform_event_semicolon()
    .from_file(path)?;
```

The setting is propagated to included STIL files. Tests cover strict rejection, tagged and untagged waveform definitions, single- and multi-event definitions, include propagation, and equivalent AST output between standard and legacy forms.