### PR TITLE
STIL - ignore include statements, in-line loop comments

### DIFF
--- a/rust/origen_metal/src/stil/mod.rs
+++ b/rust/origen_metal/src/stil/mod.rs
@@ -17,6 +17,11 @@ pub fn from_file(path: &Path) -> OrigenResult<Node<STIL>> {
     Ok(ast)
 }
 
+pub fn from_file_ignore_includes(path: &Path) -> OrigenResult<Node<STIL>> {
+    let ast = parser::parse_file(path)?;
+    Ok(ast)
+}
+
 /// Parse the given STIL file, using the given load path to resolve any include statements
 /// that are encountered.
 /// Include files can optionally be renamed using the `rename` argument, which

--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -900,13 +900,19 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
                 );
                 pairs.push(p);
             }
-            Rule::loop_statement => {
+            Rule::loop_statement | Rule::loop_statement_with_comment => {
                 let mut p = pair.into_inner();
                 ids.push(ast.push_and_open(node!(
                     STIL::Loop,
                     p.next().unwrap().as_str().parse().unwrap()
                 )));
                 pairs.push(p);
+            }
+            Rule::loop_comment => {
+                let cmt = pair.as_str().to_string();
+                let cmt = cmt.trim();
+                let cmt = cmt.replace("\n", "");
+                ast.push(node!(STIL::Comment, cmt))
             }
             Rule::match_loop => {
                 let mut p = pair.into_inner();

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -274,7 +274,7 @@ scan_inversion_val = { ("0" | "1") }
 pattern_block = { "Pattern" ~ name ~ "{" ~ (label? ~ time_unit)? ~ pattern_statement* ~ "}" }
 label = { (string | name) ~ ":" }
 time_unit = { "TimeUnit" ~ time_expr ~ EOS }
-pattern_statement = { label | vector_with_comment | vector | waveform_statement | condition | call | macro_statement |loop_statement_with_comment | 
+pattern_statement = !{ label | vector_with_comment | vector | waveform_statement | condition | call | macro_statement |loop_statement_with_comment | 
                       loop_statement | match_loop | goto | breakpoint | iddq | stop_statement | scan_chain_statement | annotation }
 
 vector = { "V" ~ "ector"? ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}" }

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -274,8 +274,8 @@ scan_inversion_val = { ("0" | "1") }
 pattern_block = { "Pattern" ~ name ~ "{" ~ (label? ~ time_unit)? ~ pattern_statement* ~ "}" }
 label = { (string | name) ~ ":" }
 time_unit = { "TimeUnit" ~ time_expr ~ EOS }
-pattern_statement = { label | vector_with_comment | vector | waveform_statement | condition | call | macro_statement | loop_statement |
-                      match_loop | goto | breakpoint | iddq | stop_statement | scan_chain_statement | annotation }
+pattern_statement = { label | vector_with_comment | vector | waveform_statement | condition | call | macro_statement |loop_statement_with_comment | 
+                      loop_statement | match_loop | goto | breakpoint | iddq | stop_statement | scan_chain_statement | annotation }
 
 vector = { "V" ~ "ector"? ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}" }
 vector_with_comment = ${ "V" ~ "ector"? ~ (space | N)* ~ "{" ~ ((space | N)* ~ (cyclized_data | non_cyclized_data))* ~ (space | N)* ~ "}" ~ vector_comment }
@@ -302,6 +302,8 @@ call = { ("Call" ~ name ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}") | ("
 macro_statement = { ("Macro" ~ name ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}") | ("Macro" ~ name ~ EOS) }
 
 loop_statement = { "Loop" ~ integer ~ "{" ~ pattern_statement* ~ "}" }
+loop_statement_with_comment = ${ "Loop" ~ (space | N)* ~ integer ~ (space | N)* ~ "{" ~ ((space | N)* ~ pattern_statement)* ~ (space | N)* ~ "}" ~ loop_comment }
+loop_comment = @{ space* ~ "//" ~ (!N ~ ANY)* ~ N }
 
 match_loop = { "MatchLoop" ~ (integer | infinite) ~ "{" ~ pattern_statement+ ~ "}" }
 infinite = { "Infinite" }


### PR DESCRIPTION
This PR includes two updates:
1. New function to parse STIL into AST that ignores `include` statements

2. Loop comments - comments on loop line are now in node that is child of loop node


**EXAMPLE STIL:**
```
  Loop 5    { V { group1=0p11T;  } } // vecLine:6, testCycle:6
  // COMMENT
  Loop 3    { V { group1=0p10t;  } } // vecLine:7, testCycle:11
  // COMMENT
```

**PREVIOUS:**
```
        Loop(5)
            Vector
                CyclizedData
                    SigRefExpr
                        String("group1")
                    Data("0p11T")
        Comment("// vecLine:6, testCycle:6")
        Comment("// COMMENT")
        Loop(3)
            Vector
                CyclizedData
                    SigRefExpr
                        String("group1")
                    Data("0p10t")
        Comment("// vecLine:7, testCycle:11")
        Comment("// COMMENT")
```

**UPDATED:**		
```
        Loop(5)
            Vector
                CyclizedData
                    SigRefExpr
                        String("group1")
                    Data("0p11T")
            Comment("// vecLine:6, testCycle:6")
        Comment("// COMMENT")
        Loop(3)
            Vector
                CyclizedData
                    SigRefExpr
                        String("group1")
                    Data("0p10t")
            Comment("// vecLine:7, testCycle:11")
        Comment("// COMMENT")
```