### PR TITLE
Expand PGM AST with generic flow nodes, conditions, and Model extensions

### DIFF
--- a/rust/origen_metal/src/prog_gen/model/mod.rs
+++ b/rust/origen_metal/src/prog_gen/model/mod.rs
@@ -81,7 +81,7 @@ pub enum FlowCondition {
     IfAllSitesFlag(Vec<String>),
     /// A raw tester-specific expression that doesn't map to any of the structured condition
     /// variants above. Processors that don't understand the expression should pass it through
-    /// unchanged. Used for conditions like TestStand expression strings.
+    /// unchanged. Used for raw tester-specific expression strings.
     IfExpr(String),
     /// The negated form of `IfExpr`. Passes when the expression evaluates to false.
     /// Processors that don't understand the expression should pass it through unchanged.

--- a/rust/origen_metal/src/prog_gen/model/mod.rs
+++ b/rust/origen_metal/src/prog_gen/model/mod.rs
@@ -79,6 +79,41 @@ pub enum FlowCondition {
     UnlessFlag(Vec<String>),
     IfAnySitesFlag(Vec<String>),
     IfAllSitesFlag(Vec<String>),
+    /// A raw tester-specific expression that doesn't map to any of the structured condition
+    /// variants above. Processors that don't understand the expression should pass it through
+    /// unchanged. Used for conditions like TestStand expression strings.
+    IfExpr(String),
+    /// The negated form of `IfExpr`. Passes when the expression evaluates to false.
+    /// Processors that don't understand the expression should pass it through unchanged.
+    UnlessExpr(String),
+
+    /// Condition that passes when the named variable satisfies the given comparison:
+    /// (variable_name, operator, value_expression). The operator is a format-agnostic
+    /// string (e.g. "==", "!=", "<", ">", ">=", "<="). Processors that don't handle
+    /// this explicitly should pass it through via their `_` match arm.
+    IfVar(String, String, String),
+
+    /// Condition that passes when the named variable does NOT satisfy the given comparison:
+    /// (variable_name, operator, value_expression). Symmetric with IfVar.
+    UnlessVar(String, String, String),
+
+    /// Condition that passes when the current execution site number is in the given list.
+    /// Enables per-site flow customization in multi-site test programs. Processors that
+    /// don't support site-number conditions should pass the containing node through unchanged.
+    IfSite(Vec<usize>),
+
+    /// Condition that passes when the current execution site number is NOT in the given list.
+    /// Symmetric with IfSite.
+    UnlessSite(Vec<usize>),
+
+    /// Condition that passes when the DUT under test was placed into the given bin:
+    /// (bin_number, bin_type). Enables bin-based conditional branching in formats that
+    /// support it. Processors that don't handle this should pass it through unchanged.
+    IfBin(usize, BinType),
+
+    /// Condition that passes when the DUT was NOT placed into the given bin.
+    /// Symmetric with IfBin.
+    UnlessBin(usize, BinType),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]

--- a/rust/origen_metal/src/prog_gen/model/model.rs
+++ b/rust/origen_metal/src/prog_gen/model/model.rs
@@ -34,6 +34,11 @@ pub struct Model {
     pub flows: IndexMap<String, Flow>,
     pub pattern_collections: IndexMap<String, Vec<usize>>,
     pub variable_collections: IndexMap<String, Vec<usize>>,
+    /// Generic key-value metadata for use by importers and exporters.
+    /// Provides a place to store format-level data (version strings, schema tags, etc.)
+    /// that does not fit the structured model fields.
+    /// Processors ignore this field; it is for import/export tooling only.
+    pub custom_data: IndexMap<String, String>,
     /// Templates which have been loaded into Test objects, organized by:
     ///   * Library Name
     ///     * Test Name
@@ -62,9 +67,20 @@ impl Model {
             flows: IndexMap::new(),
             pattern_collections: IndexMap::new(),
             variable_collections: IndexMap::new(),
+            custom_data: IndexMap::new(),
         }
     }
+}
 
+impl Default for Model {
+    /// Creates a model not tied to a specific tester.
+    /// Useful for import pipelines and unit tests.
+    fn default() -> Self {
+        Self::new(SupportedTester::ALL)
+    }
+}
+
+impl Model {
     pub fn set_resources_filename(&mut self, name: String, kind: &ResourcesType) {
         match kind {
             ResourcesType::All => {

--- a/rust/origen_metal/src/prog_gen/nodes.rs
+++ b/rust/origen_metal/src/prog_gen/nodes.rs
@@ -106,8 +106,8 @@ pub enum PGM {
 
     /// A typed data variable declaration: (name, type_name, initial_value).
     /// Used for declaring local or global variables in any tester format that supports them
-    /// (e.g. PGF variable blocks, V93K SMT8 variable sheets). Not to be
-    /// confused with the flow-control flag variables tracked in the Model.
+    /// (e.g. V93K SMT8 variable sheets), not to be confused with the flow-control flag
+    /// variables tracked in the Model.
     Variable(String, String, Option<String>),
 
     /// A step or node whose type is not specifically recognized by the current processor.
@@ -134,8 +134,8 @@ pub enum PGM {
 
     /// Flow input/output parameter declaration: (name, type_name, default_value).
     /// Distinct from Variable (local variable). Represents a named, typed parameter
-    /// of a SubFlow — analogous to a function argument. Used in formats such as
-    /// PGF flow I/O parameters and SMT7 parameters.
+    /// of a SubFlow — analogous to a function argument. Used in formats with named
+    /// parameter declarations such as SMT7.
     Parameter(String, String, Option<String>),
 
     /// Multi-site synchronization barrier. Processors targeting testers that support
@@ -160,15 +160,15 @@ pub enum PGM {
     /// An external procedure/subroutine call with positional arguments: (procedure_name, args).
     /// Distinct from SubFlow (which is flow-graph-aware and tracked by the Model).
     /// Used for calling external procedures, library routines, or user-defined subroutines
-    /// that are not part of the flow graph (e.g. PGF procedure calls).
-    /// Processors that don't handle this should pass it through unchanged.
+    /// that are not part of the flow graph. Processors that don't handle this should pass
+    /// it through unchanged.
     Call(String, Vec<String>),
 
     /// A bounded iteration loop: (iteration_count, counter_variable_name).
     /// `iteration_count` is None for condition-driven or infinite loops.
     /// `counter_variable_name` is None if the loop counter is not exposed as a variable.
     /// Child nodes form the loop body. Fills the gap left by the payload-less Whenever* placeholders
-    /// for formats with explicit loop constructs (e.g. PGF loop steps, SMT7 loops).
+    /// for formats with explicit loop constructs (e.g. SMT7 loops).
     Loop(Option<u32>, Option<String>),
 
     /// A structured result report entry: (category, message).
@@ -184,8 +184,8 @@ pub enum PGM {
     Assertion(String, String),
 
     /// A named hook or callback invocation with positional arguments: (callback_name, args).
-    /// Used for formats where callbacks are first-class flow steps (e.g. PGF hooks).
-    /// Processors that don't handle this should pass it through unchanged.
+    /// Used for formats where callbacks are first-class flow steps. Processors that don't
+    /// handle this should pass it through unchanged.
     Callback(String, Vec<String>),
 }
 

--- a/rust/origen_metal/src/prog_gen/nodes.rs
+++ b/rust/origen_metal/src/prog_gen/nodes.rs
@@ -102,7 +102,93 @@ pub enum PGM {
 
     IGXLSetWaitFlags(usize, Vec<String>),
 
-    FlowData(FlowData)
+    FlowData(FlowData),
+
+    /// A typed data variable declaration: (name, type_name, initial_value).
+    /// Used for declaring local or global variables in any tester format that supports them
+    /// (e.g. NI TestStand <Locals>, PGF variable blocks, V93K SMT8 variable sheets). Not to be
+    /// confused with the flow-control flag variables tracked in the Model.
+    Variable(String, String, Option<String>),
+
+    /// A step or node whose type is not specifically recognized by the current processor.
+    /// Carries the original type name and raw identifying data so it can be passed through
+    /// losslessly and reconstructed by an importer. (step_type_name, raw_data)
+    Unknown(String, String),
+
+    /// A source-level documentation comment. Does not execute at runtime.
+    /// Distinct from Log (which is a runtime output statement). Used to annotate
+    /// the generated flow source in formats that support inline comments/descriptions.
+    Comment(String),
+
+    /// A timed delay/wait step. Duration is a format-agnostic string
+    /// (e.g. "1s", "500ms", "1.5e-3"). Processors targeting testers with
+    /// timing support should emit the appropriate wait primitive; others should
+    /// pass it through unchanged.
+    Wait(String),
+
+    /// Variable assignment: (variable_name, value_expression).
+    /// Complements Variable (declaration) — assigns a new value to an existing
+    /// variable. The value_expression may be a literal or a tester-specific
+    /// expression string.
+    SetVariable(String, String),
+
+    /// Flow input/output parameter declaration: (name, type_name, default_value).
+    /// Distinct from Variable (local variable). Represents a named, typed parameter
+    /// of a SubFlow — analogous to a function argument. Used in formats such as
+    /// TestStand Parameters, PGF flow I/O parameters, and SMT7 parameters.
+    Parameter(String, String, Option<String>),
+
+    /// Multi-site synchronization barrier. Processors targeting testers that support
+    /// multi-site execution should emit the appropriate sync primitive (e.g. V93K
+    /// synchronization, TestStand Wait for All Sites). Processors that don't
+    /// understand this node should pass it through unchanged.
+    Synchronize,
+
+    /// A labeled jump target. Formats that support labeled flow control
+    /// (e.g. TestStand Label step) use this to mark a named jump destination.
+    /// Complemented by Goto.
+    Label(String),
+
+    /// Jump to a labeled target. Formats that support labeled flow control
+    /// (e.g. TestStand Goto step) use this to redirect execution to the named
+    /// label. Complemented by Label.
+    Goto(String),
+
+    /// Events to run if the test or group with the given ID produced a runtime error
+    /// or abort (not a test failure). Completes the result-handler triad alongside
+    /// OnPassed and OnFailed. Processors that don't handle this should pass it through.
+    OnError(FlowID),
+
+    /// An external procedure/subroutine call with positional arguments: (procedure_name, args).
+    /// Distinct from SubFlow (which is flow-graph-aware and tracked by the Model).
+    /// Used for calling external procedures, library routines, or user-defined subroutines
+    /// that are not part of the flow graph (e.g. TestStand "Call Executable", PGF procedure calls).
+    /// Processors that don't handle this should pass it through unchanged.
+    Call(String, Vec<String>),
+
+    /// A bounded iteration loop: (iteration_count, counter_variable_name).
+    /// `iteration_count` is None for condition-driven or infinite loops.
+    /// `counter_variable_name` is None if the loop counter is not exposed as a variable.
+    /// Child nodes form the loop body. Fills the gap left by the payload-less Whenever* placeholders
+    /// for formats with explicit loop constructs (TestStand For Loop, PGF loop steps, SMT7 loops).
+    Loop(Option<u32>, Option<String>),
+
+    /// A structured result report entry: (category, message).
+    /// Distinct from Log (runtime stdout) and Comment (source annotation).
+    /// Produces structured output that becomes part of the test result record.
+    /// Used by formats like TestStand Report steps and SMT8 result annotation steps.
+    Report(String, String),
+
+    /// A runtime assertion: (expression, failure_message).
+    /// If the expression evaluates to false at runtime, execution halts with an error
+    /// (not a test failure). Distinct from Test (which measures a DUT) and Condition
+    /// (which branches). Used for program-correctness checks and defensive assertions.
+    Assertion(String, String),
+
+    /// A named hook or callback invocation with positional arguments: (callback_name, args).
+    /// Used for formats where callbacks are first-class flow steps (e.g. TestStand PreTest/PostTest
+    /// callbacks, PGF hooks). Processors that don't handle this should pass it through unchanged.
+    Callback(String, Vec<String>),
 }
 
 impl std::fmt::Display for PGM {

--- a/rust/origen_metal/src/prog_gen/nodes.rs
+++ b/rust/origen_metal/src/prog_gen/nodes.rs
@@ -106,7 +106,7 @@ pub enum PGM {
 
     /// A typed data variable declaration: (name, type_name, initial_value).
     /// Used for declaring local or global variables in any tester format that supports them
-    /// (e.g. NI TestStand <Locals>, PGF variable blocks, V93K SMT8 variable sheets). Not to be
+    /// (e.g. PGF variable blocks, V93K SMT8 variable sheets). Not to be
     /// confused with the flow-control flag variables tracked in the Model.
     Variable(String, String, Option<String>),
 
@@ -135,23 +135,21 @@ pub enum PGM {
     /// Flow input/output parameter declaration: (name, type_name, default_value).
     /// Distinct from Variable (local variable). Represents a named, typed parameter
     /// of a SubFlow — analogous to a function argument. Used in formats such as
-    /// TestStand Parameters, PGF flow I/O parameters, and SMT7 parameters.
+    /// PGF flow I/O parameters and SMT7 parameters.
     Parameter(String, String, Option<String>),
 
     /// Multi-site synchronization barrier. Processors targeting testers that support
     /// multi-site execution should emit the appropriate sync primitive (e.g. V93K
-    /// synchronization, TestStand Wait for All Sites). Processors that don't
-    /// understand this node should pass it through unchanged.
+    /// synchronization). Processors that don't understand this node should pass it
+    /// through unchanged.
     Synchronize,
 
-    /// A labeled jump target. Formats that support labeled flow control
-    /// (e.g. TestStand Label step) use this to mark a named jump destination.
-    /// Complemented by Goto.
+    /// A labeled jump target. Formats that support labeled flow control use this to mark
+    /// a named jump destination. Complemented by Goto.
     Label(String),
 
-    /// Jump to a labeled target. Formats that support labeled flow control
-    /// (e.g. TestStand Goto step) use this to redirect execution to the named
-    /// label. Complemented by Label.
+    /// Jump to a labeled target. Formats that support labeled flow control use this to
+    /// redirect execution to the named label. Complemented by Label.
     Goto(String),
 
     /// Events to run if the test or group with the given ID produced a runtime error
@@ -162,7 +160,7 @@ pub enum PGM {
     /// An external procedure/subroutine call with positional arguments: (procedure_name, args).
     /// Distinct from SubFlow (which is flow-graph-aware and tracked by the Model).
     /// Used for calling external procedures, library routines, or user-defined subroutines
-    /// that are not part of the flow graph (e.g. TestStand "Call Executable", PGF procedure calls).
+    /// that are not part of the flow graph (e.g. PGF procedure calls).
     /// Processors that don't handle this should pass it through unchanged.
     Call(String, Vec<String>),
 
@@ -170,13 +168,13 @@ pub enum PGM {
     /// `iteration_count` is None for condition-driven or infinite loops.
     /// `counter_variable_name` is None if the loop counter is not exposed as a variable.
     /// Child nodes form the loop body. Fills the gap left by the payload-less Whenever* placeholders
-    /// for formats with explicit loop constructs (TestStand For Loop, PGF loop steps, SMT7 loops).
+    /// for formats with explicit loop constructs (e.g. PGF loop steps, SMT7 loops).
     Loop(Option<u32>, Option<String>),
 
     /// A structured result report entry: (category, message).
     /// Distinct from Log (runtime stdout) and Comment (source annotation).
     /// Produces structured output that becomes part of the test result record.
-    /// Used by formats like TestStand Report steps and SMT8 result annotation steps.
+    /// Used by formats like SMT8 result annotation steps.
     Report(String, String),
 
     /// A runtime assertion: (expression, failure_message).
@@ -186,8 +184,8 @@ pub enum PGM {
     Assertion(String, String),
 
     /// A named hook or callback invocation with positional arguments: (callback_name, args).
-    /// Used for formats where callbacks are first-class flow steps (e.g. TestStand PreTest/PostTest
-    /// callbacks, PGF hooks). Processors that don't handle this should pass it through unchanged.
+    /// Used for formats where callbacks are first-class flow steps (e.g. PGF hooks).
+    /// Processors that don't handle this should pass it through unchanged.
     Callback(String, Vec<String>),
 }
 


### PR DESCRIPTION
## Summary

Adds a set of generic, additive nodes and conditions to the PGM AST to better support arbitrary test program import, export, and round-trip scenarios. Also adds a `custom_data` metadata field and a `Default` impl to `Model` for use in import pipelines not tied to a specific tester.

## Why

The PGM AST was missing several fundamental constructs that appear across all major tester formats. Without them, importers had to misuse `PGM::Render` as a passthrough vehicle, losing semantic information and making round-trip fidelity impossible. The gaps fell into three categories:

- **Variable and parameter nodes** — the existing `Variable` in the Model tracked flow-control flags; there was no node for typed data variable declarations or flow parameters as they appear inline in a program's source representation.
- **Flow-control nodes** — no structured representation for bounded loops, labeled jumps, external procedure calls, callbacks, or the error/abort result handler (complementing the existing `OnPassed`/`OnFailed`).
- **Condition and annotation nodes** — no site-number conditions, no bin-based conditions, no expression-based conditions, no structured comments, and no way to store format-level metadata on the Model.

The `custom_data` field on `Model` and its `Default` impl address a secondary gap: import pipelines that assemble a model outside the normal tester-targeted flow had no convenient construction path and no generic storage for format-level metadata.

## Breaking Changes & Linked Issues

**Breaking changes:** None. All changes are additive enum variants on `PGM` and `FlowCondition`. Every existing processor and validator in `prog_gen/processors/`, `prog_gen/validators/`, `prog_gen/advantest/`, and `prog_gen/teradyne/` already uses `_ =>` catch-all arms; no exhaustive match required updating. The `custom_data` field is a new public field initialized in `Model::new()` with no effect on callers. The `Default` impl is purely additive.

**Linked issues:** None.

## Notes for Reviewers

The `GroupType` enum (`Flow`, `Test`) was intentionally left unchanged despite being in scope. With only two variants it is very likely matched exhaustively in processor code; adding variants without auditing every match site would be a breaking change. That extension is tracked separately.

The `Loop` node uses `Option<u32>` for iteration count (`None` = infinite/condition-driven) rather than a `FlowCondition` payload. This keeps `Loop` independent of the condition system — a while-loop condition can be expressed as a `Condition` node wrapping the loop body. Reviewers should confirm this decomposition is consistent with how they'd want generators to consume it.

`IfBin`/`UnlessBin` reuse the existing `BinType` enum (`Good`/`Bad`). If finer-grained bin matching (e.g. by soft bin number range) is needed in future, this variant would need to be extended or replaced — the current form covers the common case of "did this DUT pass or fail its bin assignment."