### PR TITLE
Fix 14 `mismatched_lifetime_syntaxes` compiler warnings

### DIFF
--- a/rust/origen_metal/src/framework/logger.rs
+++ b/rust/origen_metal/src/framework/logger.rs
@@ -103,7 +103,7 @@ pub struct Inner {
 }
 
 impl Logger {
-    pub fn data(&self) -> RwLockReadGuard<Inner> {
+    pub fn data(&self) -> RwLockReadGuard<'_, Inner> {
         self.inner.read().unwrap()
     }
 

--- a/rust/origen_metal/src/framework/typed_value.rs
+++ b/rust/origen_metal/src/framework/typed_value.rs
@@ -570,7 +570,7 @@ impl Map {
         self.typed_values.get(key)
     }
 
-    pub fn keys(&self) -> indexmap::map::Keys<String, TypedValue> {
+    pub fn keys(&self) -> indexmap::map::Keys<'_, String, TypedValue> {
         self.typed_values.keys()
     }
 
@@ -578,7 +578,7 @@ impl Map {
         self.typed_values.len()
     }
 
-    pub fn iter(&self) -> indexmap::map::Iter<String, TypedValue> {
+    pub fn iter(&self) -> indexmap::map::Iter<'_, String, TypedValue> {
         self.typed_values.iter()
     }
 }

--- a/rust/origen_metal/src/framework/users/user.rs
+++ b/rust/origen_metal/src/framework/users/user.rs
@@ -497,7 +497,7 @@ impl User {
         Ok(())
     }
 
-    pub fn write_data(&self, key: Option<&str>) -> Result<RwLockWriteGuard<Data>> {
+    pub fn write_data(&self, key: Option<&str>) -> Result<RwLockWriteGuard<'_, Data>> {
         let k;
         if let Some(tmp) = key {
             k = tmp;
@@ -511,7 +511,7 @@ impl User {
         }
     }
 
-    fn read_data(&self, key: Option<&str>) -> Result<RwLockReadGuard<Data>> {
+    fn read_data(&self, key: Option<&str>) -> Result<RwLockReadGuard<'_, Data>> {
         let k;
         if let Some(tmp) = key {
             k = tmp;
@@ -1206,11 +1206,11 @@ impl User {
         Data::populate(&self, name, repopulate, continue_on_error, stop_on_failure)
     }
 
-    pub fn session_config(&self) -> RwLockReadGuard<SessionConfig> {
+    pub fn session_config(&self) -> RwLockReadGuard<'_, SessionConfig> {
         self.session_config.read().unwrap()
     }
 
-    pub fn session_config_mut(&self) -> Result<RwLockWriteGuard<SessionConfig>> {
+    pub fn session_config_mut(&self) -> Result<RwLockWriteGuard<'_, SessionConfig>> {
         let sessions = crate::sessions();
         if sessions
             .groups()
@@ -1256,11 +1256,11 @@ impl User {
         ))
     }
 
-    fn roles_mut(&self) -> Result<RwLockWriteGuard<HashSet<String>>> {
+    fn roles_mut(&self) -> Result<RwLockWriteGuard<'_, HashSet<String>>> {
         Ok(self.roles.write()?)
     }
 
-    pub fn roles(&self) -> Result<RwLockReadGuard<HashSet<String>>> {
+    pub fn roles(&self) -> Result<RwLockReadGuard<'_, HashSet<String>>> {
         Ok(self.roles.read()?)
     }
 

--- a/rust/origen_metal/src/framework/users/users.rs
+++ b/rust/origen_metal/src/framework/users/users.rs
@@ -204,7 +204,7 @@ impl PopulateUsersReturn {
         &self.failed_datasets
     }
 
-    pub fn failed_outcomes(&self) -> ErrorFailedOutcomeReturn {
+    pub fn failed_outcomes(&self) -> ErrorFailedOutcomeReturn<'_> {
         self.failed_datasets
             .iter()
             .map(|(uid, _)| {
@@ -226,7 +226,7 @@ impl PopulateUsersReturn {
         &self.errored_datasets
     }
 
-    pub fn errored_outcomes(&self) -> ErrorFailedOutcomeReturn {
+    pub fn errored_outcomes(&self) -> ErrorFailedOutcomeReturn<'_> {
         self.errored_datasets
             .iter()
             .map(|(uid, _)| {

--- a/rust/origen_metal/src/prog_gen/model/test.rs
+++ b/rust/origen_metal/src/prog_gen/model/test.rs
@@ -322,7 +322,7 @@ impl Test {
         t
     }
 
-    pub fn sorted_params(&self) -> SortedParams {
+    pub fn sorted_params(&self) -> SortedParams<'_> {
         SortedParams::new(&self)
     }
 

--- a/rust/origen_metal/src/stil/parser.rs
+++ b/rust/origen_metal/src/stil/parser.rs
@@ -57,7 +57,7 @@ pub fn parse_str(stil: &str, source_file: Option<&str>) -> Result<Node<STIL>> {
     }
 }
 
-fn inner_strs(pair: Pair<Rule>) -> Vec<&str> {
+fn inner_strs(pair: Pair<'_, Rule>) -> Vec<&str> {
     pair.into_inner().map(|v| v.as_str()).collect()
 }
 

--- a/rust/origen_metal/src/utils/revision_control/supported/git.rs
+++ b/rust/origen_metal/src/utils/revision_control/supported/git.rs
@@ -662,7 +662,7 @@ impl Git {
 
     // Returns a signature (to attribute commits etc.) for the current user, falling
     // back to a default Origen signature if necessary
-    fn signature(repo: &Repository) -> Result<git2::Signature> {
+    fn signature(repo: &Repository) -> Result<git2::Signature<'_>> {
         Ok(repo
             .signature()
             .unwrap_or(git2::Signature::now("Origen", "noreply@origen-sdk.org")?))


### PR DESCRIPTION
### Summary
Resolves all 14 `#[warn(mismatched_lifetime_syntaxes)]` warnings introduced by a newer Rust toolchain. Each fix adds an explicit `'_` lifetime to return-type generic parameters where a borrowed lifetime was previously hidden/elided inconsistently.

### Changes

| File | Functions Updated |
|------|------------------|
| `src/framework/logger.rs` | `data()` |
| `src/framework/typed_value.rs` | `keys()`, `iter()` |
| `src/framework/users/user.rs` | `write_data()`, `read_data()`, `session_config()`, `session_config_mut()`, `roles_mut()`, `roles()` |
| `src/framework/users/users.rs` | `failed_outcomes()`, `errored_outcomes()` |
| `src/stil/parser.rs` | `inner_strs()` |
| `src/utils/revision_control/supported/git.rs` | `signature()` |
| `src/prog_gen/model/test.rs` | `sorted_params()` |

### Nature of Changes
- **No logic changes** — purely mechanical lifetime annotation additions
- Each fix follows the compiler's suggestion: use `'_` for type paths where the same lifetime is referred to in inconsistent ways (elided in one position, hidden in another)
- Examples of the pattern fixed:
  ```rust
  // Before
  pub fn data(&self) -> RwLockReadGuard<Inner>
  pub fn sorted_params(&self) -> SortedParams
  pub fn failed_outcomes(&self) -> ErrorFailedOutcomeReturn

  // After
  pub fn data(&self) -> RwLockReadGuard<'_, Inner>
  pub fn sorted_params(&self) -> SortedParams<'_>
  pub fn failed_outcomes(&self) -> ErrorFailedOutcomeReturn<'_>
  ```

### Testing
`cargo build` now completes with **0 warnings**.