### PR TITLE
STIL Parser update to make vector inline comment a child of vector node

### DIFF
--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -813,9 +813,15 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
                 ids.push(ast.push_and_open(node!(STIL::TimeUnit)));
                 pairs.push(pair.into_inner());
             }
-            Rule::vector => {
+            Rule::vector | Rule::vector_with_comment => {
                 ids.push(ast.push_and_open(node!(STIL::Vector)));
                 pairs.push(pair.into_inner());
+            }
+            Rule::vector_comment => {
+                let cmt = pair.as_str().to_string();
+                let cmt = cmt.trim();
+                let cmt = cmt.replace("\n", "");
+                ast.push(node!(STIL::Comment, cmt))
             }
             Rule::cyclized_data => {
                 ids.push(ast.push_and_open(node!(STIL::CyclizedData)));

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -274,10 +274,12 @@ scan_inversion_val = { ("0" | "1") }
 pattern_block = { "Pattern" ~ name ~ "{" ~ (label? ~ time_unit)? ~ pattern_statement* ~ "}" }
 label = { (string | name) ~ ":" }
 time_unit = { "TimeUnit" ~ time_expr ~ EOS }
-pattern_statement = { label | vector | waveform_statement | condition | call | macro_statement | loop_statement |
+pattern_statement = { label | vector_with_comment | vector | waveform_statement | condition | call | macro_statement | loop_statement |
                       match_loop | goto | breakpoint | iddq | stop_statement | scan_chain_statement | annotation }
 
 vector = { "V" ~ "ector"? ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}" }
+vector_with_comment = ${ "V" ~ "ector"? ~ (space | N)* ~ "{" ~ ((space | N)* ~ (cyclized_data | non_cyclized_data))* ~ (space | N)* ~ "}" ~ vector_comment }
+vector_comment = @{ space* ~ "//" ~ (!N ~ ANY)* ~ N }
 cyclized_data = { (sigref_expr ~ "=" ~ vec_data+ ~ EOS) | (sigref_expr ~ "{" ~ (vec_data ~ EOS)+ ~ "}") }
 vec_data = { repeat | waveform_format | hex_format | dec_format | data_string }
 repeat = @{ "\\r" ~ integer }


### PR DESCRIPTION
Comment node of vector inline comment (defined as inline comment between end of vector and a newline) to be a child node of the vector node.  Allows better comment traceability for downstream AST processors.

**EXAMPLE STIL:**
```
V { Jtag=1110x; }   // vecLine:1, testCycle:1
// SELECT_DR -> SELECT_IR
V { Jtag=1p10x; }   // vecLine:2, testCycle:2
// SELECT_IR -> CAPTURE_IR
```


**PREVIOUS:**
```
    Vector
        CyclizedData
            SigRefExpr
                String("Jtag")
            Data("1110x")
    Comment("// vecLine:1, testCycle:1")
    Comment("// SELECT_DR -> SELECT_IR")
    Vector
        CyclizedData
            SigRefExpr
                String("Jtag")
            Data("1p10x")
    Comment("// vecLine:2, testCycle:2")
    Comment("// SELECT_IR -> CAPTURE_IR")
```

**UPDATED:**
```
    Vector
        CyclizedData
            SigRefExpr
                String("Jtag")
            Data("1110x")
        Comment("// vecLine:1, testCycle:1")
    Comment("// SELECT_DR -> SELECT_IR")
    Vector
        CyclizedData
            SigRefExpr
                String("Jtag")
            Data("1p10x")
        Comment("// vecLine:2, testCycle:2")
    Comment("// SELECT_IR -> CAPTURE_IR")
```