### PR TITLE
STIL Parser Bug Fixes and Vector Comment Regression Fix

### DIFF
--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -1008,7 +1008,7 @@ pub fn to_ast(mut pair: Pair<Rule>, source_file: Option<&str>) -> Result<AST<STI
             Rule::call => {
                 let mut p = pair.into_inner();
                 ids.push(
-                    ast.push_and_open(node!(STIL::Call, p.next().unwrap().as_str().to_string())),
+                    ast.push_and_open(node!(STIL::Call, unquote(p.next().unwrap().as_str()))),
                 );
                 pairs.push(p);
             }

--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -1344,4 +1344,65 @@ mod tests {
             Err(e) => { println!("{}", e); assert_eq!(1, 0); }
         }
     }
+
+    #[test]
+    fn test_example17_can_parse() {
+        let txt = read("example17");
+        match STILParser::parse(Rule::stil_source, &txt) {
+            Ok(_) => {}
+            Err(e) => { println!("{}", e); assert_eq!(1, 0); }
+        }
+    }
+
+    /// Verifies that a trailing same-line `// comment` after a Vector block's closing `}`
+    /// is captured as a direct child Comment node of the Vector AST node, not as a sibling.
+    #[test]
+    fn test_vector_inline_comment_is_child_of_vector() {
+        let stil = "STIL 1.0;\nPattern p1 {\n    V { sig1 = 0; } // inline vector comment\n}\n";
+        let root = parse_str(stil, None).expect("Should parse STIL with trailing vector comment");
+
+        fn find_vector_with_comment_child(node: &Node<STIL>) -> bool {
+            if matches!(node.attrs, STIL::Vector) {
+                return node.children.iter().any(|c| matches!(c.attrs, STIL::Comment(_)));
+            }
+            node.children.iter().any(|c| find_vector_with_comment_child(c))
+        }
+
+        assert!(
+            find_vector_with_comment_child(&root),
+            "Trailing inline comment should be a direct child of the Vector AST node"
+        );
+    }
+
+    /// Verifies that a Vector block containing internal `//` and `/* */` comments
+    /// between cyclized_data entries parses correctly, and that a trailing comment
+    /// is still captured as a child of the Vector node.
+    #[test]
+    fn test_vector_with_internal_comments_parses() {
+        let stil = concat!(
+            "STIL 1.0;\n",
+            "Pattern p1 {\n",
+            "    V {\n",
+            "        // internal line comment\n",
+            "        sig1 = 0;\n",
+            "        /* block comment */\n",
+            "        sig2 = 1;\n",
+            "    } // trailing comment\n",
+            "}\n"
+        );
+        let root = parse_str(stil, None)
+            .expect("Should parse vector with internal line and block comments");
+
+        fn find_vector_with_comment_child(node: &Node<STIL>) -> bool {
+            if matches!(node.attrs, STIL::Vector) {
+                return node.children.iter().any(|c| matches!(c.attrs, STIL::Comment(_)));
+            }
+            node.children.iter().any(|c| find_vector_with_comment_child(c))
+        }
+
+        assert!(
+            find_vector_with_comment_child(&root),
+            "Trailing comment should be a Vector child even when internal comments are present"
+        );
+    }
 }

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -288,7 +288,7 @@ time_unit = { "TimeUnit" ~ time_expr ~ EOS }
 pattern_statement = !{ label | vector | waveform_statement | condition | fixed_statement | call | macro_statement |
                       loop_statement | match_loop | goto | breakpoint | iddq | stop_statement | scan_chain_statement | annotation | udb_stmt }
 
-vector = ${ "V" ~ "ector"? ~ (space | N)* ~ "{" ~ ((space | N)* ~ (cyclized_data | non_cyclized_data))* ~ (space | N)* ~ "}" ~ vector_comment? }
+vector = { "V" ~ "ector"? ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}" }
 vector_comment = @{ space* ~ "//" ~ (!N ~ ANY)* ~ N }
 cyclized_data = { (sigref_expr ~ "=" ~ vec_data+ ~ EOS) | (sigref_expr ~ "{" ~ (vec_data ~ EOS)+ ~ "}") }
 vec_data = { repeat | capture | noop | waveform_format | hex_format | dec_format | data_string | wfc_data_string }

--- a/rust/origen_metal/src/stil/stil.pest
+++ b/rust/origen_metal/src/stil/stil.pest
@@ -288,9 +288,9 @@ time_unit = { "TimeUnit" ~ time_expr ~ EOS }
 pattern_statement = !{ label | vector | waveform_statement | condition | fixed_statement | call | macro_statement |
                       loop_statement | match_loop | goto | breakpoint | iddq | stop_statement | scan_chain_statement | annotation | udb_stmt }
 
-vector = { "V" ~ "ector"? ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}" }
+vector = ${ "V" ~ "ector"? ~ s ~ "{" ~ (s ~ (cyclized_data | non_cyclized_data))* ~ s ~ "}" ~ vector_comment? }
 vector_comment = @{ space* ~ "//" ~ (!N ~ ANY)* ~ N }
-cyclized_data = { (sigref_expr ~ "=" ~ vec_data+ ~ EOS) | (sigref_expr ~ "{" ~ (vec_data ~ EOS)+ ~ "}") }
+cyclized_data = !{ (sigref_expr ~ "=" ~ vec_data+ ~ EOS) | (sigref_expr ~ "{" ~ (vec_data ~ EOS)+ ~ "}") }
 vec_data = { repeat | capture | noop | waveform_format | hex_format | dec_format | data_string | wfc_data_string }
 repeat  = @{ "\\r" ~ integer }
 capture = @{ "\\c" ~ integer }
@@ -300,8 +300,8 @@ hex_format = @{ "\\h " | ("\\h" ~ data_string) }
 dec_format = @{ "\\d " | ("\\d" ~ data_string) }
 data_string = { ASCII_ALPHANUMERIC+ }
 wfc_data_string = { wfc_char+ }
-non_cyclized_data = { (time_value ~ sigref_expr ~ "=" ~ event_list ~ EOS) |
-                      (time_value ~ "{" ~ (sigref_expr ~ "=" ~ event_list ~ EOS)+ ~ "}") }
+non_cyclized_data = !{ (time_value ~ sigref_expr ~ "=" ~ event_list ~ EOS) |
+                       (time_value ~ "{" ~ (sigref_expr ~ "=" ~ event_list ~ EOS)+ ~ "}") }
 time_value = @{ "@" ~ integer }
 
 waveform_statement = { "W" ~ "aveformTable"? ~ name ~ EOS }

--- a/test_apps/python_app/vendor/stil/example17.stil
+++ b/test_apps/python_app/vendor/stil/example17.stil
@@ -1,0 +1,34 @@
+// example17.stil
+// Tests for vector inline (trailing) comments and internal comments inside vector blocks
+
+STIL 1.0;
+
+Signals {
+    clk In;
+    data In;
+    out Out;
+}
+
+Pattern p1 {
+    // Vector with a trailing same-line comment — comment must be a child of the Vector node
+    V { clk = 0; data = 1; out = X; } // trailing inline comment
+
+    // Vector with internal line comments between cyclized_data entries
+    V {
+        // internal line comment before first entry
+        clk = 1;
+        // internal line comment between entries
+        data = 0;
+        out = 1;
+    } // trailing comment after vector with internal comments
+
+    // Vector with an internal block comment
+    V {
+        clk = 0; /* block comment between signals */
+        data = 1;
+        out = 0;
+    }
+
+    // Plain vector with no trailing comment — baseline, must still parse correctly
+    V { clk = 1; data = 1; out = X; }
+}


### PR DESCRIPTION
### Background

A prior optimization commit merged the separate `vector_with_comment` variant into a single `vector = ${ ... ~ vector_comment? }` rule. The subsequent "quick patch" reverted `vector` back to a plain `{ }` rule to fix a regression where internal `//` and `/* */` comments inside Vector blocks caused parse failures (because the `$` modifier suppresses implicit COMMENT handling). That revert was correct to fix the internal-comment bug, but it introduced a new regression: trailing same-line comments (`} // comment`) were no longer captured as **children** of the Vector AST node — they fell through to the outer implicit COMMENT rule and became siblings instead.

---

### Changes

**`stil.pest`**

Restored `vector_comment?` capture with a properly structured compound-atomic rule that avoids both failure modes:

```pest
// Before (quick patch — lost vector_comment as AST child):
vector = { "V" ~ "ector"? ~ "{" ~ (cyclized_data | non_cyclized_data)* ~ "}" }

// After:
vector = ${ "V" ~ "ector"? ~ s ~ "{" ~ (s ~ (cyclized_data | non_cyclized_data))* ~ s ~ "}" ~ vector_comment? }
cyclized_data    = !{ (sigref_expr ~ "=" ~ vec_data+ ~ EOS) | ... }
non_cyclized_data = !{ (time_value ~ sigref_expr ~ "=" ~ event_list ~ EOS) | ... }
```

Key mechanics:
- `$` (compound-atomic) prevents implicit WHITESPACE between `}` and `vector_comment?`, ensuring only a same-line trailing comment is captured as a vector child — a comment on a subsequent line is correctly left for the outer context.
- The existing silent `s = _{ (space | N | one_line_comment | block_comment)* }` rule is used in whitespace positions inside `$`, correctly handling both newlines and comments (line and block) between `cyclized_data` entries.
- `cyclized_data` and `non_cyclized_data` are marked `!` (non-atomic) to re-enable implicit WHITESPACE for their own `~` sequences when called from the `$` vector context. Without this, pest's atomicity propagation from `$` to sub-rules suppresses the implicit WHITESPACE needed to match `sigref_expr = vec_data;` patterns with spaces.

**`parser.rs`**

- Fixed `Rule::call` to apply `unquote()` to the procedure name, matching the handling of `macro_statement`, `procedures_def`, and `macro_def`. Previously, a `Call "quoted_name" { ... }` would produce an AST node with the literal quoted string including surrounding `"` characters.

**`test_apps/python_app/vendor/stil/example17.stil`** (new)

New test fixture exercising:
- Vectors with a trailing same-line `// comment`
- Vectors with internal `//` line comments and `/* */` block comments between data entries
- Plain vectors without any trailing comment (baseline)

**`parser.rs` — new tests**

- `test_example17_can_parse` — parse coverage for the new fixture
- `test_vector_inline_comment_is_child_of_vector` — walks the AST and asserts that a trailing `// comment` on the same line as `}` is stored as a direct `STIL::Comment` child of the `STIL::Vector` node
- `test_vector_with_internal_comments_parses` — asserts that internal `//` and `/* */` comments between `cyclized_data` entries parse correctly AND the trailing comment is still a Vector child

All 27 STIL parser tests pass.