### PR TITLE
Add support for SMT8 parameter collections

### DIFF
--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -8,6 +8,15 @@ on:
       - 'rust/origen/cli/Cargo.toml'
       - 'python/origen/pyproject.toml'
       - 'python/origen_metal/pyproject.toml'
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      # Ignore updates to just the publish action
+      - '.github/workflows/publish.yml'
+      # Ignore updates to just version files for Origen/OM/CLI
+      - 'rust/origen/cli/Cargo.toml'
+      - 'python/origen/pyproject.toml'
+      - 'python/origen_metal/pyproject.toml'
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -1,22 +1,21 @@
 name: Regression Tests
+
+x-regression-test-paths-ignore: &regression-test-paths-ignore
+  # Ignore updates to just the publish action
+  - '.github/workflows/publish.yml'
+  # Ignore updates to just version files for Origen/OM/CLI
+  - 'rust/origen/cli/Cargo.toml'
+  - 'python/origen/pyproject.toml'
+  - 'python/origen_metal/pyproject.toml'
+
 on:
   push:
-    paths-ignore:
-      # Ignore updates to just the publish action
-      - '.github/workflows/publish.yml'
-      # Ignore updates to just version files for Origen/OM/CLI
-      - 'rust/origen/cli/Cargo.toml'
-      - 'python/origen/pyproject.toml'
-      - 'python/origen_metal/pyproject.toml'
+    branches:
+      - master
+    paths-ignore: *regression-test-paths-ignore
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths-ignore:
-      # Ignore updates to just the publish action
-      - '.github/workflows/publish.yml'
-      # Ignore updates to just version files for Origen/OM/CLI
-      - 'rust/origen/cli/Cargo.toml'
-      - 'python/origen/pyproject.toml'
-      - 'python/origen_metal/pyproject.toml'
+    paths-ignore: *regression-test-paths-ignore
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/regression_test.yml
+++ b/.github/workflows/regression_test.yml
@@ -1,18 +1,15 @@
 name: Regression Tests
-
-x-regression-test-paths-ignore: &regression-test-paths-ignore
-  # Ignore updates to just the publish action
-  - '.github/workflows/publish.yml'
-  # Ignore updates to just version files for Origen/OM/CLI
-  - 'rust/origen/cli/Cargo.toml'
-  - 'python/origen/pyproject.toml'
-  - 'python/origen_metal/pyproject.toml'
-
 on:
   push:
     branches:
       - master
-    paths-ignore: *regression-test-paths-ignore
+    paths-ignore: &regression-test-paths-ignore
+      # Ignore updates to just the publish action
+      - '.github/workflows/publish.yml'
+      # Ignore updates to just version files for Origen/OM/CLI
+      - 'rust/origen/cli/Cargo.toml'
+      - 'python/origen/pyproject.toml'
+      - 'python/origen_metal/pyproject.toml'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore: *regression-test-paths-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ log/
 rls/
 .pytest_cache
 .cline_storage/
+.codex/
+.claude/
 
 
 # pyenv

--- a/python/origen_metal/pyproject.toml
+++ b/python/origen_metal/pyproject.toml
@@ -29,21 +29,21 @@ termcolor = ">= 1.1.0"
 colorama = ">= 0.4.4" # Note: colorama is usually installed on the system already, but it isn't actually required (e.g. WSL won't have this by default)
 importlib-metadata = ">= 6.7.0" # For use with Python pre-3.8
 
-# [project]
-# name = "origen-metal"
-# version = "1.2.2"
-# description = "Bare metal APIs for the Origen SDK"
-## UV doesn't like some of these, the author I think
+[project]
+name = "origen-metal"
+version = "1.2.2"
+description = "Bare metal APIs for the Origen SDK"
+# UV doesn't like some of these, the author I think
 ##license = "MIT"
 ##readme = "README.md"
 ##authors = ["Origen-SDK"]
-# requires-python = ">=3.7.0,<3.13"
-# dependencies = [
-#      "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
-#      "termcolor >=1.1.0",
-#      "colorama >=0.4.4",
-#      "importlib-metadata >=6.7.0",
-# ]
+requires-python = ">=3.7.0,<3.13"
+dependencies = [
+     "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
+     "termcolor >=1.1.0",
+     "colorama >=0.4.4",
+     "importlib-metadata >=6.7.0",
+]
 
 [tool.poetry.dev-dependencies]
 pytest-rerunfailures = "13.0" # Last version that supports Python 3.7

--- a/python/origen_metal/pyproject.toml
+++ b/python/origen_metal/pyproject.toml
@@ -29,21 +29,21 @@ termcolor = ">= 1.1.0"
 colorama = ">= 0.4.4" # Note: colorama is usually installed on the system already, but it isn't actually required (e.g. WSL won't have this by default)
 importlib-metadata = ">= 6.7.0" # For use with Python pre-3.8
 
-[project]
-name = "origen-metal"
-version = "1.2.2"
-description = "Bare metal APIs for the Origen SDK"
+# [project]
+# name = "origen-metal"
+# version = "1.2.2"
+# description = "Bare metal APIs for the Origen SDK"
 ## UV doesn't like some of these, the author I think
 ##license = "MIT"
 ##readme = "README.md"
 ##authors = ["Origen-SDK"]
-requires-python = ">=3.7.0,<3.13"
-dependencies = [
-     "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
-     "termcolor >=1.1.0",
-     "colorama >=0.4.4",
-     "importlib-metadata >=6.7.0",
-]
+# requires-python = ">=3.7.0,<3.13"
+# dependencies = [
+#      "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
+#      "termcolor >=1.1.0",
+#      "colorama >=0.4.4",
+#      "importlib-metadata >=6.7.0",
+# ]
 
 [tool.poetry.dev-dependencies]
 pytest-rerunfailures = "13.0" # Last version that supports Python 3.7

--- a/python/origen_metal/pyproject.toml
+++ b/python/origen_metal/pyproject.toml
@@ -29,21 +29,21 @@ termcolor = ">= 1.1.0"
 colorama = ">= 0.4.4" # Note: colorama is usually installed on the system already, but it isn't actually required (e.g. WSL won't have this by default)
 importlib-metadata = ">= 6.7.0" # For use with Python pre-3.8
 
-# [project]
-# name = "origen-metal"
-# version = "1.2.2"
-# description = "Bare metal APIs for the Origen SDK"
+[project]
+name = "origen-metal"
+version = "1.2.2"
+description = "Bare metal APIs for the Origen SDK"
 ## UV doesn't like some of these, the author I think
 ##license = "MIT"
 ##readme = "README.md"
 ##authors = ["Origen-SDK"]
-# requires-python = ">=3.7.0,<3.13"
-# dependencies = [
-#      "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
-#      "termcolor >=1.1.0",
-#      "colorama >=0.4.4",
-#      "importlib-metadata >=6.7.0",
-# ]
+requires-python = ">=3.7.0,<3.13"
+dependencies = [
+     "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
+     "termcolor >=1.1.0",
+     "colorama >=0.4.4",
+     "importlib-metadata >=6.7.0",
+]
 
 [tool.poetry.dev-dependencies]
 pytest-rerunfailures = "13.0" # Last version that supports Python 3.7

--- a/python/origen_metal/pyproject.toml
+++ b/python/origen_metal/pyproject.toml
@@ -29,21 +29,21 @@ termcolor = ">= 1.1.0"
 colorama = ">= 0.4.4" # Note: colorama is usually installed on the system already, but it isn't actually required (e.g. WSL won't have this by default)
 importlib-metadata = ">= 6.7.0" # For use with Python pre-3.8
 
-[project]
-name = "origen-metal"
-version = "1.2.2"
-description = "Bare metal APIs for the Origen SDK"
-# UV doesn't like some of these, the author I think
+# [project]
+# name = "origen-metal"
+# version = "1.2.2"
+# description = "Bare metal APIs for the Origen SDK"
+## UV doesn't like some of these, the author I think
 ##license = "MIT"
 ##readme = "README.md"
 ##authors = ["Origen-SDK"]
-requires-python = ">=3.7.0,<3.13"
-dependencies = [
-     "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
-     "termcolor >=1.1.0",
-     "colorama >=0.4.4",
-     "importlib-metadata >=6.7.0",
-]
+# requires-python = ">=3.7.0,<3.13"
+# dependencies = [
+#      "pyreadline3 >=3.3,<4.0; sys_platform == 'win32'",
+#      "termcolor >=1.1.0",
+#      "colorama >=0.4.4",
+#      "importlib-metadata >=6.7.0",
+# ]
 
 [tool.poetry.dev-dependencies]
 pytest-rerunfailures = "13.0" # Last version that supports Python 3.7

--- a/rust/origen_metal/src/prog_gen/advantest/smt8/processors/flow_generator.rs
+++ b/rust/origen_metal/src/prog_gen/advantest/smt8/processors/flow_generator.rs
@@ -3,6 +3,8 @@ use crate::prog_gen::config::SMT8Config;
 use crate::prog_gen::{BinType, FlowCondition, GroupType, Model, PGM, ParamValue};
 use crate::Result;
 use crate::ast::{Node, Processor, Return};
+use indexmap::IndexMap;
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -107,6 +109,201 @@ pub fn run(ast: &Node<PGM>, output_dir: &Path, model: Model) -> Result<(Model, V
 }
 
 impl FlowGenerator {
+    fn alpha_cmp(a: &str, b: &str) -> Ordering {
+        a.to_ascii_lowercase()
+            .cmp(&b.to_ascii_lowercase())
+            .then_with(|| a.cmp(b))
+    }
+
+    fn natural_cmp(a: &str, b: &str) -> Ordering {
+        let mut left = a.chars().peekable();
+        let mut right = b.chars().peekable();
+
+        loop {
+            match (left.peek(), right.peek()) {
+                (None, None) => return Ordering::Equal,
+                (None, Some(_)) => return Ordering::Less,
+                (Some(_), None) => return Ordering::Greater,
+                (Some(lc), Some(rc)) => {
+                    if lc.is_ascii_digit() && rc.is_ascii_digit() {
+                        let mut l_digits = String::new();
+                        let mut r_digits = String::new();
+                        while let Some(c) = left.peek() {
+                            if c.is_ascii_digit() {
+                                l_digits.push(*c);
+                                left.next();
+                            } else {
+                                break;
+                            }
+                        }
+                        while let Some(c) = right.peek() {
+                            if c.is_ascii_digit() {
+                                r_digits.push(*c);
+                                right.next();
+                            } else {
+                                break;
+                            }
+                        }
+                        let l_trimmed = l_digits.trim_start_matches('0');
+                        let r_trimmed = r_digits.trim_start_matches('0');
+                        let number_cmp = l_trimmed
+                            .len()
+                            .cmp(&r_trimmed.len())
+                            .then_with(|| l_trimmed.cmp(r_trimmed))
+                            .then_with(|| l_digits.len().cmp(&r_digits.len()));
+                        if number_cmp != Ordering::Equal {
+                            return number_cmp;
+                        }
+                    } else {
+                        let l = left.next().unwrap();
+                        let r = right.next().unwrap();
+                        let char_cmp = l
+                            .to_ascii_lowercase()
+                            .cmp(&r.to_ascii_lowercase())
+                            .then_with(|| l.cmp(&r));
+                        if char_cmp != Ordering::Equal {
+                            return char_cmp;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn format_number(value: f64) -> String {
+        if value.is_infinite() {
+            if value.is_sign_positive() {
+                "Infinity".to_string()
+            } else {
+                "-Infinity".to_string()
+            }
+        } else {
+            format!("{}", value)
+        }
+    }
+
+    fn format_plain_float(value: f64) -> String {
+        if value.is_infinite() {
+            Self::format_number(value)
+        } else if value.fract() == 0.0 {
+            format!("{:.1}", value)
+        } else {
+            format!("{}", value)
+        }
+    }
+
+    fn write_param_value(
+        f: &mut std::fs::File,
+        indent: usize,
+        name: &str,
+        value: &ParamValue,
+    ) -> Result<()> {
+        let indent = "    ".repeat(indent);
+        match value {
+            ParamValue::String(v) | ParamValue::Any(v) => {
+                writeln!(f, "{}{} = \"{}\";", indent, name, v)?;
+            }
+            ParamValue::Int(v) => {
+                writeln!(f, "{}{} = {};", indent, name, v)?;
+            }
+            ParamValue::UInt(v) => {
+                writeln!(f, "{}{} = {};", indent, name, v)?;
+            }
+            ParamValue::Float(v) => {
+                writeln!(f, "{}{} = {};", indent, name, Self::format_plain_float(*v))?;
+            }
+            ParamValue::Current(v) => {
+                writeln!(f, "{}{} = \"{}[A]\";", indent, name, Self::format_number(*v))?;
+            }
+            ParamValue::Voltage(v) => {
+                writeln!(f, "{}{} = \"{}[V]\";", indent, name, Self::format_number(*v))?;
+            }
+            ParamValue::Time(v) => {
+                writeln!(f, "{}{} = \"{}[s]\";", indent, name, Self::format_number(*v))?;
+            }
+            ParamValue::Frequency(v) => {
+                writeln!(f, "{}{} = \"{}[Hz]\";", indent, name, Self::format_number(*v))?;
+            }
+            ParamValue::Bool(v) => {
+                writeln!(f, "{}{} = {};", indent, name, if *v { "true" } else { "false" })?;
+            }
+        }
+        Ok(())
+    }
+
+    fn render_sorted_contents(
+        &self,
+        f: &mut std::fs::File,
+        indent: usize,
+        values: &IndexMap<String, ParamValue>,
+        default_values: &IndexMap<String, ParamValue>,
+        collections: &IndexMap<String, Vec<usize>>,
+    ) -> Result<()> {
+        let mut names: Vec<String> = values
+            .iter()
+            .filter_map(|(name, value)| {
+                if !self.options.render_default_tmparams
+                    && default_values.get(name).is_some_and(|default| default == value)
+                {
+                    None
+                } else {
+                    Some(name.clone())
+                }
+            })
+            .collect();
+        for (collection_name, ids) in collections {
+            let has_renderable_items = ids.iter().any(|id| {
+                self.model
+                    .test_collection_items
+                    .get(id)
+                    .is_some_and(|item| item.available)
+            });
+            if has_renderable_items {
+                names.push(collection_name.clone());
+            }
+        }
+        names.sort_by(|a, b| Self::alpha_cmp(a, b));
+        names.dedup();
+
+        for name in names {
+            if let Some(value) = values.get(&name) {
+                if !self.options.render_default_tmparams
+                    && default_values.get(&name).is_some_and(|default| default == value)
+                {
+                    continue;
+                }
+                Self::write_param_value(f, indent, &name, value)?;
+                continue;
+            }
+
+            if let Some(ids) = collections.get(&name) {
+                let mut items = ids
+                    .iter()
+                    .filter_map(|id| self.model.test_collection_items.get(id))
+                    .filter(|item| item.available)
+                    .collect::<Vec<_>>();
+                items.sort_by(|a, b| Self::natural_cmp(&a.instance_id, &b.instance_id));
+                for item in items {
+                    let indent_str = "    ".repeat(indent);
+                    writeln!(
+                        f,
+                        "{}{}[{}] = {{",
+                        indent_str, item.collection_name, item.instance_id
+                    )?;
+                    self.render_sorted_contents(
+                        f,
+                        indent + 1,
+                        &item.values,
+                        &item.default_values,
+                        &item.collections,
+                    )?;
+                    writeln!(f, "{}}};", indent_str)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn current_flow_path(&self) -> Option<String> {
         if self.flow_stack.is_empty() || self.flow_stack.len() == 1 {
             None
@@ -213,56 +410,13 @@ impl FlowGenerator {
                 if let Some(spec) = test_invocation.get("spec")?.map(|p| p.to_string()) {
                     writeln!(&mut f, "            measurement.specification = setupRef({}specs.{});", &namespace, spec)?;
                 }
-                let sorted_param_keys =  {
-                    let mut keys: Vec<&String> = test.values.keys().collect();
-                    keys.sort();
-                    keys
-                };
-
-                for param in sorted_param_keys {
-                    let value = test.values.get(param).unwrap();
-                    if !self.options.render_default_tmparams {
-                        let default_value = test.default_values.get(param);
-                        if let Some(default_value) = default_value {
-                            if default_value == value {
-                                continue;
-                            }
-                        }
-                    }
-                    match value {
-                        ParamValue::String(v) | ParamValue::Any(v) => {
-                            writeln!(&mut f, "            {} = \"{}\";", param, v)?;
-                        }
-                        ParamValue::Int(v) => {
-                            writeln!(&mut f, "            {} = {};", param, v)?;
-                        }
-                        ParamValue::UInt(v) =>  {
-                            writeln!(&mut f, "            {} = {};", param, v)?;
-                        }
-                        ParamValue::Float(v) => {
-                            writeln!(&mut f, "            {} = {};", param, v)?;
-                        }
-                        ParamValue::Current(v) => {
-                            writeln!(&mut f, "            {} = \"{}[A]\";", param, v)?;
-                        }
-                        ParamValue::Voltage(v) =>  {
-                            writeln!(&mut f, "            {} = \"{}[V]\";", param, v)?;
-                        }
-                        ParamValue::Time(v) => {
-                            writeln!(&mut f, "            {} = \"{}[s]\";", param, v)?;
-                        }
-                        ParamValue::Frequency(v) => {
-                            writeln!(&mut f, "            {} = \"{}[Hz]\";", param, v)?;
-                        }
-                        ParamValue::Bool(v) => {
-                            if *v {
-                                writeln!(&mut f, "            {} = true;", param)?;
-                            } else {
-                                writeln!(&mut f, "            {} = false;", param)?;
-                            }
-                        }
-                    }
-                }
+                self.render_sorted_contents(
+                    &mut f,
+                    3,
+                    &test.values,
+                    &test.default_values,
+                    &test.collections,
+                )?;
                 writeln!(&mut f, "        }}")?;
             }
             writeln!(&mut f, "")?;
@@ -824,6 +978,25 @@ impl Processor<PGM> for FlowGenerator {
             _ => {}
         }
         Ok(Return::Unmodified)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FlowGenerator;
+    use std::cmp::Ordering;
+
+    #[test]
+    fn natural_sort_orders_numeric_suffixes() {
+        let mut ids = vec!["param10", "param2", "param1", "param11", "param3"];
+        ids.sort_by(|a, b| FlowGenerator::natural_cmp(a, b));
+        assert_eq!(ids, vec!["param1", "param2", "param3", "param10", "param11"]);
+    }
+
+    #[test]
+    fn alpha_sort_is_case_insensitive() {
+        assert_eq!(FlowGenerator::alpha_cmp("testName", "testerState"), Ordering::Greater);
+        assert_eq!(FlowGenerator::alpha_cmp("Y1Variable", "zDataDeltaLimit"), Ordering::Less);
     }
 }
 

--- a/rust/origen_metal/src/prog_gen/flow_api.rs
+++ b/rust/origen_metal/src/prog_gen/flow_api.rs
@@ -89,6 +89,27 @@ pub fn assign_test_to_invocation(
     Ok(())
 }
 
+pub fn define_test_collection_item(
+    parent_id: usize,
+    collection_name: &str,
+    instance_id: &str,
+    allow_missing: bool,
+    meta: Option<Meta>,
+) -> Result<usize> {
+    let id = crate::PROG_GEN_CONFIG.generate_unique_id();
+    let n = node!(
+        PGM::DefTestCollectionItem,
+        id,
+        parent_id,
+        collection_name.to_owned(),
+        instance_id.to_owned(),
+        allow_missing;
+        meta
+    );
+    FLOW.push(n)?;
+    Ok(id)
+}
+
 /// Execute the given test (or invocation) from the current flow
 pub fn execute_test(id: usize, flow_id: FlowID, meta: Option<Meta>) -> Result<()> {
     let n = node!(PGM::Test, id, flow_id; meta);

--- a/rust/origen_metal/src/prog_gen/mod.rs
+++ b/rust/origen_metal/src/prog_gen/mod.rs
@@ -30,12 +30,14 @@ pub use model::PatternGroupType;
 pub use model::PatternReferenceType;
 pub use model::PatternType;
 pub use model::Test;
+pub use model::TestCollection;
+pub use model::TestCollectionItem;
 pub use model::Variable;
 pub use model::VariableOperation;
 pub use model::VariableType;
 pub use nodes::PGM;
 pub use supported_testers::SupportedTester;
-pub use model::{TestTemplate, TestTemplateParameter};
+pub use model::{TestTemplate, TestTemplateCollection, TestTemplateParameter};
 use model::load_test_from_lib;
 
 use crate::ast::AST;

--- a/rust/origen_metal/src/prog_gen/model/mod.rs
+++ b/rust/origen_metal/src/prog_gen/model/mod.rs
@@ -25,11 +25,13 @@ pub use pattern::PatternType;
 use std::fmt;
 use std::str::FromStr;
 pub use sub_test::SubTest;
-pub use test::Test;
+pub use test::{Test, TestCollection, TestCollectionItem};
 pub use variable::Variable;
 pub use variable::VariableOperation;
 pub use variable::VariableType;
-pub use template_loader::{TestTemplate, TestTemplateParameter, load_test_from_lib};
+pub use template_loader::{
+    load_test_from_lib, TestTemplate, TestTemplateCollection, TestTemplateParameter,
+};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum PatternGroupType {
@@ -158,10 +160,10 @@ impl FromStr for ParamType {
         // Accept any case and with or without underscores
         let str = s.to_lowercase();
         match str.trim() {
-            "string" => Ok(ParamType::String),
+            "string" | "class" => Ok(ParamType::String),
             "int" | "integer" => Ok(ParamType::Int),
             "uint" | "uinteger" => Ok(ParamType::UInt),
-            "float" | "number" | "num" => Ok(ParamType::Float),
+            "float" | "double" | "number" | "num" => Ok(ParamType::Float),
             "current" | "curr" | "i" => Ok(ParamType::Current),
             "voltage" | "volt" | "v" => Ok(ParamType::Voltage),
             "time" | "t" | "s" => Ok(ParamType::Time),

--- a/rust/origen_metal/src/prog_gen/model/mod.rs
+++ b/rust/origen_metal/src/prog_gen/model/mod.rs
@@ -25,13 +25,13 @@ pub use pattern::PatternType;
 use std::fmt;
 use std::str::FromStr;
 pub use sub_test::SubTest;
+pub use template_loader::{
+    load_test_from_lib, TestTemplate, TestTemplateCollection, TestTemplateParameter,
+};
 pub use test::{Test, TestCollection, TestCollectionItem};
 pub use variable::Variable;
 pub use variable::VariableOperation;
 pub use variable::VariableType;
-pub use template_loader::{
-    load_test_from_lib, TestTemplate, TestTemplateCollection, TestTemplateParameter,
-};
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum PatternGroupType {
@@ -158,10 +158,14 @@ impl FromStr for ParamType {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // Accept any case and with or without underscores
-        let str = s.to_lowercase();
-        match str.trim() {
+        let normalized = s.trim().to_ascii_lowercase().replace('_', "");
+        match normalized.as_str() {
             "string" | "class" => Ok(ParamType::String),
+            "pinstring" | "specvalue" | "specvariable" | "contextpins" | "optionlist" => {
+                Ok(ParamType::String)
+            }
             "int" | "integer" => Ok(ParamType::Int),
+            "long" => Ok(ParamType::Int),
             "uint" | "uinteger" => Ok(ParamType::UInt),
             "float" | "double" | "number" | "num" => Ok(ParamType::Float),
             "current" | "curr" | "i" => Ok(ParamType::Current),
@@ -170,8 +174,40 @@ impl FromStr for ParamType {
             "frequency" | "freq" | "hz" => Ok(ParamType::Frequency),
             "boolean" | "bool" => Ok(ParamType::Bool),
             "any" => Ok(ParamType::Any),
-            _ => Err(format!("'{}' is not a valid parameter type, the available types are: String, Int, UInt, Number, Current, Voltage, Time, Frequency, Bool, Any", str)),
+            _ => Err(format!(
+                "'{}' is not a valid parameter type, the available types are: String, PinString, SpecValue, SpecVariable, ContextPins, OptionList, Int, long, UInt, Number, Current, Voltage, Time, Frequency, Bool, Any",
+                s.trim()
+            )),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ParamType;
+    use std::str::FromStr;
+
+    #[test]
+    fn param_type_accepts_v93k_aliases() {
+        assert_eq!(ParamType::from_str("PinString").unwrap(), ParamType::String);
+        assert_eq!(
+            ParamType::from_str("pin_string").unwrap(),
+            ParamType::String
+        );
+        assert_eq!(ParamType::from_str("SpecValue").unwrap(), ParamType::String);
+        assert_eq!(
+            ParamType::from_str("spec_variable").unwrap(),
+            ParamType::String
+        );
+        assert_eq!(
+            ParamType::from_str("ContextPins").unwrap(),
+            ParamType::String
+        );
+        assert_eq!(
+            ParamType::from_str("OptionList").unwrap(),
+            ParamType::String
+        );
+        assert_eq!(ParamType::from_str("long").unwrap(), ParamType::Int);
     }
 }
 

--- a/rust/origen_metal/src/prog_gen/model/model.rs
+++ b/rust/origen_metal/src/prog_gen/model/model.rs
@@ -1,7 +1,7 @@
 use super::template_loader::load_test_from_lib;
 use super::{
     Flow, ParamValue, Pattern, PatternReferenceType, PatternType, ResourcesType, SubTest, Test,
-    Variable, VariableOperation, VariableType,
+    TestCollectionItem, Variable, VariableOperation, VariableType,
 };
 use crate::prog_gen::model::test::TEST_NUMBER_ALIASES;
 use crate::prog_gen::supported_testers::SupportedTester;
@@ -21,6 +21,8 @@ pub struct Model {
     /// Test invocation objects, stored by their internal ID.
     /// These map to test flow lines for IG-XL and test suites for V93K.
     pub test_invocations: IndexMap<usize, Test>,
+    /// Collection item objects referenced by test methods and nested collection items.
+    pub test_collection_items: IndexMap<usize, TestCollectionItem>,
     /// Tests can store a single limit, but if a test has multiple limits then they are represented as sub-tests
     pub sub_tests: Vec<SubTest>,
     /// All pattern references made in the test program, flows and pattern_collections make reference to these
@@ -52,6 +54,7 @@ impl Model {
             current_variable_resource: None,
             tests: IndexMap::new(),
             test_invocations: IndexMap::new(),
+            test_collection_items: IndexMap::new(),
             sub_tests: vec![],
             templates: IndexMap::new(),
             patterns: vec![],
@@ -436,9 +439,99 @@ impl Model {
             test.set(name, value, allow_missing)?;
             return Ok(());
         }
+        if self.test_collection_items.contains_key(&id) {
+            let item = self.test_collection_items.get_mut(&id).unwrap();
+            item.set(name, value, allow_missing)?;
+            return Ok(());
+        }
         bail!(
             "Something has gone wrong, no test or invocation exists with ID '{}'",
             id
         )
+    }
+
+    pub fn add_test_collection_item(
+        &mut self,
+        parent_id: usize,
+        item_id: usize,
+        collection_name: &str,
+        instance_id: &str,
+        allow_missing: bool,
+    ) -> Result<()> {
+        if self.test_collection_items.contains_key(&item_id) {
+            bail!(
+                "Something has gone wrong, two collection items have been generated with the same internal ID '{}' in flow '{}'",
+                item_id,
+                &self.current_flow
+            );
+        }
+
+        let item = if self.tests.contains_key(&parent_id) {
+            let test = self.tests.get_mut(&parent_id).unwrap();
+            let schema = test.collection_defs.get(collection_name).cloned();
+            let item = match schema {
+                Some(schema) => TestCollectionItem::from_collection(
+                    item_id,
+                    parent_id,
+                    instance_id,
+                    &schema,
+                ),
+                None if allow_missing => {
+                    TestCollectionItem::unavailable(item_id, parent_id, collection_name, instance_id)
+                }
+                None => {
+                    bail!(
+                        "Test '{}' does not have a collection named '{}'",
+                        test.name,
+                        collection_name
+                    );
+                }
+            };
+            test.collections
+                .entry(item.collection_name.clone())
+                .or_insert_with(Vec::new)
+                .push(item_id);
+            item
+        } else if self.test_collection_items.contains_key(&parent_id) {
+            let parent = self.test_collection_items.get_mut(&parent_id).unwrap();
+            let schema = if parent.available {
+                parent.collection_defs.get(collection_name).cloned()
+            } else {
+                None
+            };
+            let item = match schema {
+                Some(schema) => TestCollectionItem::from_collection(
+                    item_id,
+                    parent_id,
+                    instance_id,
+                    &schema,
+                ),
+                None if allow_missing || !parent.available => {
+                    TestCollectionItem::unavailable(item_id, parent_id, collection_name, instance_id)
+                }
+                None => {
+                    bail!(
+                        "Collection item '{}[{}]' does not have a collection named '{}'",
+                        parent.collection_name,
+                        parent.instance_id,
+                        collection_name
+                    );
+                }
+            };
+            parent
+                .collections
+                .entry(item.collection_name.clone())
+                .or_insert_with(Vec::new)
+                .push(item_id);
+            item
+        } else {
+            bail!(
+                "Something has gone wrong, no test or collection item exists with ID '{}'",
+                parent_id
+            );
+        };
+
+        self.test_collection_items.insert(item_id, item);
+        Ok(())
     }
 }

--- a/rust/origen_metal/src/prog_gen/model/template_loader.rs
+++ b/rust/origen_metal/src/prog_gen/model/template_loader.rs
@@ -2,6 +2,7 @@
 
 use crate::prog_gen::supported_testers::SupportedTester;
 use crate::Result;
+use indexmap::IndexMap;
 use phf::phf_map;
 use std::collections::{HashMap, HashSet};
 use std::sync::RwLock;
@@ -31,17 +32,24 @@ lazy_static! {
 /// Test template definitions from json files are read into this structure
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct TestTemplate {
-    pub parameter_list: Option<HashMap<String, String>>,
-    pub aliases: Option<HashMap<String, String>>,
-    pub values: Option<HashMap<String, serde_json::Value>>,
-    pub parameters: Option<HashMap<String, TestTemplateParameter>>,
+    pub parameter_list: Option<IndexMap<String, String>>,
+    pub aliases: Option<IndexMap<String, String>>,
+    pub values: Option<IndexMap<String, serde_json::Value>>,
+    pub parameters: Option<IndexMap<String, TestTemplateParameter>>,
+    pub collections: Option<IndexMap<String, TestTemplateCollection>>,
     pub class_name: Option<String>,
-    pub accepted_values: Option<HashMap<String, Vec<serde_json::Value>>>,
+    pub accepted_values: Option<IndexMap<String, Vec<serde_json::Value>>>,
+}
+
+#[derive(Debug, Deserialize, Clone, Serialize)]
+pub struct TestTemplateCollection {
+    pub parameters: Option<IndexMap<String, TestTemplateParameter>>,
+    pub collections: Option<IndexMap<String, TestTemplateCollection>>,
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct TestTemplateParameter {
-    #[serde(rename(deserialize = "type"))]
+    #[serde(alias = "type")]
     pub kind: Option<String>,
     pub aliases: Option<Vec<String>>,
     pub value: Option<serde_json::Value>,
@@ -141,5 +149,67 @@ mod unit_tests {
             let _: TestTemplate =
                 serde_json::from_str(content).expect(&format!("Failed to import {}", file));
         }
+    }
+
+    #[test]
+    fn test_kind_alias_and_recursive_collections_import() {
+        let template: TestTemplate = serde_json::from_str(
+            r#"{
+                "parameters": {
+                    "enableSoftset": {
+                        "kind": "boolean",
+                        "value": "false"
+                    }
+                },
+                "collections": {
+                    "tsen": {
+                        "parameters": {
+                            "zDataDeltaLimit": {
+                                "kind": "double",
+                                "value": "0.0"
+                            }
+                        },
+                        "collections": {
+                            "registers": {
+                                "parameters": {
+                                    "zLowLimit": {
+                                        "type": "double",
+                                        "value": "-Infinity"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            template.parameters.as_ref().unwrap()["enableSoftset"]
+                .kind
+                .as_deref(),
+            Some("boolean")
+        );
+        assert!(template.collections.as_ref().unwrap().contains_key("tsen"));
+        assert!(
+            template.collections.as_ref().unwrap()["tsen"]
+                .collections
+                .as_ref()
+                .unwrap()
+                .contains_key("registers")
+        );
+        assert_eq!(
+            template.collections.as_ref().unwrap()["tsen"]
+                .collections
+                .as_ref()
+                .unwrap()["registers"]
+                .parameters
+                .as_ref()
+                .unwrap()["zLowLimit"]
+                .kind
+                .as_deref(),
+            Some("double")
+        );
     }
 }

--- a/rust/origen_metal/src/prog_gen/model/test.rs
+++ b/rust/origen_metal/src/prog_gen/model/test.rs
@@ -1,4 +1,4 @@
-use super::template_loader::TestTemplate;
+use super::template_loader::{TestTemplate, TestTemplateCollection, TestTemplateParameter};
 use super::Model;
 use super::{Constraint, Limit, ParamType, ParamValue};
 use crate::prog_gen::supported_testers::SupportedTester;
@@ -7,6 +7,33 @@ use indexmap::IndexMap;
 use std::str::FromStr;
 
 pub const TEST_NUMBER_ALIASES: [&str; 6] = ["testnumber", "test_number", "number", "testnum", "test_num", "tnum"];
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestCollection {
+    pub name: String,
+    pub params: IndexMap<String, ParamType>,
+    pub default_values: IndexMap<String, ParamValue>,
+    pub aliases: IndexMap<String, String>,
+    pub constraints: IndexMap<String, Vec<Constraint>>,
+    pub collections: IndexMap<String, TestCollection>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TestCollectionItem {
+    pub id: usize,
+    pub parent_id: usize,
+    pub collection_name: String,
+    pub instance_id: String,
+    pub available: bool,
+    pub params: IndexMap<String, ParamType>,
+    pub values: IndexMap<String, ParamValue>,
+    pub default_values: IndexMap<String, ParamValue>,
+    pub aliases: IndexMap<String, String>,
+    pub constraints: IndexMap<String, Vec<Constraint>>,
+    pub collection_defs: IndexMap<String, TestCollection>,
+    pub collections: IndexMap<String, Vec<usize>>,
+    _private: (),
+}
 
 /// This is an abstract data object which is used to model test instances on Teradyne platforms
 /// and both test methods and test suites on Advantest platforms.
@@ -30,6 +57,8 @@ pub struct Test {
     pub default_values: IndexMap<String, ParamValue>,
     pub aliases: IndexMap<String, String>,
     pub constraints: IndexMap<String, Vec<Constraint>>,
+    pub collection_defs: IndexMap<String, TestCollection>,
+    pub collections: IndexMap<String, Vec<usize>>,
     pub tester: SupportedTester,
     pub class_name: Option<String>,
     /// References an invocation and vice versa
@@ -80,6 +109,177 @@ impl<'a> Iterator for SortedParams<'a> {
     }
 }
 
+impl TestCollection {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            params: IndexMap::new(),
+            default_values: IndexMap::new(),
+            aliases: IndexMap::new(),
+            constraints: IndexMap::new(),
+            collections: IndexMap::new(),
+        }
+    }
+
+    pub fn import_test_template(
+        &mut self,
+        template: &TestTemplateCollection,
+        owner_name: &str,
+    ) -> Result<()> {
+        if let Some(params) = &template.parameters {
+            let mut values = IndexMap::new();
+            for (name, param) in params {
+                import_template_parameter(
+                    name,
+                    param,
+                    owner_name,
+                    &mut self.params,
+                    &mut values,
+                    &mut self.default_values,
+                    &mut self.aliases,
+                    &mut self.constraints,
+                )?;
+            }
+        }
+        if let Some(collections) = &template.collections {
+            for (name, collection) in collections {
+                let mut c = TestCollection::new(name);
+                c.import_test_template(collection, owner_name)?;
+                self.collections.insert(name.to_owned(), c);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl TestCollectionItem {
+    pub fn from_collection(
+        id: usize,
+        parent_id: usize,
+        instance_id: &str,
+        collection: &TestCollection,
+    ) -> Self {
+        Self {
+            id,
+            parent_id,
+            collection_name: collection.name.clone(),
+            instance_id: instance_id.to_string(),
+            available: true,
+            params: collection.params.clone(),
+            values: collection.default_values.clone(),
+            default_values: collection.default_values.clone(),
+            aliases: collection.aliases.clone(),
+            constraints: collection.constraints.clone(),
+            collection_defs: collection.collections.clone(),
+            collections: IndexMap::new(),
+            _private: (),
+        }
+    }
+
+    pub fn unavailable(id: usize, parent_id: usize, collection_name: &str, instance_id: &str) -> Self {
+        Self {
+            id,
+            parent_id,
+            collection_name: collection_name.to_string(),
+            instance_id: instance_id.to_string(),
+            available: false,
+            params: IndexMap::new(),
+            values: IndexMap::new(),
+            default_values: IndexMap::new(),
+            aliases: IndexMap::new(),
+            constraints: IndexMap::new(),
+            collection_defs: IndexMap::new(),
+            collections: IndexMap::new(),
+            _private: (),
+        }
+    }
+
+    pub fn set(
+        &mut self,
+        param_name_or_alias: &str,
+        value: Option<ParamValue>,
+        allow_missing: bool,
+    ) -> Result<()> {
+        if !self.available {
+            return Ok(());
+        }
+        if allow_missing && !self.has_param(param_name_or_alias) {
+            return Ok(());
+        }
+        let param_name = { self.to_param_name(param_name_or_alias)?.to_owned() };
+        let kind = self.get_type(&param_name)?;
+        if let Some(value) = value {
+            let value = coerce_param_value(kind, value)?;
+            if value.is_type(kind) || kind == &ParamType::Any {
+                if let Some(constraints) = self.constraints.get(&param_name) {
+                    for constraint in constraints {
+                        if let Err(e) = constraint.is_satisfied(&value) {
+                            bail!(
+                                "Illegal value applied to attribute '{}' of collection item '{}[{}]': {}",
+                                param_name_or_alias,
+                                self.collection_name,
+                                self.instance_id,
+                                e
+                            );
+                        }
+                    }
+                }
+                self.values.insert(param_name, value);
+                Ok(())
+            } else {
+                bail!(
+                    "The type of the given value for '{}' in collection item '{}[{}]' does not match the required type: expected {:?}, given {:?}",
+                    param_name,
+                    self.collection_name,
+                    self.instance_id,
+                    kind,
+                    value
+                )
+            }
+        } else {
+            self.values.remove(&param_name);
+            Ok(())
+        }
+    }
+
+    pub fn has_param(&self, param_name: &str) -> bool {
+        self.params.contains_key(param_name) || {
+            let n = clean(param_name);
+            self.aliases.contains_key(&n)
+        }
+    }
+
+    pub fn get_type(&self, param_name_or_alias: &str) -> Result<&ParamType> {
+        let param_name = self.to_param_name(param_name_or_alias)?;
+        Ok(&self.params[param_name])
+    }
+
+    pub fn to_param_name<'a>(&'a self, name: &'a str) -> Result<&'a str> {
+        if self.params.contains_key(name) {
+            Ok(name)
+        } else {
+            let n = clean(name);
+            if self.aliases.contains_key(&n) {
+                Ok(&self.aliases[&n])
+            } else {
+                let available_attributes = self.params.keys().collect::<Vec<&String>>();
+                let mut msg = format!(
+                    "Collection item '{}[{}]' does not have an attribute named '{}'",
+                    self.collection_name,
+                    self.instance_id,
+                    name
+                );
+                msg += "\nThe available attributes are:";
+                for attr in available_attributes {
+                    let attr_type: &ParamType = &self.params[attr];
+                    msg += &format!("\n  - {} ({})", attr, attr_type);
+                }
+                bail!(&msg);
+            }
+        }
+    }
+}
+
 impl Test {
     pub fn new(name: &str, id: usize, tester: SupportedTester) -> Test {
         let mut t = Test {
@@ -92,6 +292,8 @@ impl Test {
             default_values: IndexMap::new(),
             aliases: IndexMap::new(),
             constraints: IndexMap::new(),
+            collection_defs: IndexMap::new(),
+            collections: IndexMap::new(),
             tester: tester,
             class_name: None,
             // If the test is modelling an invocation then this will reflect the ID of the
@@ -119,43 +321,23 @@ impl Test {
         self.class_name = test_template.class_name.to_owned();
         if let Some(params) = &test_template.parameters {
             for (name, param) in params {
-                let kind = match &param.kind {
-                    Some(k) => match ParamType::from_str(k) {
-                        Err(msg) => {
-                            bail!(
-                                "{} (for parameter '{}' in test template '{}')",
-                                msg,
-                                name,
-                                &self.name
-                            )
-                        }
-                        Ok(t) => t,
-                    },
-                    None => ParamType::String,
-                };
-                self.params.insert(name.to_owned(), kind.clone());
-                let clean_name = clean(name);
-                if &clean_name != name {
-                    self.aliases.insert(clean_name, name.to_owned());
-                }
-                if let Some(aliases) = &param.aliases {
-                    for alias in aliases {
-                        self.aliases.insert(clean(alias), name.to_owned());
-                    }
-                }
-                if let Some(value) = &param.value {
-                    let v = self.import_value(&kind, name, value)?;
-                    self.values.insert(name.to_owned(), v.clone());
-                    self.default_values.insert(name.to_owned(), v);
-                }
-                if let Some(accepted_values) = &param.accepted_values {
-                    let mut values: Vec<ParamValue> = vec![];
-                    for value in accepted_values {
-                        values.push(self.import_value(&kind, name, value)?);
-                    }
-                    self.constraints
-                        .insert(name.to_owned(), vec![Constraint::In(values)]);
-                }
+                import_template_parameter(
+                    name,
+                    param,
+                    &self.name,
+                    &mut self.params,
+                    &mut self.values,
+                    &mut self.default_values,
+                    &mut self.aliases,
+                    &mut self.constraints,
+                )?;
+            }
+        }
+        if let Some(collections) = &test_template.collections {
+            for (name, collection) in collections {
+                let mut c = TestCollection::new(name);
+                c.import_test_template(collection, &self.name)?;
+                self.collection_defs.insert(name.to_owned(), c);
             }
         }
         if let Some(params) = &test_template.parameter_list {
@@ -191,7 +373,7 @@ impl Test {
         if let Some(values) = &test_template.values {
             for (name, value) in values {
                 let param_name = { self.to_param_name(name)?.to_owned() };
-                let v = self.import_value(self.get_type(&param_name)?, name, value)?;
+                let v = import_value(self.get_type(&param_name)?, name, &self.name, value)?;
                 self.values.insert(param_name, v);
             }
         }
@@ -200,105 +382,18 @@ impl Test {
                 let param_name = { self.to_param_name(name)?.to_owned() };
                 let mut values: Vec<ParamValue> = vec![];
                 for value in accepted_values {
-                    values.push(self.import_value(self.get_type(&param_name)?, name, value)?);
+                    values.push(import_value(
+                        self.get_type(&param_name)?,
+                        name,
+                        &self.name,
+                        value,
+                    )?);
                 }
                 self.constraints
                     .insert(param_name, vec![Constraint::In(values)]);
             }
         }
         Ok(())
-    }
-
-    fn import_value(
-        &self,
-        kind: &ParamType,
-        name: &str,
-        value: &serde_json::Value,
-    ) -> Result<ParamValue> {
-        match kind {
-            &ParamType::String => match value.as_str() {
-                Some(x) => Ok(ParamValue::String(x.to_owned())),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a string: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Int => match value.as_i64() {
-                Some(x) => Ok(ParamValue::Int(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not an integer: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::UInt => match value.as_u64() {
-                Some(x) => Ok(ParamValue::UInt(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not an unsigned integer: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Float => match value.as_f64() {
-                Some(x) => Ok(ParamValue::Float(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a float: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Current => match value.as_f64() {
-                Some(x) => Ok(ParamValue::Current(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a number: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Voltage => match value.as_f64() {
-                Some(x) => Ok(ParamValue::Voltage(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a number: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Time => match value.as_f64() {
-                Some(x) => Ok(ParamValue::Time(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a number: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Frequency => match value.as_f64() {
-                Some(x) => Ok(ParamValue::Frequency(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a number: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Bool => match value.as_bool() {
-                Some(x) => Ok(ParamValue::Bool(x)),
-                None => bail!(
-                    "Value given for '{}' in test '{}' is not a boolean: '{:?}'",
-                    name,
-                    &self.name,
-                    value
-                ),
-            },
-            &ParamType::Any => Ok(ParamValue::Any(format!("{}", value))),
-        }
     }
 
     /// Set the value of the given parameter to the given value, returns an error if the
@@ -318,6 +413,7 @@ impl Test {
         let param_name = { self.to_param_name(param_name_or_alias)?.to_owned() };
         let kind = self.get_type(&param_name)?;
         if let Some(value) = value {
+            let value = coerce_param_value(kind, value)?;
             if value.is_type(kind) || kind == &ParamType::Any {
                 if let Some(constraints) = self.constraints.get(&param_name) {
                     for constraint in constraints {
@@ -459,6 +555,302 @@ impl Test {
     }
 }
 
+fn import_template_parameter(
+    name: &str,
+    param: &TestTemplateParameter,
+    owner_name: &str,
+    params: &mut IndexMap<String, ParamType>,
+    values: &mut IndexMap<String, ParamValue>,
+    default_values: &mut IndexMap<String, ParamValue>,
+    aliases: &mut IndexMap<String, String>,
+    constraints: &mut IndexMap<String, Vec<Constraint>>,
+) -> Result<()> {
+    let kind = match &param.kind {
+        Some(k) => match ParamType::from_str(k) {
+            Err(msg) => {
+                bail!(
+                    "{} (for parameter '{}' in test template '{}')",
+                    msg,
+                    name,
+                    owner_name
+                )
+            }
+            Ok(t) => t,
+        },
+        None => ParamType::String,
+    };
+    params.insert(name.to_owned(), kind.clone());
+    let clean_name = clean(name);
+    if &clean_name != name {
+        aliases.insert(clean_name, name.to_owned());
+    }
+    if let Some(param_aliases) = &param.aliases {
+        for alias in param_aliases {
+            aliases.insert(clean(alias), name.to_owned());
+        }
+    }
+    if let Some(value) = &param.value {
+        let v = import_value(&kind, name, owner_name, value)?;
+        values.insert(name.to_owned(), v.clone());
+        default_values.insert(name.to_owned(), v);
+    }
+    if let Some(accepted_values) = &param.accepted_values {
+        let mut accepted: Vec<ParamValue> = vec![];
+        for value in accepted_values {
+            accepted.push(import_value(&kind, name, owner_name, value)?);
+        }
+        constraints.insert(name.to_owned(), vec![Constraint::In(accepted)]);
+    }
+    Ok(())
+}
+
+fn coerce_param_value(kind: &ParamType, value: ParamValue) -> Result<ParamValue> {
+    Ok(match (kind, value) {
+        (ParamType::Any, value) => value,
+        (ParamType::Int, ParamValue::UInt(v)) => match i64::try_from(v) {
+            Ok(v) => ParamValue::Int(v),
+            Err(_) => ParamValue::UInt(v),
+        },
+        (ParamType::UInt, ParamValue::Int(v)) if v >= 0 => ParamValue::UInt(v as u64),
+        (_, value) => value,
+    })
+}
+
+fn import_value(
+    kind: &ParamType,
+    name: &str,
+    owner_name: &str,
+    value: &serde_json::Value,
+) -> Result<ParamValue> {
+    match kind {
+        ParamType::String => match value {
+            serde_json::Value::String(x) => Ok(ParamValue::String(x.to_owned())),
+            _ => bail!(
+                "Value given for '{}' in test '{}' is not a string: '{:?}'",
+                name,
+                owner_name,
+                value
+            ),
+        },
+        ParamType::Int => parse_i64(value).map(ParamValue::Int).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not an integer: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::UInt => parse_u64(value).map(ParamValue::UInt).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not an unsigned integer: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::Float => parse_f64(value).map(ParamValue::Float).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not a float: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::Current => parse_f64(value).map(ParamValue::Current).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not a number: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::Voltage => parse_f64(value).map(ParamValue::Voltage).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not a number: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::Time => parse_f64(value).map(ParamValue::Time).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not a number: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::Frequency => {
+            parse_f64(value).map(ParamValue::Frequency).ok_or_else(|| {
+                crate::Error::new(&format!(
+                    "Value given for '{}' in test '{}' is not a number: '{:?}'",
+                    name, owner_name, value
+                ))
+            })
+        }
+        ParamType::Bool => parse_bool(value).map(ParamValue::Bool).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not a boolean: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
+        ParamType::Any => Ok(ParamValue::Any(match value {
+            serde_json::Value::String(v) => v.clone(),
+            _ => value.to_string(),
+        })),
+    }
+}
+
+fn parse_i64(value: &serde_json::Value) -> Option<i64> {
+    if let Some(v) = value.as_i64() {
+        Some(v)
+    } else if let Some(v) = value.as_u64() {
+        i64::try_from(v).ok()
+    } else if let Some(v) = value.as_str() {
+        v.parse::<i64>().ok()
+    } else {
+        None
+    }
+}
+
+fn parse_u64(value: &serde_json::Value) -> Option<u64> {
+    if let Some(v) = value.as_u64() {
+        Some(v)
+    } else if let Some(v) = value.as_i64() {
+        u64::try_from(v).ok()
+    } else if let Some(v) = value.as_str() {
+        v.parse::<u64>().ok()
+    } else {
+        None
+    }
+}
+
+fn parse_f64(value: &serde_json::Value) -> Option<f64> {
+    if let Some(v) = value.as_f64() {
+        Some(v)
+    } else if let Some(v) = value.as_str() {
+        match v.trim() {
+            "Infinity" => Some(f64::INFINITY),
+            "-Infinity" => Some(f64::NEG_INFINITY),
+            other => other.parse::<f64>().ok(),
+        }
+    } else {
+        None
+    }
+}
+
+fn parse_bool(value: &serde_json::Value) -> Option<bool> {
+    if let Some(v) = value.as_bool() {
+        Some(v)
+    } else if let Some(v) = value.as_str() {
+        match v.trim().to_ascii_lowercase().as_str() {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
 fn clean(name: &str) -> String {
     name.to_lowercase().replace("_", "").replace(".", "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prog_gen::supported_testers::SupportedTester;
+
+    #[test]
+    fn imports_recursive_collection_defs_and_stringified_values() {
+        let template: TestTemplate = serde_json::from_str(
+            r#"{
+                "class_name": "com.example.Test",
+                "parameters": {
+                    "enableSoftset": {
+                        "kind": "boolean",
+                        "value": "true"
+                    }
+                },
+                "collections": {
+                    "tsen": {
+                        "parameters": {
+                            "zDataDeltaLimit": {
+                                "kind": "double",
+                                "value": "0.0"
+                            }
+                        },
+                        "collections": {
+                            "registers": {
+                                "parameters": {
+                                    "zLowLimit": {
+                                        "kind": "double",
+                                        "value": "-Infinity"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let mut test = Test::new("example", 1, SupportedTester::V93KSMT8);
+        test.import_test_template(&template).unwrap();
+
+        assert_eq!(
+            test.values.get("enableSoftset"),
+            Some(&ParamValue::Bool(true))
+        );
+        let tsen = test.collection_defs.get("tsen").unwrap();
+        assert_eq!(
+            tsen.default_values.get("zDataDeltaLimit"),
+            Some(&ParamValue::Float(0.0))
+        );
+        let registers = tsen.collections.get("registers").unwrap();
+        assert_eq!(
+            registers.default_values.get("zLowLimit"),
+            Some(&ParamValue::Float(f64::NEG_INFINITY))
+        );
+    }
+
+    #[test]
+    fn test_set_coerces_uint_to_int_for_flat_test_attrs() {
+        let mut test = Test::new("example", 1, SupportedTester::V93KSMT8);
+        test.add_param("width", ParamType::Int, None, None, None)
+            .unwrap();
+
+        test.set("width", Some(ParamValue::UInt(8)), false).unwrap();
+
+        assert_eq!(test.values.get("width"), Some(&ParamValue::Int(8)));
+    }
+
+    #[test]
+    fn test_set_coerces_uint_to_int_for_collection_item_attrs() {
+        let mut collection = TestCollection::new("softsetVariables");
+        collection
+            .params
+            .insert("width".to_string(), ParamType::Int);
+        let mut item = TestCollectionItem::from_collection(1, 0, "v3", &collection);
+
+        item.set("width", Some(ParamValue::UInt(8)), false).unwrap();
+
+        assert_eq!(item.values.get("width"), Some(&ParamValue::Int(8)));
+    }
+
+    #[test]
+    fn test_set_coerces_non_negative_int_to_uint() {
+        let mut test = Test::new("example", 1, SupportedTester::V93KSMT8);
+        test.add_param("count", ParamType::UInt, None, None, None)
+            .unwrap();
+
+        test.set("count", Some(ParamValue::Int(8)), false).unwrap();
+
+        assert_eq!(test.values.get("count"), Some(&ParamValue::UInt(8)));
+    }
+
+    #[test]
+    fn test_set_rejects_negative_int_for_uint() {
+        let mut test = Test::new("example", 1, SupportedTester::V93KSMT8);
+        test.add_param("count", ParamType::UInt, None, None, None)
+            .unwrap();
+
+        let err = test
+            .set("count", Some(ParamValue::Int(-1)), false)
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("does not match the required type"));
+    }
 }

--- a/rust/origen_metal/src/prog_gen/model/test.rs
+++ b/rust/origen_metal/src/prog_gen/model/test.rs
@@ -6,7 +6,14 @@ use crate::Result;
 use indexmap::IndexMap;
 use std::str::FromStr;
 
-pub const TEST_NUMBER_ALIASES: [&str; 6] = ["testnumber", "test_number", "number", "testnum", "test_num", "tnum"];
+pub const TEST_NUMBER_ALIASES: [&str; 6] = [
+    "testnumber",
+    "test_number",
+    "number",
+    "testnum",
+    "test_num",
+    "tnum",
+];
 
 #[derive(Debug, Clone, Serialize)]
 pub struct TestCollection {
@@ -176,7 +183,12 @@ impl TestCollectionItem {
         }
     }
 
-    pub fn unavailable(id: usize, parent_id: usize, collection_name: &str, instance_id: &str) -> Self {
+    pub fn unavailable(
+        id: usize,
+        parent_id: usize,
+        collection_name: &str,
+        instance_id: &str,
+    ) -> Self {
         Self {
             id,
             parent_id,
@@ -265,9 +277,7 @@ impl TestCollectionItem {
                 let available_attributes = self.params.keys().collect::<Vec<&String>>();
                 let mut msg = format!(
                     "Collection item '{}[{}]' does not have an attribute named '{}'",
-                    self.collection_name,
-                    self.instance_id,
-                    name
+                    self.collection_name, self.instance_id, name
                 );
                 msg += "\nThe available attributes are:";
                 for attr in available_attributes {
@@ -509,8 +519,7 @@ impl Test {
                 let available_attributes = self.params.keys().collect::<Vec<&String>>();
                 let mut msg = format!(
                     "Test '{}' does not have an attribute named '{}'",
-                    self.name,
-                    name
+                    self.name, name
                 );
                 msg += "\nThe available attributes are:";
                 for attr in available_attributes {
@@ -668,14 +677,12 @@ fn import_value(
                 name, owner_name, value
             ))
         }),
-        ParamType::Frequency => {
-            parse_f64(value).map(ParamValue::Frequency).ok_or_else(|| {
-                crate::Error::new(&format!(
-                    "Value given for '{}' in test '{}' is not a number: '{:?}'",
-                    name, owner_name, value
-                ))
-            })
-        }
+        ParamType::Frequency => parse_f64(value).map(ParamValue::Frequency).ok_or_else(|| {
+            crate::Error::new(&format!(
+                "Value given for '{}' in test '{}' is not a number: '{:?}'",
+                name, owner_name, value
+            ))
+        }),
         ParamType::Bool => parse_bool(value).map(ParamValue::Bool).ok_or_else(|| {
             crate::Error::new(&format!(
                 "Value given for '{}' in test '{}' is not a boolean: '{:?}'",
@@ -849,8 +856,72 @@ mod tests {
             .set("count", Some(ParamValue::Int(-1)), false)
             .unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("does not match the required type"));
+        assert!(err.to_string().contains("does not match the required type"));
+    }
+
+    #[test]
+    fn imports_v93k_param_kind_aliases() {
+        let template: TestTemplate = serde_json::from_str(
+            r#"{
+                "class_name": "com.example.Test",
+                "parameters": {
+                    "registerSetup.pinList": {
+                        "kind": "PinString",
+                        "value": "BP_BTDO"
+                    },
+                    "trigger.delay": {
+                        "kind": "SpecValue",
+                        "value": "0[ms]"
+                    },
+                    "search.specVar": {
+                        "kind": "SpecVariable",
+                        "value": "specs.Nominal"
+                    },
+                    "search.focusedPins": {
+                        "kind": "ContextPins",
+                        "value": "Tj_PWM"
+                    },
+                    "mode.select": {
+                        "kind": "OptionList",
+                        "value": "pass/fail"
+                    },
+                    "bitNumbers": {
+                        "kind": "long",
+                        "value": "0"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let mut test = Test::new("example", 1, SupportedTester::V93KSMT8);
+        test.import_test_template(&template).unwrap();
+
+        assert_eq!(
+            test.params.get("registerSetup.pinList"),
+            Some(&ParamType::String)
+        );
+        assert_eq!(test.params.get("trigger.delay"), Some(&ParamType::String));
+        assert_eq!(test.params.get("search.specVar"), Some(&ParamType::String));
+        assert_eq!(
+            test.params.get("search.focusedPins"),
+            Some(&ParamType::String)
+        );
+        assert_eq!(test.params.get("mode.select"), Some(&ParamType::String));
+        assert_eq!(test.params.get("bitNumbers"), Some(&ParamType::Int));
+
+        assert_eq!(
+            test.values.get("registerSetup.pinList"),
+            Some(&ParamValue::String("BP_BTDO".to_string()))
+        );
+        assert_eq!(
+            test.values.get("trigger.delay"),
+            Some(&ParamValue::String("0[ms]".to_string()))
+        );
+        assert_eq!(
+            test.values.get("mode.select"),
+            Some(&ParamValue::String("pass/fail".to_string()))
+        );
+        assert_eq!(test.values.get("bitNumbers"), Some(&ParamValue::Int(0)));
     }
 }

--- a/rust/origen_metal/src/prog_gen/nodes.rs
+++ b/rust/origen_metal/src/prog_gen/nodes.rs
@@ -34,6 +34,9 @@ pub enum PGM {
     /// Assign an existing test to an existing invocation
     ///                 InvID  TestID
     AssignTestToInv(usize, usize),
+    /// Define a collection item underneath a test or another collection item
+    ///                       ItemID ParentID CollectionName InstanceID AllowMissing
+    DefTestCollectionItem(usize, usize, String, String, bool),
     /// Set the attribute with the given name within the given test (ID), to the given value
     SetAttr(usize, String, Option<ParamValue>, bool),
     /// Set the limit of the given test or invocation, (test_id, inv_id, hi/lo, value). Note that either test_id

--- a/rust/origen_metal/src/prog_gen/processors/initial_model_extract.rs
+++ b/rust/origen_metal/src/prog_gen/processors/initial_model_extract.rs
@@ -66,6 +66,19 @@ impl Processor<PGM> for ExtractToModel {
                     trace!(self.model.assign_test_to_inv(*inv_id, *test_id), node);
                     Return::None
                 }
+                PGM::DefTestCollectionItem(id, parent_id, collection_name, instance_id, allow_missing) => {
+                    trace!(
+                        self.model.add_test_collection_item(
+                            *parent_id,
+                            *id,
+                            collection_name,
+                            instance_id,
+                            *allow_missing,
+                        ),
+                        node
+                    );
+                    Return::None
+                }
                 _ => Return::ProcessChildren,
             })
         } else {

--- a/rust/pyapi_metal/src/prog_gen/mod.rs
+++ b/rust/pyapi_metal/src/prog_gen/mod.rs
@@ -2,6 +2,7 @@ pub mod tester_apis;
 mod test_invocation;
 mod flow_options;
 mod test;
+mod test_collection_item;
 mod group;
 mod pattern_group;
 mod condition;
@@ -13,6 +14,7 @@ use std::str::FromStr;
 
 use test_invocation::TestInvocation;
 use test::Test;
+use test_collection_item::TestCollectionItem;
 use group::Group;
 use pattern_group::PatternGroup;
 use condition::Condition;

--- a/rust/pyapi_metal/src/prog_gen/test.rs
+++ b/rust/pyapi_metal/src/prog_gen/test.rs
@@ -1,4 +1,5 @@
 use super::to_param_value;
+use super::TestCollectionItem;
 use crate::prog_gen::flow_options;
 use super::src_caller_meta;
 use origen_metal::prog_gen::{flow_api, Limit, LimitSelector, ParamValue, SupportedTester};
@@ -114,6 +115,23 @@ impl Test {
         };
         flow_api::set_test_attr(self.id, name, value, allow_missing, src_caller_meta())?;
         Ok(())
+    }
+
+    #[pyo3(signature=(collection_name, instance_id, allow_missing=false))]
+    pub fn add_collection_item(
+        &self,
+        collection_name: &str,
+        instance_id: &str,
+        allow_missing: bool,
+    ) -> Result<TestCollectionItem> {
+        let id = flow_api::define_test_collection_item(
+            self.id,
+            collection_name,
+            instance_id,
+            allow_missing,
+            src_caller_meta(),
+        )?;
+        Ok(TestCollectionItem::new(id))
     }
 
     fn __setattr__(&mut self, name: &str, value: &PyAny) -> PyResult<()> {

--- a/rust/pyapi_metal/src/prog_gen/test_collection_item.rs
+++ b/rust/pyapi_metal/src/prog_gen/test_collection_item.rs
@@ -1,0 +1,62 @@
+use super::src_caller_meta;
+use super::to_param_value;
+use origen_metal::prog_gen::{flow_api, ParamValue};
+use origen_metal::Result;
+use pyo3::prelude::*;
+
+#[pyclass]
+#[derive(Debug, Clone)]
+pub struct TestCollectionItem {
+    pub id: usize,
+}
+
+impl TestCollectionItem {
+    pub fn new(id: usize) -> Self {
+        Self { id }
+    }
+
+    pub fn set_attr_value(
+        &self,
+        name: &str,
+        value: Option<ParamValue>,
+        allow_missing: bool,
+    ) -> Result<()> {
+        flow_api::set_test_attr(self.id, name, value, allow_missing, src_caller_meta())?;
+        Ok(())
+    }
+}
+
+#[pymethods]
+impl TestCollectionItem {
+    #[pyo3(signature=(name, value=None, allow_missing=false))]
+    pub fn set_attr(&self, name: &str, value: Option<&PyAny>, allow_missing: bool) -> Result<()> {
+        let value = match value {
+            Some(v) => to_param_value(v)?,
+            None => None,
+        };
+        self.set_attr_value(name, value, allow_missing)?;
+        Ok(())
+    }
+
+    #[pyo3(signature=(collection_name, instance_id, allow_missing=false))]
+    pub fn add_collection_item(
+        &self,
+        collection_name: &str,
+        instance_id: &str,
+        allow_missing: bool,
+    ) -> Result<TestCollectionItem> {
+        let id = flow_api::define_test_collection_item(
+            self.id,
+            collection_name,
+            instance_id,
+            allow_missing,
+            src_caller_meta(),
+        )?;
+        Ok(TestCollectionItem::new(id))
+    }
+
+    fn __setattr__(&mut self, name: &str, value: &PyAny) -> PyResult<()> {
+        self.set_attr_value(name, to_param_value(value)?, false)?;
+        Ok(())
+    }
+}

--- a/test_apps/python_app/approved/v93ksmt8/test_program/flows/prb1/TEST.flow
+++ b/test_apps/python_app/approved/v93ksmt8/test_program/flows/prb1/TEST.flow
@@ -1,6 +1,4 @@
 flow TEST {
-
-
     setup {
         suite meas_read_pump calls dc_tml.DcTest.GeneralPMU {
             measurement.pattern = setupRef(OrigenTesters.patterns.meas_read_pump);
@@ -18,8 +16,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite meas_read_pump_1 calls dc_tml.DcTest.GeneralPMU {
@@ -38,8 +36,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite meas_read_pump_2 calls dc_tml.DcTest.GeneralPMU {
@@ -58,8 +56,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite meas_read_pump_3 calls dc_tml.DcTest.GeneralPMU {
@@ -78,8 +76,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite meas_read_pump_4 calls dc_tml.DcTest.GeneralPMU {
@@ -98,8 +96,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite meas_read_pump_5 calls dc_tml.DcTest.GeneralPMU {
@@ -118,8 +116,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite meas_read_pump_6 calls dc_tml.DcTest.GeneralPMU {
@@ -138,8 +136,8 @@ flow TEST {
             settlingTime = "0[s]";
             spmuClamp = "0[A]";
             termination = "OFF";
-            testName = "passLimit_uA_mV";
             testerState = "CONNECTED";
+            testName = "passLimit_uA_mV";
         }
 
         suite program_ckbd calls ac_tml.AcTest.FunctionalTest {
@@ -149,10 +147,76 @@ flow TEST {
             testName = "Functional";
         }
 
+        suite thermal_tsen_sensor_read_calibration calls com.amd.testmethod.ate.TsenSensorRead {
+            measurement.pattern = setupRef(OrigenTesters.patterns.program_ckbd);
+            measurement.specification = setupRef(OrigenTesters.specs.specs.Nominal);
+            activateSpec.afterRunActivateSpec = "specs.Nominal";
+            binning.binnable = false;
+            enableSoftset = true;
+            registerSetupPinList = "BP_BTDO";
+            softsetPatternInfo[param1] = {
+                patternName = "pats.shell.pat.common.PHC_CCD_RESET_Unified_Reset_Sequence_Fuse_Override_pJtag";
+                pinNames = "BP_BTDI";
+                profileName = "SoftsetProfile_shell";
+            };
+            softsetPatternInfo[param2] = {
+                patternName = "pats.shell.pat.common.PHC_CCD_RESET_Unified_Reset_Sequence_Fuse_Override_pJtag";
+                pinNames = "BP_BTDI";
+                profileName = "SoftsetProfile_shell";
+            };
+            softsetPatternInfo[param10] = {
+                patternName = "pats.shell.pat.common.PHC_CCD_RESET_Unified_Reset_Sequence_Fuse_Override_pJtag";
+                pinNames = "BP_BTDI";
+                profileName = "SoftsetProfile_shell";
+            };
+            testDescription.baseClass = "TCC";
+            testDescription.componentHash = "PHCX3D.0";
+            testDescription.paramRefGroup = "thermal_tsen_sensor_read_calibration";
+            testDescription.subClass = "CAL";
+            tsen[ctsen2] = {
+                registers[rtsen3] = {
+                    name = "WS1_CTSEN2_RTSEN3";
+                    zHighLimit = 2000.0;
+                    zLowLimit = 0.0;
+                };
+                registers[rtsen11] = {
+                    name = "WS1_CTSEN2_RTSEN11";
+                    zHighLimit = 2000.0;
+                    zLowLimit = 0.0;
+                };
+                sensorAverageVariable = "ctsen2_avg";
+                tdiodeTemperatureVariable = "ctsen2_tdiode";
+                Y1Variable = "ctsen2_y1";
+                zDataDeltaLimit = 0.0;
+            };
+            tsen[ctsen10] = {
+                registers[rtsen1] = {
+                    name = "WS1_CTSEN10_RTSEN1";
+                    zHighLimit = 2000.0;
+                    zLowLimit = 0.0;
+                };
+                registers[rtsen2] = {
+                    name = "WS1_CTSEN10_RTSEN2";
+                    zHighLimit = 2000.0;
+                    zLowLimit = 0.0;
+                };
+                registers[rtsen10] = {
+                    name = "WS1_CTSEN10_RTSEN10";
+                    zHighLimit = 2000.0;
+                    zLowLimit = 0.0;
+                };
+                sensorAverageVariable = "ctsen10_avg";
+                tdiodeTemperatureVariable = "ctsen10_tdiode";
+                Y1Variable = "ctsen10_y1";
+                zDataDeltaLimit = 0.0;
+            };
+        }
+
     }
 
     execute {
         program_ckbd.execute();
+        thermal_tsen_sensor_read_calibration.execute();
         meas_read_pump.execute();
         meas_read_pump_1.execute();
         meas_read_pump_2.execute();

--- a/test_apps/python_app/approved/v93ksmt8/test_program/limits/Main.PRB1_Tests.csv
+++ b/test_apps/python_app/approved/v93ksmt8/test_program/limits/Main.PRB1_Tests.csv
@@ -103,6 +103,7 @@ PRB1_MAIN.cc_test_1,cc_test_1,7001,cc_test_1,0,0,,
 PRB1_MAIN.cc_test_2,cc_test_2,7002,cc_test_2,0,0,,
 PRB1_MAIN.DEEP_NESTED.deep_test,deep_test,,deep_test,0,0,,
 TEST.program_ckbd,program_ckbd,40000,program_ckbd,0,0,,1100
+TEST.thermal_tsen_sensor_read_calibration,thermal_tsen_sensor_read_calibration,40002,thermal_tsen_sensor_read_calibration,,,,
 TEST.meas_read_pump,meas_read_pump,40005,meas_read_pump,35,,,2
 TEST.meas_read_pump_1,meas_read_pump_1,40010,meas_read_pump_1,,45,,2
 TEST.meas_read_pump_2,meas_read_pump_2,40020,meas_read_pump_2,35,45,,2

--- a/test_apps/python_app/example/flows/o1_testcases/test.py
+++ b/test_apps/python_app/example/flows/o1_testcases/test.py
@@ -10,6 +10,7 @@ with Flow() as flow:
     #if tester.v93k? && tester.create_limits_file
     with tester().eq("v93ksmt8"):
         flow.func("program_ckbd", bin=100, soft_bin=1100, number=40000)
+        flow.collection_test("thermal_tsen_sensor_read_calibration", number=40002)
 
     flow.meas("read_pump",
               bin=119,

--- a/test_apps/python_app/example/interface/interface.py
+++ b/test_apps/python_app/example/interface/interface.py
@@ -135,6 +135,52 @@ class Interface(BaseInterface):
         with tester().neq("igxl"):
             self.func('por_ins', **options)
 
+    def collection_test(self, name, number=None, **kwargs):
+        options = {}
+        options.update(kwargs)
+
+        with tester().eq("v93k") as v93k:
+            tm = v93k.new_test_method("tsen_sensor_read",
+                                      library="com_amd_testmethod_ate",
+                                      allow_missing=True)
+            tm.set_attr("activateSpec.afterRunActivateSpec", "specs.Nominal")
+            tm.set_attr("binning.binnable", False)
+            tm.set_attr("enableSoftset", True)
+            tm.set_attr("registerSetupPinList", "BP_BTDO")
+            tm.set_attr("testDescription.baseClass", "TCC")
+            tm.set_attr("testDescription.componentHash", "PHCX3D.0")
+            tm.set_attr("testDescription.paramRefGroup", name)
+            tm.set_attr("testDescription.subClass", "CAL")
+
+            for instance_id in ["param10", "param2", "param1"]:
+                item = tm.add_collection_item("softsetPatternInfo", instance_id)
+                item.set_attr("profileName", "SoftsetProfile_shell")
+                item.set_attr("patternName",
+                              "pats.shell.pat.common.PHC_CCD_RESET_Unified_Reset_Sequence_Fuse_Override_pJtag")
+                item.set_attr("pinNames", "BP_BTDI")
+
+            for tsen_name, register_names in {
+                "ctsen10": ["rtsen10", "rtsen2", "rtsen1"],
+                "ctsen2": ["rtsen11", "rtsen3"],
+            }.items():
+                tsen = tm.add_collection_item("tsen", tsen_name)
+                tsen.set_attr("sensorAverageVariable", f"{tsen_name}_avg")
+                tsen.set_attr("Y1Variable", f"{tsen_name}_y1")
+                tsen.set_attr("tdiodeTemperatureVariable", f"{tsen_name}_tdiode")
+                tsen.set_attr("zDataDeltaLimit", 0.0)
+                for register_name in register_names:
+                    register = tsen.add_collection_item("registers", register_name)
+                    register.set_attr("name", f"WS1_{tsen_name.upper()}_{register_name.upper()}")
+                    register.set_attr("zHighLimit", 2000.0)
+                    register.set_attr("zLowLimit", 0.0)
+
+            ts = v93k.new_test_suite(name, **options)
+            ts.test_method = tm
+            ts.pattern = "program_ckbd"
+            ts.spec = "specs.Nominal"
+            ts.number = number
+            self.add_test(ts, **options)
+
     def mto_memory(self, name, **kwargs):
         options = {"duration": "static"}
         options.update(kwargs)

--- a/test_apps/python_app/example/interface/test_templates/v93ksmt8/com_amd_testmethod_ate/tsen_sensor_read.json
+++ b/test_apps/python_app/example/interface/test_templates/v93ksmt8/com_amd_testmethod_ate/tsen_sensor_read.json
@@ -1,0 +1,93 @@
+{
+    "class_name": "com.amd.testmethod.ate.TsenSensorRead",
+    "parameters": {
+        "activateSpec.afterRunActivateSpec": {
+            "kind": "class",
+            "value": null
+        },
+        "binning.binnable": {
+            "kind": "boolean",
+            "value": "false"
+        },
+        "enableSoftset": {
+            "kind": "boolean",
+            "value": "false"
+        },
+        "registerSetupPinList": {
+            "kind": "class",
+            "value": null
+        },
+        "testDescription.baseClass": {
+            "kind": "class",
+            "value": null
+        },
+        "testDescription.componentHash": {
+            "kind": "class",
+            "value": null
+        },
+        "testDescription.paramRefGroup": {
+            "kind": "class",
+            "value": null
+        },
+        "testDescription.subClass": {
+            "kind": "class",
+            "value": null
+        }
+    },
+    "collections": {
+        "softsetPatternInfo": {
+            "parameters": {
+                "patternName": {
+                    "kind": "class",
+                    "value": null
+                },
+                "pinNames": {
+                    "kind": "class",
+                    "value": null
+                },
+                "profileName": {
+                    "kind": "class",
+                    "value": null
+                }
+            }
+        },
+        "tsen": {
+            "parameters": {
+                "sensorAverageVariable": {
+                    "kind": "class",
+                    "value": null
+                },
+                "Y1Variable": {
+                    "kind": "class",
+                    "value": null
+                },
+                "tdiodeTemperatureVariable": {
+                    "kind": "class",
+                    "value": null
+                },
+                "zDataDeltaLimit": {
+                    "kind": "double",
+                    "value": "0.0"
+                }
+            },
+            "collections": {
+                "registers": {
+                    "parameters": {
+                        "name": {
+                            "kind": "class",
+                            "value": null
+                        },
+                        "zHighLimit": {
+                            "kind": "double",
+                            "value": "0.0"
+                        },
+                        "zLowLimit": {
+                            "kind": "double",
+                            "value": "-Infinity"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds SMT8 test parameter collection support to Origen Metal and the metal Python bindings.

It enables test methods to define top-level and nested collection items, imports recursive collection schemas from SMT8 templates, renders collection content into SMT8 suite output, and adds acceptance coverage in the Python test app.

It also includes a follow-up type-coercion fix so schema-defined `Int` collection fields accept normal positive Python integers from the application even when they initially arrive as unsigned values on the Rust side.

## Key Changes

### Program generation model

- Added recursive collection schema support to SMT8 test templates.
- Added runtime model support for collection definitions and instantiated collection items.
- Added prog-gen AST nodes and extraction flow to define collection items before applying attrs.
- Reused existing `SetAttr` handling so collection-item attributes follow the same validation path
  as flat test attributes.

### Python API

- Added `Test.add_collection_item(...)`.
- Added a new `TestCollectionItem` object with:
  - `set_attr(...)`
  - `add_collection_item(...)`
  - `__setattr__`

This allows the application to build nested collection structures directly from the Python tester API.

### SMT8 rendering

- Added SMT8 rendering for collection items inside suite setup blocks.
- Rendered parameters and collection names as a single alphabetically sorted group at each level.
- Rendered collection instance IDs using natural sort so names like `param1`, `param2`, `param10`
  appear in the expected order.
- Preserved original parameter and collection names from the template JSON in the emitted SMT8 output.

### Type handling

- Added schema-aware numeric coercion in the prog-gen model setters.
- When a field expects `Int`, `UInt` values are normalized to `Int` when they fit.
- When a field expects `UInt`, non-negative `Int` values are normalized to `UInt`.
- This fixes collection-item assignment failures caused by normal Python integers being treated as
  unsigned values before validation.

### Acceptance coverage

- Added an SMT8-only example test method template with both top-level and nested collections.
- Added an SMT8 example flow/interface path that exercises:
  - top-level collections
  - nested collections
  - collection ordering
  - natural sorting of instance IDs
- Updated the approved SMT8 outputs for the Python acceptance app.

## Example

### Template JSON

Collection schemas are defined under `collections`, and each collection node can contain its own `parameters` and child `collections`:

```json
{
  "class_name": "com.amd.testmethod.ate.TsenSensorRead",
  "parameters": {
    "enableSoftset": {
      "kind": "boolean",
      "value": "false"
    }
  },
  "collections": {
    "softsetPatternInfo": {
      "parameters": {
        "patternName": { "kind": "class", "value": null },
        "pinNames": { "kind": "class", "value": null },
        "profileName": { "kind": "class", "value": null }
      }
    },
    "tsen": {
      "parameters": {
        "sensorAverageVariable": { "kind": "class", "value": null },
        "zDataDeltaLimit": { "kind": "double", "value": "0.0" }
      },
      "collections": {
        "registers": {
          "parameters": {
            "name": { "kind": "class", "value": null },
            "zHighLimit": { "kind": "double", "value": "0.0" },
            "zLowLimit": { "kind": "double", "value": "-Infinity" }
          }
        }
      }
    }
  }
}
```

### Python usage

The application can build collection items directly from the test method object, including nested collections:

```python
tm = v93k.new_test_method(
    "tsen_sensor_read",
    library="com_amd_testmethod_ate",
    allow_missing=True,
)
tm.set_attr("enableSoftset", True)

item = tm.add_collection_item("softsetPatternInfo", "param1")
item.set_attr("profileName", "SoftsetProfile_shell")
item.set_attr("patternName", "pats.shell.pat.common.reset_sequence")
item.set_attr("pinNames", "BP_BTDI")

tsen = tm.add_collection_item("tsen", "ctsen10")
tsen.set_attr("sensorAverageVariable", "ctsen10_avg")
tsen.set_attr("zDataDeltaLimit", 0.0)

register = tsen.add_collection_item("registers", "rtsen1")
register.set_attr("name", "WS1_CTSEN10_RTSEN1")
register.set_attr("zHighLimit", 2000.0)
register.set_attr("zLowLimit", 0.0)
```

### Rendered SMT8 flow output

The generated SMT8 suite renders flat parameters and collection names together in sorted order, and renders collection instance IDs using natural sort:

```text
setup {
    suite thermal_tsen_sensor_read_calibration calls com.amd.testmethod.ate.TsenSensorRead {
        enableSoftset = true;
        softsetPatternInfo[param1] = {
            patternName = "pats.shell.pat.common.reset_sequence";
            pinNames = "BP_BTDI";
            profileName = "SoftsetProfile_shell";
        };
        tsen[ctsen10] = {
            registers[rtsen1] = {
                name = "WS1_CTSEN10_RTSEN1";
                zHighLimit = 2000.0;
                zLowLimit = 0.0;
            };
            sensorAverageVariable = "ctsen10_avg";
            zDataDeltaLimit = 0.0;
        };
    }
}
```

## Validation

Validated with:

- `cargo test -p origen_metal`
- `origen origen build`
- `cd test_apps/python_app && origen examples`
