### PR TITLE
Fix V93K raw flow rendering

### DIFF
--- a/rust/origen_metal/src/prog_gen/advantest/smt7/processors/flow_generator.rs
+++ b/rust/origen_metal/src/prog_gen/advantest/smt7/processors/flow_generator.rs
@@ -822,7 +822,10 @@ impl Processor<PGM> for FlowGenerator {
                 Return::None
             }
             PGM::Render(text) => {
-                self.push_body(&format!(r#"{}"#, text));
+                // Use split to preserve empty and trailing lines in the rendered text.
+                for line in text.split('\n') {
+                    self.push_body(line);
+                }
                 Return::None
             }
             PGM::Resources => {
@@ -835,5 +838,46 @@ impl Processor<PGM> for FlowGenerator {
             _ => Return::ProcessChildren,
         };
         Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use crate::prog_gen::{process_flow, FlowCondition, Model, PGM, SupportedTester};
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn multiline_render_is_indented() -> crate::Result<()> {
+        let flow = node!(PGM::Flow, "multiline_render".to_string() =>
+            node!(PGM::Volatile, "render_enabled".to_string()),
+            node!(PGM::Render, "initialize();\nconfigure();".to_string()),
+            node!(PGM::Condition, FlowCondition::IfFlag(vec!["render_enabled".to_string()]) =>
+                node!(PGM::Render, "stop();\ncleanup();".to_string())
+            )
+        );
+
+        let mut flow_ast = crate::ast::AST::new();
+        flow_ast.start(flow);
+        let (ast, model) = process_flow(
+            &flow_ast,
+            Model::new(SupportedTester::V93KSMT7),
+            SupportedTester::V93KSMT7,
+            true,
+        )?;
+        let output_dir = tempdir()?;
+        let (_model, files) = run(&ast, output_dir.path(), model)?;
+        let flow_path = files
+            .iter()
+            .find(|path| {
+                path.file_name().and_then(|name| name.to_str()) == Some("multiline_render.tf")
+            })
+            .expect("expected generated SMT7 flow file");
+        let flow = fs::read_to_string(flow_path)?;
+
+        assert!(flow.contains("    initialize();\n    configure();"));
+        assert!(flow.contains("       stop();\n       cleanup();"));
+        Ok(())
     }
 }

--- a/rust/origen_metal/src/prog_gen/advantest/smt8/processors/flow_generator.rs
+++ b/rust/origen_metal/src/prog_gen/advantest/smt8/processors/flow_generator.rs
@@ -908,10 +908,11 @@ impl Processor<PGM> for FlowGenerator {
                 Return::None
             }
             PGM::Render(text) => {
-                self.flow_stack
-                    .last_mut()
-                    .unwrap()
-                    .execute_line(text.to_owned());
+                let current_flow = self.flow_stack.last_mut().unwrap();
+                // Use split to preserve empty and trailing lines in the rendered text.
+                for line in text.split('\n') {
+                    current_flow.execute_line(line.to_owned());
+                }
                 Return::None
             }
             PGM::Resources => {
@@ -989,6 +990,42 @@ mod tests {
 
         assert!(flow.contains("        initialize();\n        test1.execute();"));
         assert!(flow.contains("if (TEST1_FAILED == 1) {\n            stop();\n        }"));
+        Ok(())
+    }
+
+    #[test]
+    fn multiline_render_is_indented() -> crate::Result<()> {
+        let flow = node!(PGM::Flow, "multiline_render".to_string() =>
+            node!(PGM::Volatile, "render_enabled".to_string()),
+            node!(PGM::Render, "initialize();\nconfigure();".to_string()),
+            node!(PGM::Condition, FlowCondition::IfFlag(vec!["render_enabled".to_string()]) =>
+                node!(PGM::Render, "stop();\ncleanup();".to_string())
+            )
+        );
+
+        let mut flow_ast = crate::ast::AST::new();
+        flow_ast.start(flow);
+        let (ast, model) = process_flow(
+            &flow_ast,
+            Model::new(SupportedTester::V93KSMT8),
+            SupportedTester::V93KSMT8,
+            true,
+        )?;
+        let output_dir = tempdir()?;
+        let (_model, files) = run(&ast, output_dir.path(), model)?;
+        let flow_path = files
+            .iter()
+            .find(|path| {
+                path.file_name().and_then(|name| name.to_str())
+                    == Some("MULTILINE_RENDER.flow")
+            })
+            .expect("expected generated SMT8 flow file");
+        let flow = fs::read_to_string(flow_path)?;
+
+        assert!(flow.contains("        initialize();\n        configure();"));
+        assert!(flow.contains(
+            "if (RENDER_ENABLED == 1) {\n            stop();\n            cleanup();\n        }"
+        ));
         Ok(())
     }
 

--- a/rust/origen_metal/src/prog_gen/advantest/smt8/processors/flow_generator.rs
+++ b/rust/origen_metal/src/prog_gen/advantest/smt8/processors/flow_generator.rs
@@ -907,10 +907,13 @@ impl Processor<PGM> for FlowGenerator {
                 };
                 Return::None
             }
-            //PGM::Render(text) => {
-            //    self.push_body(&format!(r#"{}"#, text));
-            //    Return::None
-            //}
+            PGM::Render(text) => {
+                self.flow_stack
+                    .last_mut()
+                    .unwrap()
+                    .execute_line(text.to_owned());
+                Return::None
+            }
             PGM::Resources => {
                 let orig = self.resources_block;
                 self.resources_block = true;
@@ -953,6 +956,40 @@ mod tests {
     fn alpha_sort_is_case_insensitive() {
         assert_eq!(FlowGenerator::alpha_cmp("testName", "testerState"), Ordering::Greater);
         assert_eq!(FlowGenerator::alpha_cmp("Y1Variable", "zDataDeltaLimit"), Ordering::Less);
+    }
+
+    #[test]
+    fn conditional_render_is_emitted() -> crate::Result<()> {
+        let flow = node!(PGM::Flow, "conditional_render".to_string() =>
+            node!(PGM::Render, "initialize();".to_string()),
+            node!(PGM::TestStr, "test1".to_string(), FlowID::from_str("test1"), None, None, None),
+            node!(PGM::Condition, FlowCondition::IfFailed(vec![FlowID::from_str("test1")]) =>
+                node!(PGM::Render, "stop();".to_string())
+            )
+        );
+
+        let mut flow_ast = crate::ast::AST::new();
+        flow_ast.start(flow);
+        let (ast, model) = process_flow(
+            &flow_ast,
+            Model::new(SupportedTester::V93KSMT8),
+            SupportedTester::V93KSMT8,
+            true,
+        )?;
+        let output_dir = tempdir()?;
+        let (_model, files) = run(&ast, output_dir.path(), model)?;
+        let flow_path = files
+            .iter()
+            .find(|path| {
+                path.file_name().and_then(|name| name.to_str())
+                    == Some("CONDITIONAL_RENDER.flow")
+            })
+            .expect("expected generated SMT8 flow file");
+        let flow = fs::read_to_string(flow_path)?;
+
+        assert!(flow.contains("        initialize();\n        test1.execute();"));
+        assert!(flow.contains("if (TEST1_FAILED == 1) {\n            stop();\n        }"));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- emit `PGM::Render` content in generated V93K SMT8 flow files
- preserve conditional placement by routing SMT8 raw text through the buffered execute-line path
- indent every physical line of multiline renders in both SMT7 and SMT8
- add output-level regression coverage for unconditional, conditional, and multiline rendering

## Problems

### SMT8 render nodes were discarded

A render operation beneath a flow condition was silently discarded by the SMT8 generator. For example:

```python
test1
with flow.if_failed("test1"):
    flow.render_str("stop();")
```

The generated SMT8 flow retained the condition but produced an empty body:

```text
if (TEST1_FAILED == 1) {
} else {
}
```

The SMT8 generator had no active `PGM::Render` match arm; its placeholder referenced the SMT7-only `push_body` helper.

### Continuation lines were not indented

Both V93K backends treated an entire rendered string as one output line. Generator indentation was therefore applied only before the first physical line:

```text
        if (TEST1_FAILED == 1) {
            first();
second();
        }
```

SMT7 already emitted raw render nodes, but had the same multiline indentation issue.

## Fix

SMT8 now handles `PGM::Render` through `execute_line`, the same path used by other execute statements. This ensures raw text participates in condition and result-branch buffering.

Both SMT7 and SMT8 split rendered text on `\n` and submit each physical line through their existing line-output methods. As a result:

- every line receives the active base and nesting indentation
- all lines remain within their generated condition or result guard
- caller-supplied leading whitespace is preserved
- empty and trailing lines retain the existing raw-render newline behavior

`split("\n")` is intentional rather than `lines()` so empty and trailing segments are not dropped.

## Backend audit

`render_program` currently has concrete flow renderers only for V93K SMT7 and SMT8, and both are covered here. J750, UltraFLEX, IGXL, and Simulator are recognized tester IDs, but their program-generation paths currently return no rendered files; the Teradyne generator modules are placeholders. No speculative behavior was added for those targets.

## Regression coverage

- SMT8 single-line `if_failed` render is emitted inside its guard
- SMT8 unconditional render is emitted
- SMT8 multiline unconditional and flag-gated renders have correct indentation
- SMT7 multiline unconditional and flag-gated renders have correct indentation
- existing nested SMT8 result-branch coverage remains passing

## Validation

- `cargo test multiline_render_is_indented -- --nocapture`
  - 2 passed
- `cargo test conditional_render_is_emitted -- --nocapture`
  - 1 passed
- `cargo test --lib --features origen_skip_frontend_tests`
  - 118 passed, 6 ignored
- `git diff --check`
  - clean

Frontend-dependent session tests are skipped with the repository-provided feature because the local Python extension module is not built in this worktree.

## Scope

No public API changes. Existing single-line SMT7 output remains unchanged.